### PR TITLE
#6 - Downloads: Offline download manager with progress tracking

### DIFF
--- a/Lume/LumeApp.swift
+++ b/Lume/LumeApp.swift
@@ -76,6 +76,12 @@ struct LumeApp: App {
             ContentView()
                 .environment(TraktService.shared)
                 .task {
+                    // Give DownloadManager access to the model container so it
+                    // can persist download state from its delegate callbacks.
+                    #if !os(tvOS)
+                        DownloadManager.shared.configure(container: sharedModelContainer)
+                    #endif
+
                     // Commit any watch progress that a previous session buffered
                     // but never flushed to SwiftData (e.g. it was killed mid-
                     // playback). Runs off the main thread before playback starts.

--- a/Lume/Services/Downloads/DownloadManager.swift
+++ b/Lume/Services/Downloads/DownloadManager.swift
@@ -1,0 +1,318 @@
+import Foundation
+import OSLog
+import SwiftData
+
+// MARK: - Data types
+
+/// Progress snapshot for a single active or queued download.
+struct ActiveDownload: Identifiable {
+    let id: String
+    let title: String
+    var fractionCompleted: Double = 0
+}
+
+private struct PendingDownload {
+    let id: String
+    let title: String
+    let url: URL
+    let filename: String
+}
+
+// MARK: - DownloadManager
+
+/// Central download manager. Serialises file downloads, persists completion
+/// state into SwiftData, and exposes live progress to the UI.
+///
+/// Not available on tvOS — the download feature targets iOS and macOS only.
+@MainActor
+@Observable
+final class DownloadManager: NSObject {
+    static let shared = DownloadManager()
+
+    // MARK: - Settings keys
+
+    static let maxConcurrentKey = "downloads.maxConcurrent"
+    static let autoDeleteKey = "downloads.autoDeleteAfterWatching"
+
+    // MARK: - Public observable state
+
+    /// Actively downloading items, keyed by content id.
+    private(set) var activeDownloads: [String: ActiveDownload] = [:]
+    /// Content ids that are queued but not yet started.
+    private(set) var pendingIDs: Set<String> = []
+
+    // MARK: - Private
+
+    var modelContainer: ModelContainer?
+
+    private var session: URLSession!
+    private var taskMap: [Int: String] = [:]
+    private var idToTask: [String: URLSessionDownloadTask] = [:]
+    private var idToFilename: [String: String] = [:]
+    private var pendingQueue: [PendingDownload] = []
+
+    // MARK: - Init
+
+    override private init() {
+        super.init()
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForResource = 0
+        session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
+        ensureDownloadsDirectory()
+    }
+
+    // MARK: - Configuration
+
+    func configure(container: ModelContainer) {
+        modelContainer = container
+    }
+
+    // MARK: - Public API
+
+    func startDownload(movie: Movie, playlist: Playlist) {
+        let id = movie.id
+        guard activeDownloads[id] == nil, !pendingIDs.contains(id) else { return }
+        guard movie.downloadStatus != .completed else { return }
+
+        let directURL = movie.directURL.flatMap(URL.init(string:))
+        guard let url = directURL ?? XtreamClient().buildMovieURL(for: movie, playlist: playlist) else { return }
+
+        let ext = movie.containerExtension ?? "mp4"
+        let filename = "\(sanitize(id)).\(ext)"
+        idToFilename[id] = filename
+        enqueue(PendingDownload(id: id, title: movie.name, url: url, filename: filename))
+    }
+
+    func startDownload(episode: Episode, playlist: Playlist) {
+        let id = episode.id
+        guard activeDownloads[id] == nil, !pendingIDs.contains(id) else { return }
+        guard episode.downloadStatus != .completed else { return }
+
+        let directURL = playlist.sourceType == .m3u
+            ? episode.directSource.flatMap(URL.init(string:))
+            : nil
+        guard let url = directURL ?? XtreamClient().buildEpisodeURL(for: episode, playlist: playlist) else { return }
+
+        let ext = episode.containerExtension
+        let filename = "\(sanitize(id)).\(ext)"
+        let title = episode.series.map { "\($0.name) S\(episode.seasonNum)E\(episode.episodeNum)" } ?? episode.title
+        idToFilename[id] = filename
+        enqueue(PendingDownload(id: id, title: title, url: url, filename: filename))
+    }
+
+    func cancelDownload(id: String) {
+        idToTask[id]?.cancel()
+        idToTask.removeValue(forKey: id)
+        activeDownloads.removeValue(forKey: id)
+        pendingIDs.remove(id)
+        pendingQueue.removeAll { $0.id == id }
+        scheduleModelUpdate(id: id, status: nil, localURL: nil)
+    }
+
+    func deleteLocalFile(id: String) {
+        let filename = idToFilename[id]
+        if let filename {
+            let fileURL = downloadsDirectory.appendingPathComponent(filename)
+            try? FileManager.default.removeItem(at: fileURL)
+        } else {
+            let sanitizedID = sanitize(id)
+            let all = (try? FileManager.default.contentsOfDirectory(at: downloadsDirectory, includingPropertiesForKeys: nil)) ?? []
+            for file in all where file.deletingPathExtension().lastPathComponent == sanitizedID {
+                try? FileManager.default.removeItem(at: file)
+            }
+        }
+        scheduleModelUpdate(id: id, status: nil, localURL: nil)
+    }
+
+    /// If auto-delete is enabled, removes the local file after the content is
+    /// marked watched. Call this whenever watched state changes to `true`.
+    func checkAutoDelete(id: String) {
+        guard UserDefaults.standard.bool(forKey: Self.autoDeleteKey) else { return }
+        deleteLocalFile(id: id)
+    }
+
+    // MARK: - Status helpers
+
+    func isActive(_ id: String) -> Bool {
+        activeDownloads[id] != nil || pendingIDs.contains(id)
+    }
+
+    // MARK: - Directory
+
+    var downloadsDirectory: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Downloads", isDirectory: true)
+    }
+
+    // MARK: - Private
+
+    private func ensureDownloadsDirectory() {
+        try? FileManager.default.createDirectory(
+            at: downloadsDirectory,
+            withIntermediateDirectories: true
+        )
+    }
+
+    private var maxConcurrent: Int {
+        let raw = UserDefaults.standard.integer(forKey: Self.maxConcurrentKey)
+        return raw > 0 ? raw : 1
+    }
+
+    private func enqueue(_ item: PendingDownload) {
+        pendingQueue.append(item)
+        pendingIDs.insert(item.id)
+        scheduleModelUpdate(id: item.id, status: .pending, localURL: nil)
+        promoteIfNeeded()
+    }
+
+    private func promoteIfNeeded() {
+        let max = maxConcurrent
+        while activeDownloads.count < max, !pendingQueue.isEmpty {
+            let item = pendingQueue.removeFirst()
+            pendingIDs.remove(item.id)
+            startTask(item)
+        }
+    }
+
+    private func startTask(_ item: PendingDownload) {
+        let task = session.downloadTask(with: item.url)
+        taskMap[task.taskIdentifier] = item.id
+        idToTask[item.id] = task
+        activeDownloads[item.id] = ActiveDownload(id: item.id, title: item.title)
+        scheduleModelUpdate(id: item.id, status: .downloading, localURL: nil)
+        task.resume()
+    }
+
+    private func scheduleModelUpdate(id: String, status: DownloadStatus?, localURL: String?) {
+        guard let container = modelContainer else { return }
+        let capturedID = id
+        let capturedStatus = status
+        let capturedURL = localURL
+        Task.detached {
+            await DownloadManager.persistStatus(
+                id: capturedID,
+                status: capturedStatus,
+                localURL: capturedURL,
+                container: container
+            )
+        }
+    }
+
+    private nonisolated static func persistStatus(
+        id: String,
+        status: DownloadStatus?,
+        localURL: String?,
+        container: ModelContainer
+    ) async {
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+        do {
+            var movieDesc = FetchDescriptor<Movie>(predicate: #Predicate { $0.id == id })
+            movieDesc.fetchLimit = 1
+            if let movie = try context.fetch(movieDesc).first {
+                movie.downloadStatus = status
+                movie.localFileURL = localURL
+                movie.downloadedAt = status == .completed ? Date() : nil
+                try context.save()
+                return
+            }
+            var epDesc = FetchDescriptor<Episode>(predicate: #Predicate { $0.id == id })
+            epDesc.fetchLimit = 1
+            if let episode = try context.fetch(epDesc).first {
+                episode.downloadStatus = status
+                episode.localFileURL = localURL
+                episode.downloadedAt = status == .completed ? Date() : nil
+                try context.save()
+            }
+        } catch {
+            Logger.downloads.error("Failed to persist download status for \(id): \(error)")
+        }
+    }
+
+    private nonisolated func sanitize(_ id: String) -> String {
+        id.replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
+    }
+}
+
+// MARK: - URLSessionDownloadDelegate
+
+extension DownloadManager: URLSessionDownloadDelegate {
+    nonisolated func urlSession(
+        _: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData _: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        let fraction = totalBytesExpectedToWrite > 0
+            ? Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+            : 0
+        let taskID = downloadTask.taskIdentifier
+        Task { @MainActor in
+            self.activeDownloads[self.taskMap[taskID] ?? ""]?.fractionCompleted = fraction
+        }
+    }
+
+    nonisolated func urlSession(
+        _: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        let taskID = downloadTask.taskIdentifier
+        let responseURL = downloadTask.response?.url ?? downloadTask.currentRequest?.url
+
+        Task { @MainActor in
+            guard let id = self.taskMap[taskID] else { return }
+
+            let filename: String
+            if let name = self.idToFilename[id] {
+                filename = name
+            } else {
+                let ext = responseURL?.pathExtension ?? "mp4"
+                filename = "\(self.sanitize(id)).\(ext)"
+                self.idToFilename[id] = filename
+            }
+
+            let destination = self.downloadsDirectory.appendingPathComponent(filename)
+            do {
+                if FileManager.default.fileExists(atPath: destination.path) {
+                    try FileManager.default.removeItem(at: destination)
+                }
+                try FileManager.default.moveItem(at: location, to: destination)
+                Logger.downloads.info("Download complete: \(id)")
+                self.activeDownloads.removeValue(forKey: id)
+                self.taskMap.removeValue(forKey: taskID)
+                self.idToTask.removeValue(forKey: id)
+                self.scheduleModelUpdate(id: id, status: .completed, localURL: destination.path)
+            } catch {
+                Logger.downloads.error("Failed to save download for \(id): \(error)")
+                self.handleFailure(taskID: taskID, id: id)
+            }
+            self.promoteIfNeeded()
+        }
+    }
+
+    nonisolated func urlSession(
+        _: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        guard let error else { return }
+        let taskID = task.taskIdentifier
+        Task { @MainActor in
+            guard let id = self.taskMap[taskID] else { return }
+            Logger.downloads.error("Download failed for \(id): \(error)")
+            self.handleFailure(taskID: taskID, id: id)
+            self.promoteIfNeeded()
+        }
+    }
+
+    @MainActor
+    private func handleFailure(taskID: Int, id: String) {
+        activeDownloads.removeValue(forKey: id)
+        taskMap.removeValue(forKey: taskID)
+        idToTask.removeValue(forKey: id)
+        scheduleModelUpdate(id: id, status: .failed, localURL: nil)
+    }
+}

--- a/Lume/Services/Player/PlayableMedia.swift
+++ b/Lume/Services/Player/PlayableMedia.swift
@@ -32,8 +32,26 @@ struct PlayableMedia: Identifiable, Hashable, Codable {
 extension PlayableMedia {
     // m3u content carries its full playback URL on the model (`directURL` /
     // `directSource`); Xtream content builds one from credentials + stream id.
+    // When a local file is available (downloaded for offline viewing), it takes
+    // priority over the remote URL.
 
     static func from(movie: Movie, playlist: Playlist, client: XtreamClient = XtreamClient()) -> PlayableMedia? {
+        // Prefer local file for offline/downloaded playback
+        if let path = movie.localFileURL,
+           movie.downloadStatus == .completed,
+           FileManager.default.fileExists(atPath: path)
+        {
+            return PlayableMedia(
+                id: "movie-\(movie.id)",
+                url: URL(fileURLWithPath: path),
+                title: movie.name,
+                subtitle: movie.releaseDate,
+                posterURL: URL(string: movie.streamIcon ?? ""),
+                kind: .vod,
+                startTime: movie.watchProgress,
+                contentRef: .movie(movie.id)
+            )
+        }
         let directURL = movie.directURL.flatMap(URL.init(string:))
         guard let url = directURL ?? client.buildMovieURL(for: movie, playlist: playlist) else { return nil }
         return PlayableMedia(
@@ -49,6 +67,23 @@ extension PlayableMedia {
     }
 
     static func from(episode: Episode, playlist: Playlist, client: XtreamClient = XtreamClient()) -> PlayableMedia? {
+        // Prefer local file for offline/downloaded playback
+        if let path = episode.localFileURL,
+           episode.downloadStatus == .completed,
+           FileManager.default.fileExists(atPath: path)
+        {
+            let seriesName = episode.series?.name
+            return PlayableMedia(
+                id: "episode-\(episode.id)",
+                url: URL(fileURLWithPath: path),
+                title: seriesName ?? episode.title,
+                subtitle: "S\(episode.seasonNum) E\(episode.episodeNum) · \(episode.title)",
+                posterURL: URL(string: episode.movieImage ?? ""),
+                kind: .vod,
+                startTime: episode.watchProgress,
+                contentRef: .episode(episode.id)
+            )
+        }
         let directURL = playlist.sourceType == .m3u
             ? episode.directSource.flatMap(URL.init(string:))
             : nil

--- a/Lume/Utils/Logger.swift
+++ b/Lume/Utils/Logger.swift
@@ -5,4 +5,5 @@ nonisolated extension Logger {
     static let database = Logger(subsystem: subsystem, category: "Database")
     static let network = Logger(subsystem: subsystem, category: "Network")
     static let player = Logger(subsystem: subsystem, category: "Player")
+    static let downloads = Logger(subsystem: subsystem, category: "Downloads")
 }

--- a/Lume/Views/Components/MediaDetailComponents.swift
+++ b/Lume/Views/Components/MediaDetailComponents.swift
@@ -209,6 +209,8 @@ struct MetadataLineView: View {
 
 // MARK: - Buttons
 
+// MARK: - Play button
+
 /// The big, white, full-width primary action (Play / Resume).
 struct PrimaryPlayButton: View {
     let title: LocalizedStringKey

--- a/Lume/Views/Downloads/DownloadButton.swift
+++ b/Lume/Views/Downloads/DownloadButton.swift
@@ -1,8 +1,9 @@
 #if !os(tvOS)
     import SwiftUI
 
-    /// Full-width secondary button below the Play button showing download state.
-    struct DownloadButton: View {
+    /// Compact icon button for the toolbar — sits alongside watched/favorite icons.
+    /// Shows a circular progress ring while downloading, a filled icon when complete.
+    struct DownloadGlassButton: View {
         let id: String
         let downloadStatus: DownloadStatus?
         let downloads: DownloadManager
@@ -11,72 +12,63 @@
 
         var body: some View {
             if let active = downloads.activeDownloads[id] {
-                HStack(spacing: 12) {
-                    if active.fractionCompleted > 0 {
-                        ProgressView(value: active.fractionCompleted)
-                            .progressViewStyle(.linear)
-                            .frame(maxWidth: .infinity)
-                    } else {
-                        ProgressView()
-                            .progressViewStyle(.linear)
-                            .frame(maxWidth: .infinity)
-                    }
-                    Button {
-                        downloads.cancelDownload(id: id)
-                    } label: {
-                        Label("Cancel", systemImage: "xmark.circle")
-                            .font(.subheadline)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
+                Button { downloads.cancelDownload(id: id) } label: {
+                    progressRing(fraction: active.fractionCompleted)
                 }
-                .padding(.horizontal, 4)
+                .buttonStyle(.plain)
+                .accessibilityLabel("Cancel download")
             } else if downloads.pendingIDs.contains(id) {
-                HStack(spacing: 10) {
-                    ProgressView().controlSize(.small)
-                    Text("Waiting…")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    Spacer(minLength: 0)
-                    Button {
-                        downloads.cancelDownload(id: id)
-                    } label: {
-                        Label("Cancel", systemImage: "xmark.circle")
-                            .font(.subheadline)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
+                Button { downloads.cancelDownload(id: id) } label: {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .controlSize(.mini)
+                        .tint(.white)
+                        .glassCircleFrame()
                 }
-                .padding(.horizontal, 4)
+                .buttonStyle(.plain)
+                .accessibilityLabel("Cancel download")
             } else if downloadStatus == .completed {
-                Button(role: .destructive, action: onDelete) {
-                    Label("Remove Download", systemImage: "trash")
-                        .font(.headline)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 30)
+                Button(action: onDelete) {
+                    Image(systemName: "arrow.down.circle.fill")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.tint)
+                        .glassCircleFrame()
                 }
-                .buttonStyle(.bordered)
-                .tint(.red)
-                .controlSize(.large)
-            } else if downloadStatus == .failed {
-                Button(action: onStart) {
-                    Label("Retry Download", systemImage: "arrow.clockwise.circle")
-                        .font(.headline)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 30)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.large)
+                .buttonStyle(.plain)
+                .accessibilityLabel("Remove download")
             } else {
-                Button(action: onStart) {
-                    Label("Download", systemImage: "arrow.down.circle")
-                        .font(.headline)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 30)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.large)
+                GlassIconButton(
+                    systemImage: downloadStatus == .failed ? "exclamationmark.circle" : "arrow.down.circle",
+                    accessibilityLabel: downloadStatus == .failed ? "Retry download" : "Download",
+                    action: onStart
+                )
             }
+        }
+
+        private func progressRing(fraction: Double) -> some View {
+            ZStack {
+                Circle()
+                    .stroke(.white.opacity(0.25), lineWidth: 2.5)
+                    .frame(width: 22, height: 22)
+                Circle()
+                    .trim(from: 0, to: max(0.04, fraction))
+                    .stroke(.white, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .animation(.linear(duration: 0.1), value: fraction)
+                    .frame(width: 22, height: 22)
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+            .glassCircleFrame()
+        }
+    }
+
+    private extension View {
+        func glassCircleFrame() -> some View {
+            frame(width: 34, height: 34)
+                .background(.ultraThinMaterial, in: Circle())
+                .overlay(Circle().stroke(.white.opacity(0.15), lineWidth: 0.5))
         }
     }
 #endif

--- a/Lume/Views/Downloads/DownloadButton.swift
+++ b/Lume/Views/Downloads/DownloadButton.swift
@@ -1,0 +1,82 @@
+#if !os(tvOS)
+    import SwiftUI
+
+    /// Full-width secondary button below the Play button showing download state.
+    struct DownloadButton: View {
+        let id: String
+        let downloadStatus: DownloadStatus?
+        let downloads: DownloadManager
+        let onStart: () -> Void
+        let onDelete: () -> Void
+
+        var body: some View {
+            if let active = downloads.activeDownloads[id] {
+                HStack(spacing: 12) {
+                    if active.fractionCompleted > 0 {
+                        ProgressView(value: active.fractionCompleted)
+                            .progressViewStyle(.linear)
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        ProgressView()
+                            .progressViewStyle(.linear)
+                            .frame(maxWidth: .infinity)
+                    }
+                    Button {
+                        downloads.cancelDownload(id: id)
+                    } label: {
+                        Label("Cancel", systemImage: "xmark.circle")
+                            .font(.subheadline)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+                .padding(.horizontal, 4)
+            } else if downloads.pendingIDs.contains(id) {
+                HStack(spacing: 10) {
+                    ProgressView().controlSize(.small)
+                    Text("Waiting…")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 0)
+                    Button {
+                        downloads.cancelDownload(id: id)
+                    } label: {
+                        Label("Cancel", systemImage: "xmark.circle")
+                            .font(.subheadline)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+                .padding(.horizontal, 4)
+            } else if downloadStatus == .completed {
+                Button(role: .destructive, action: onDelete) {
+                    Label("Remove Download", systemImage: "trash")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 30)
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+                .controlSize(.large)
+            } else if downloadStatus == .failed {
+                Button(action: onStart) {
+                    Label("Retry Download", systemImage: "arrow.clockwise.circle")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 30)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            } else {
+                Button(action: onStart) {
+                    Label("Download", systemImage: "arrow.down.circle")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 30)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            }
+        }
+    }
+#endif

--- a/Lume/Views/Downloads/DownloadsView.swift
+++ b/Lume/Views/Downloads/DownloadsView.swift
@@ -1,0 +1,339 @@
+import SwiftData
+import SwiftUI
+
+#if !os(tvOS)
+
+    /// Displays all downloaded movies and episodes and lets the user delete them.
+    struct DownloadsView: View {
+        @Environment(\.modelContext) private var modelContext
+
+        @Query(
+            filter: #Predicate<Movie> { $0.downloadStatusRaw == "completed" },
+            sort: \Movie.downloadedAt,
+            order: .reverse
+        )
+        private var downloadedMovies: [Movie]
+
+        @Query(
+            filter: #Predicate<Episode> { $0.downloadStatusRaw == "completed" },
+            sort: \Episode.downloadedAt,
+            order: .reverse
+        )
+        private var downloadedEpisodes: [Episode]
+
+        @Query private var playlists: [Playlist]
+
+        @State private var downloads = DownloadManager.shared
+        @State private var playingMedia: PlayableMedia?
+        @State private var itemToDelete: DeletionTarget?
+
+        private var isEmpty: Bool {
+            downloadedMovies.isEmpty && downloadedEpisodes.isEmpty && downloads.activeDownloads.isEmpty && downloads.pendingIDs.isEmpty
+        }
+
+        var body: some View {
+            List {
+                inProgressSection
+                moviesSection
+                episodesSection
+            }
+            .overlay {
+                if isEmpty {
+                    ContentUnavailableView(
+                        "No Downloads",
+                        systemImage: "arrow.down.circle",
+                        description: Text("Downloaded movies and episodes appear here for offline viewing.")
+                    )
+                }
+            }
+            .platformNavigationTitle("Downloads")
+            #if os(iOS)
+                .fullScreenCover(item: $playingMedia) { media in
+                    FullScreenPlayerView(media: media)
+                }
+            #elseif os(macOS)
+                .sheet(item: $playingMedia) { media in
+                    FullScreenPlayerView(media: media)
+                }
+            #endif
+                .confirmationDialog(
+                    "Delete Download",
+                    isPresented: Binding(
+                        get: { itemToDelete != nil },
+                        set: { if !$0 { itemToDelete = nil } }
+                    ),
+                    titleVisibility: .visible
+                ) {
+                    Button("Delete", role: .destructive) {
+                        if let target = itemToDelete {
+                            downloads.deleteLocalFile(id: target.id)
+                            itemToDelete = nil
+                        }
+                    }
+                    Button("Cancel", role: .cancel) { itemToDelete = nil }
+                } message: {
+                    Text("The downloaded file will be removed. You can re-download it later.")
+                }
+        }
+
+        // MARK: - Sections
+
+        @ViewBuilder
+        private var inProgressSection: some View {
+            let inProgress = Array(downloads.activeDownloads.values) + downloads.pendingIDs.map {
+                ActiveDownload(id: $0, title: $0, fractionCompleted: 0)
+            }
+            if !inProgress.isEmpty {
+                Section("In Progress") {
+                    ForEach(inProgress) { item in
+                        ActiveDownloadRow(item: item) {
+                            downloads.cancelDownload(id: item.id)
+                        }
+                    }
+                }
+            }
+        }
+
+        @ViewBuilder
+        private var moviesSection: some View {
+            if !downloadedMovies.isEmpty {
+                Section("Movies") {
+                    ForEach(downloadedMovies) { movie in
+                        DownloadedMovieRow(movie: movie) {
+                            play(movie: movie)
+                        } onDelete: {
+                            itemToDelete = DeletionTarget(id: movie.id, name: movie.name)
+                        }
+                    }
+                }
+            }
+        }
+
+        @ViewBuilder
+        private var episodesSection: some View {
+            if !downloadedEpisodes.isEmpty {
+                Section("Episodes") {
+                    ForEach(downloadedEpisodes) { episode in
+                        DownloadedEpisodeRow(episode: episode) {
+                            play(episode: episode)
+                        } onDelete: {
+                            itemToDelete = DeletionTarget(id: episode.id, name: episode.title)
+                        }
+                    }
+                }
+            }
+        }
+
+        // MARK: - Playback
+
+        private func play(movie: Movie) {
+            // Try local file first, then fall back to streaming via the playlist
+            if let path = movie.localFileURL, FileManager.default.fileExists(atPath: path) {
+                playingMedia = PlayableMedia(
+                    id: "movie-\(movie.id)",
+                    url: URL(fileURLWithPath: path),
+                    title: movie.name,
+                    subtitle: movie.releaseDate,
+                    posterURL: URL(string: movie.streamIcon ?? ""),
+                    kind: .vod,
+                    startTime: movie.watchProgress,
+                    contentRef: .movie(movie.id)
+                )
+                return
+            }
+            guard let playlist = playlists.first(where: { movie.id.hasPrefix($0.id.uuidString) }) ?? playlists.first,
+                  let media = PlayableMedia.from(movie: movie, playlist: playlist)
+            else { return }
+            playingMedia = media
+        }
+
+        private func play(episode: Episode) {
+            if let path = episode.localFileURL, FileManager.default.fileExists(atPath: path) {
+                let seriesName = episode.series?.name
+                playingMedia = PlayableMedia(
+                    id: "episode-\(episode.id)",
+                    url: URL(fileURLWithPath: path),
+                    title: seriesName ?? episode.title,
+                    subtitle: "S\(episode.seasonNum) E\(episode.episodeNum) · \(episode.title)",
+                    posterURL: URL(string: episode.movieImage ?? ""),
+                    kind: .vod,
+                    startTime: episode.watchProgress,
+                    contentRef: .episode(episode.id)
+                )
+                return
+            }
+            guard let series = episode.series,
+                  let playlist = playlists.first(where: { series.id.hasPrefix($0.id.uuidString) }) ?? playlists.first,
+                  let media = PlayableMedia.from(episode: episode, playlist: playlist)
+            else { return }
+            playingMedia = media
+        }
+    }
+
+    // MARK: - Row views
+
+    private struct ActiveDownloadRow: View {
+        let item: ActiveDownload
+        let onCancel: () -> Void
+
+        var body: some View {
+            HStack(spacing: 14) {
+                Image(systemName: "arrow.down.circle")
+                    .font(.title3)
+                    .foregroundStyle(.tint)
+                    .frame(width: 32)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.title)
+                        .font(.subheadline.weight(.medium))
+                        .lineLimit(1)
+                    if item.fractionCompleted > 0 {
+                        ProgressView(value: item.fractionCompleted)
+                            .progressViewStyle(.linear)
+                    } else {
+                        ProgressView()
+                            .progressViewStyle(.linear)
+                    }
+                }
+
+                Button(action: onCancel) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    private struct DownloadedMovieRow: View {
+        let movie: Movie
+        let onPlay: () -> Void
+        let onDelete: () -> Void
+
+        var body: some View {
+            HStack(spacing: 14) {
+                CachedAsyncImage(url: URL(string: movie.streamIcon ?? ""), maxPixelSize: 60) { phase in
+                    switch phase {
+                    case let .success(image):
+                        image.resizable().aspectRatio(contentMode: .fill)
+                    default:
+                        Rectangle().fill(Color.gray.opacity(0.25))
+                            .overlay { Image(systemName: "film").foregroundStyle(.secondary) }
+                    }
+                }
+                .frame(width: 40, height: 60)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(movie.name)
+                        .font(.subheadline.weight(.medium))
+                        .lineLimit(2)
+                    if let date = movie.downloadedAt {
+                        Text(date.formatted(date: .abbreviated, time: .omitted))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    fileSizeLabel(path: movie.localFileURL)
+                }
+
+                Spacer(minLength: 0)
+
+                Button(action: onPlay) {
+                    Image(systemName: "play.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(.tint)
+                }
+                .buttonStyle(.plain)
+
+                Button(action: onDelete) {
+                    Image(systemName: "trash")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    private struct DownloadedEpisodeRow: View {
+        let episode: Episode
+        let onPlay: () -> Void
+        let onDelete: () -> Void
+
+        var body: some View {
+            HStack(spacing: 14) {
+                CachedAsyncImage(url: URL(string: episode.movieImage ?? ""), maxPixelSize: 100) { phase in
+                    switch phase {
+                    case let .success(image):
+                        image.resizable().aspectRatio(contentMode: .fill)
+                    default:
+                        Rectangle().fill(Color.gray.opacity(0.25))
+                            .overlay {
+                                Text("E\(episode.episodeNum)")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+                            }
+                    }
+                }
+                .frame(width: 70, height: 40)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    if let seriesName = episode.series?.name {
+                        Text(seriesName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text("S\(episode.seasonNum) E\(episode.episodeNum) · \(episode.title)")
+                        .font(.subheadline.weight(.medium))
+                        .lineLimit(2)
+                    if let date = episode.downloadedAt {
+                        Text(date.formatted(date: .abbreviated, time: .omitted))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    fileSizeLabel(path: episode.localFileURL)
+                }
+
+                Spacer(minLength: 0)
+
+                Button(action: onPlay) {
+                    Image(systemName: "play.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(.tint)
+                }
+                .buttonStyle(.plain)
+
+                Button(action: onDelete) {
+                    Image(systemName: "trash")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    // MARK: - Helpers
+
+    @ViewBuilder
+    private func fileSizeLabel(path: String?) -> some View {
+        if let path, let size = fileSize(at: path) {
+            Text(ByteCountFormatter.string(fromByteCount: size, countStyle: .file))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func fileSize(at path: String) -> Int64? {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: path)
+        return attrs?[.size] as? Int64
+    }
+
+    private struct DeletionTarget: Identifiable {
+        let id: String
+        let name: String
+    }
+
+#endif

--- a/Lume/Views/Movies/MovieDetailView.swift
+++ b/Lume/Views/Movies/MovieDetailView.swift
@@ -34,6 +34,11 @@ struct MovieDetailView: View {
     @State private var otherSources: [HomeMediaItem] = []
     @State private var refreshToken: UUID = .init()
     @State private var isLoadingTMDB: Bool
+    #if !os(tvOS)
+        @State private var downloads = DownloadManager.shared
+        @AppStorage(DownloadManager.maxConcurrentKey) private var maxConcurrent = 1
+        @AppStorage(DownloadManager.autoDeleteKey) private var autoDeleteAfterWatching = false
+    #endif
 
     init(movie: Movie, animationNamespace: Namespace.ID? = nil) {
         self.movie = movie
@@ -205,11 +210,24 @@ struct MovieDetailView: View {
     }
 
     private var actions: some View {
-        PrimaryPlayButton(
-            title: movie.watchProgress > 1 ? "Resume" : "Play",
-            isEnabled: moviePlaylist != nil,
-            action: startPlayback
-        )
+        VStack(spacing: 12) {
+            PrimaryPlayButton(
+                title: movie.watchProgress > 1 ? "Resume" : "Play",
+                isEnabled: moviePlaylist != nil,
+                action: startPlayback
+            )
+            #if !os(tvOS)
+                if let playlist = moviePlaylist {
+                    DownloadButton(
+                        id: movie.id,
+                        downloadStatus: movie.downloadStatus,
+                        downloads: downloads,
+                        onStart: { downloads.startDownload(movie: movie, playlist: playlist) },
+                        onDelete: { deleteMovieDownload() }
+                    )
+                }
+            #endif
+        }
     }
 
     @ViewBuilder
@@ -432,9 +450,18 @@ struct MovieDetailView: View {
         movie.isWatched.toggle()
         if movie.isWatched {
             movie.watchProgress = Double(movie.durationSecs ?? 0)
+            #if !os(tvOS)
+                downloads.checkAutoDelete(id: movie.id)
+            #endif
         }
         TraktService.shared.syncWatched(movie: movie, watched: movie.isWatched)
     }
+
+    #if !os(tvOS)
+        private func deleteMovieDownload() {
+            downloads.deleteLocalFile(id: movie.id)
+        }
+    #endif
 }
 
 #Preview("Basic") {

--- a/Lume/Views/Movies/MovieDetailView.swift
+++ b/Lume/Views/Movies/MovieDetailView.swift
@@ -36,8 +36,6 @@ struct MovieDetailView: View {
     @State private var isLoadingTMDB: Bool
     #if !os(tvOS)
         @State private var downloads = DownloadManager.shared
-        @AppStorage(DownloadManager.maxConcurrentKey) private var maxConcurrent = 1
-        @AppStorage(DownloadManager.autoDeleteKey) private var autoDeleteAfterWatching = false
     #endif
 
     init(movie: Movie, animationNamespace: Namespace.ID? = nil) {
@@ -210,24 +208,11 @@ struct MovieDetailView: View {
     }
 
     private var actions: some View {
-        VStack(spacing: 12) {
-            PrimaryPlayButton(
-                title: movie.watchProgress > 1 ? "Resume" : "Play",
-                isEnabled: moviePlaylist != nil,
-                action: startPlayback
-            )
-            #if !os(tvOS)
-                if let playlist = moviePlaylist {
-                    DownloadButton(
-                        id: movie.id,
-                        downloadStatus: movie.downloadStatus,
-                        downloads: downloads,
-                        onStart: { downloads.startDownload(movie: movie, playlist: playlist) },
-                        onDelete: { deleteMovieDownload() }
-                    )
-                }
-            #endif
-        }
+        PrimaryPlayButton(
+            title: movie.watchProgress > 1 ? "Resume" : "Play",
+            isEnabled: moviePlaylist != nil,
+            action: startPlayback
+        )
     }
 
     @ViewBuilder
@@ -276,37 +261,71 @@ struct MovieDetailView: View {
             }
             ToolbarItem(placement: .topBarTrailing) {
                 HStack(spacing: 10) {
+                    if let playlist = moviePlaylist {
+                        DownloadGlassButton(
+                            id: movie.id,
+                            downloadStatus: movie.downloadStatus,
+                            downloads: downloads,
+                            onStart: { downloads.startDownload(movie: movie, playlist: playlist) },
+                            onDelete: { downloads.deleteLocalFile(id: movie.id) }
+                        )
+                    }
                     GlassIconButton(
                         systemImage: movie.isWatched ? "checkmark.circle.fill" : "checkmark.circle",
                         accessibilityLabel: movie.isWatched ? "Mark as unwatched" : "Mark as watched"
                     ) { toggleWatched() }
-
                     GlassIconButton(
                         systemImage: movie.isFavorite ? "heart.fill" : "heart",
                         accessibilityLabel: movie.isFavorite ? "Remove from favorites" : "Add to favorites"
                     ) { toggleFavorite() }
                 }
             }
-        #else
+        #elseif os(macOS)
             ToolbarItem(placement: .primaryAction) {
-                Button {
-                    toggleWatched()
-                } label: {
+                Button { toggleWatched() } label: {
                     Image(systemName: movie.isWatched ? "checkmark.circle.fill" : "checkmark.circle")
                 }
                 .help(movie.isWatched ? "Mark as Unwatched" : "Mark as Watched")
             }
             ToolbarItem(placement: .primaryAction) {
-                Button {
-                    toggleFavorite()
-                } label: {
+                Button { toggleFavorite() } label: {
                     Image(systemName: movie.isFavorite ? "heart.fill" : "heart")
                         .foregroundStyle(movie.isFavorite ? .red : .primary)
                 }
                 .help(movie.isFavorite ? "Remove from Favorites" : "Add to Favorites")
             }
+            ToolbarItem(placement: .primaryAction) {
+                downloadMacItem
+            }
         #endif
     }
+
+    #if !os(tvOS)
+        @ViewBuilder
+        private var downloadMacItem: some View {
+            if let active = downloads.activeDownloads[movie.id] {
+                Button { downloads.cancelDownload(id: movie.id) } label: {
+                    Image(systemName: "stop.circle")
+                }
+                .help("Cancel — \(Int(active.fractionCompleted * 100))%")
+            } else if downloads.pendingIDs.contains(movie.id) {
+                Button { downloads.cancelDownload(id: movie.id) } label: {
+                    Image(systemName: "stop.circle")
+                }
+                .help("Cancel download")
+            } else if movie.downloadStatus == .completed {
+                Button { downloads.deleteLocalFile(id: movie.id) } label: {
+                    Image(systemName: "arrow.down.circle.fill")
+                }
+                .help("Remove download")
+            } else if let playlist = moviePlaylist {
+                Button { downloads.startDownload(movie: movie, playlist: playlist) } label: {
+                    Image(systemName: movie.downloadStatus == .failed ? "exclamationmark.circle" : "arrow.down.circle")
+                }
+                .help("Download")
+            }
+        }
+    #endif
 
     // MARK: - Derived data
 
@@ -456,12 +475,6 @@ struct MovieDetailView: View {
         }
         TraktService.shared.syncWatched(movie: movie, watched: movie.isWatched)
     }
-
-    #if !os(tvOS)
-        private func deleteMovieDownload() {
-            downloads.deleteLocalFile(id: movie.id)
-        }
-    #endif
 }
 
 #Preview("Basic") {

--- a/Lume/Views/Series/EpisodeCard.swift
+++ b/Lume/Views/Series/EpisodeCard.swift
@@ -8,6 +8,11 @@ struct EpisodeCard: View {
     var onToggleWatched: () -> Void = {}
     var onMarkPreviousWatched: () -> Void = {}
     var onMarkFollowingUnwatched: () -> Void = {}
+    #if !os(tvOS)
+        var onDownload: (() -> Void)?
+        var onDeleteDownload: (() -> Void)?
+        var downloadProgress: Double?
+    #endif
 
     var body: some View {
         Button(action: onPlay) {
@@ -53,11 +58,34 @@ struct EpisodeCard: View {
                 onMarkPreviousWatched: onMarkPreviousWatched,
                 onMarkFollowingUnwatched: onMarkFollowingUnwatched
             )
+            #if !os(tvOS)
+                Divider()
+                if episode.downloadStatus == .completed {
+                    Button(role: .destructive) {
+                        onDeleteDownload?()
+                    } label: {
+                        Label("Remove Download", systemImage: "trash")
+                    }
+                } else if downloadProgress == nil {
+                    Button {
+                        onDownload?()
+                    } label: {
+                        Label("Download Episode", systemImage: "arrow.down.circle")
+                    }
+                    .disabled(onDownload == nil)
+                } else {
+                    Button(role: .destructive) {
+                        onDeleteDownload?()
+                    } label: {
+                        Label("Cancel Download", systemImage: "xmark.circle")
+                    }
+                }
+            #endif
         }
     }
 
     private var thumbnail: some View {
-        ZStack {
+        ZStack(alignment: .topLeading) {
             CachedAsyncImage(url: URL(string: episode.movieImage ?? ""), maxPixelSize: 142) { phase in
                 switch phase {
                 case let .success(image):
@@ -76,12 +104,44 @@ struct EpisodeCard: View {
             .frame(width: 142, height: 80)
             .clipShape(RoundedRectangle(cornerRadius: 8))
 
+            #if !os(tvOS)
+                if let progress = downloadProgress {
+                    // Actively downloading: show a progress indicator
+                    ZStack {
+                        Rectangle()
+                            .fill(.black.opacity(0.45))
+                        if progress > 0 {
+                            ProgressView(value: progress)
+                                .progressViewStyle(.circular)
+                                .tint(.white)
+                                .scaleEffect(0.6)
+                        } else {
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                                .tint(.white)
+                                .scaleEffect(0.6)
+                        }
+                    }
+                    .frame(width: 142, height: 80)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                } else if episode.downloadStatus == .completed {
+                    Image(systemName: "arrow.down.circle.fill")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .padding(4)
+                        .background(.tint.opacity(0.85), in: Circle())
+                        .padding(5)
+                }
+            #endif
+
             Image(systemName: "play.circle.fill")
                 .font(.title2)
                 .foregroundStyle(.white)
                 .shadow(radius: 4)
                 .opacity(0.9)
+                .frame(width: 142, height: 80)
         }
+        .frame(width: 142, height: 80)
     }
 
     /// Air date and runtime joined on a single caption line, omitting whichever is missing.

--- a/Lume/Views/Series/SeriesDetailView.swift
+++ b/Lume/Views/Series/SeriesDetailView.swift
@@ -34,6 +34,9 @@ struct SeriesDetailView: View {
     @State private var otherSources: [HomeMediaItem] = []
     @State private var refreshToken: UUID = .init()
     @State private var isLoadingTMDB: Bool
+    #if !os(tvOS)
+        @State private var downloads = DownloadManager.shared
+    #endif
 
     init(series: Series, animationNamespace: Namespace.ID? = nil) {
         self.series = series
@@ -215,13 +218,27 @@ struct SeriesDetailView: View {
             } else {
                 LazyVStack(spacing: 16) {
                     ForEach(seasonEpisodes) { episode in
-                        EpisodeCard(
-                            episode: episode,
-                            onPlay: { playEpisode(episode) },
-                            onToggleWatched: { toggleWatched(episode) },
-                            onMarkPreviousWatched: { markPreviousWatched(episode) },
-                            onMarkFollowingUnwatched: { markFollowingUnwatched(episode) }
-                        )
+                        #if os(tvOS)
+                            EpisodeCard(
+                                episode: episode,
+                                onPlay: { playEpisode(episode) },
+                                onToggleWatched: { toggleWatched(episode) },
+                                onMarkPreviousWatched: { markPreviousWatched(episode) },
+                                onMarkFollowingUnwatched: { markFollowingUnwatched(episode) }
+                            )
+                        #else
+                            EpisodeCard(
+                                episode: episode,
+                                onPlay: { playEpisode(episode) },
+                                onToggleWatched: { toggleWatched(episode) },
+                                onMarkPreviousWatched: { markPreviousWatched(episode) },
+                                onMarkFollowingUnwatched: { markFollowingUnwatched(episode) },
+                                onDownload: seriesPlaylist.map { playlist in { downloads.startDownload(episode: episode, playlist: playlist) } },
+                                onDeleteDownload: { downloads.deleteLocalFile(id: episode.id) },
+                                downloadProgress: downloads.activeDownloads[episode.id].map(\.fractionCompleted)
+                                    ?? (downloads.pendingIDs.contains(episode.id) ? 0 : nil)
+                            )
+                        #endif
                     }
                 }
                 .padding(.horizontal, DetailMetrics.contentPadding)
@@ -351,10 +368,6 @@ struct SeriesDetailView: View {
         )
     }
 
-    private var seasonCountLabel: String {
-        availableSeasons.count == 1 ? String(localized: "1 Season") : String(localized: "\(availableSeasons.count) Seasons")
-    }
-
     private var availableSeasons: [Int] {
         Set(series.episodes.map(\.seasonNum)).sorted()
     }
@@ -412,12 +425,6 @@ struct SeriesDetailView: View {
               let index = ordered.firstIndex(where: { $0 === watched })
         else { return seasonEpisodes.first ?? ordered.first }
         return index + 1 < ordered.count ? ordered[index + 1] : ordered.first
-    }
-
-    private var playTitle: LocalizedStringKey {
-        guard let episode = nextEpisode else { return "Play" }
-        let resume = !episode.isWatched && episode.watchProgress > 1
-        return resume ? "Resume S\(episode.seasonNum) E\(episode.episodeNum)" : "Play S\(episode.seasonNum) E\(episode.episodeNum)"
     }
 
     private var backgroundColor: Color {
@@ -532,6 +539,11 @@ private extension SeriesDetailView {
     func toggleWatched(_ episode: Episode) {
         episode.setWatched(!episode.isWatched)
         TraktService.shared.syncWatched(episode: episode, watched: episode.isWatched)
+        #if !os(tvOS)
+            if episode.isWatched {
+                downloads.checkAutoDelete(id: episode.id)
+            }
+        #endif
         try? modelContext.save()
     }
 
@@ -546,52 +558,16 @@ private extension SeriesDetailView {
     }
 }
 
-#Preview("Basic") {
-    let container = previewContainer()
-    let series = PreviewData.sampleSeries
-    return NavigationStack {
-        SeriesDetailView(series: series)
-    }
-    .modelContainer(container)
-}
+// MARK: - Derived helpers
 
-#Preview("With TMDB + Episodes") {
-    let container = previewContainer()
-    let series = PreviewData.sampleSeries
-    series.backdropPath = "/abc123backdrop.jpg"
-    series.tagline = "I am the one who knocks."
-    series.contentRating = "TV-MA"
-    series.tmdbId = 1396
-    series.tmdb = "1396"
-    series.tmdbEnrichedAt = Date().addingTimeInterval(-3600)
-    series.isFavorite = true
-    return NavigationStack {
-        SeriesDetailView(series: series)
+private extension SeriesDetailView {
+    var seasonCountLabel: String {
+        availableSeasons.count == 1 ? String(localized: "1 Season") : String(localized: "\(availableSeasons.count) Seasons")
     }
-    .modelContainer(container)
-}
 
-#Preview("No TMDB") {
-    let container = previewContainer()
-    let series = PreviewData.sampleSeries
-    series.plot = nil
-    series.genre = nil
-    series.director = nil
-    return NavigationStack {
-        SeriesDetailView(series: series)
+    var playTitle: LocalizedStringKey {
+        guard let episode = nextEpisode else { return "Play" }
+        let resume = !episode.isWatched && episode.watchProgress > 1
+        return resume ? "Resume S\(episode.seasonNum) E\(episode.episodeNum)" : "Play S\(episode.seasonNum) E\(episode.episodeNum)"
     }
-    .modelContainer(container)
-}
-
-#Preview("Favorite") {
-    let container = previewContainer()
-    let series = PreviewData.sampleSeries
-    series.backdropPath = "/abc123backdrop.jpg"
-    series.tagline = "I am the one who knocks."
-    series.tmdbId = 1396
-    series.isFavorite = true
-    return NavigationStack {
-        SeriesDetailView(series: series)
-    }
-    .modelContainer(container)
 }

--- a/Lume/Views/Series/SeriesDetailViewPreviews.swift
+++ b/Lume/Views/Series/SeriesDetailViewPreviews.swift
@@ -1,0 +1,52 @@
+import SwiftData
+import SwiftUI
+
+#Preview("Basic") {
+    let container = previewContainer()
+    let series = PreviewData.sampleSeries
+    return NavigationStack {
+        SeriesDetailView(series: series)
+    }
+    .modelContainer(container)
+}
+
+#Preview("With TMDB + Episodes") {
+    let container = previewContainer()
+    let series = PreviewData.sampleSeries
+    series.backdropPath = "/abc123backdrop.jpg"
+    series.tagline = "I am the one who knocks."
+    series.contentRating = "TV-MA"
+    series.tmdbId = 1396
+    series.tmdb = "1396"
+    series.tmdbEnrichedAt = Date().addingTimeInterval(-3600)
+    series.isFavorite = true
+    return NavigationStack {
+        SeriesDetailView(series: series)
+    }
+    .modelContainer(container)
+}
+
+#Preview("No TMDB") {
+    let container = previewContainer()
+    let series = PreviewData.sampleSeries
+    series.plot = nil
+    series.genre = nil
+    series.director = nil
+    return NavigationStack {
+        SeriesDetailView(series: series)
+    }
+    .modelContainer(container)
+}
+
+#Preview("Favorite") {
+    let container = previewContainer()
+    let series = PreviewData.sampleSeries
+    series.backdropPath = "/abc123backdrop.jpg"
+    series.tagline = "I am the one who knocks."
+    series.tmdbId = 1396
+    series.isFavorite = true
+    return NavigationStack {
+        SeriesDetailView(series: series)
+    }
+    .modelContainer(container)
+}

--- a/Lume/Views/Settings/SettingsView.swift
+++ b/Lume/Views/Settings/SettingsView.swift
@@ -15,6 +15,10 @@ struct SettingsView: View {
     private var showNextEpisodeButton = PlayerSettings.Playback.showNextEpisodeButtonDefault
     /// Not `private`: read by the SettingsView+AutoSync extension (separate file).
     @AppStorage(SyncFrequency.storageKey) var syncFrequencyRaw: String = SyncFrequency.defaultValue.rawValue
+    #if !os(tvOS)
+        @AppStorage(DownloadManager.maxConcurrentKey) private var maxConcurrent = 1
+        @AppStorage(DownloadManager.autoDeleteKey) private var autoDeleteAfterWatching = false
+    #endif
 
     #if os(tvOS)
         /// The category whose content is shown in the right pane. Follows focus
@@ -57,6 +61,7 @@ struct SettingsView: View {
                         integrationsSection
                     }
                     playbackSection
+                    downloadsSection
                     playerSection
                     playerEngineSection
                     aboutSection
@@ -181,6 +186,28 @@ struct SettingsView: View {
                 Text("Playback")
             } footer: {
                 Text("Automatically start the next episode when one finishes, and show a button near the end to skip ahead.")
+            }
+        }
+
+        private var downloadsSection: some View {
+            Section {
+                NavigationLink {
+                    DownloadsView()
+                } label: {
+                    Label("Manage Downloads", systemImage: "arrow.down.circle")
+                }
+
+                Stepper(
+                    "Max Simultaneous Downloads: \(maxConcurrent)",
+                    value: $maxConcurrent,
+                    in: 1 ... 5
+                )
+
+                Toggle("Auto-Delete After Watching", isOn: $autoDeleteAfterWatching)
+            } header: {
+                Text("Downloads")
+            } footer: {
+                Text("Download movies and episodes for offline playback. Auto-delete removes the file once you've finished watching.")
             }
         }
 


### PR DESCRIPTION
## Issue
https://github.com/bilipp/Lume/issues/6

## Feature
Adds full offline-download support for movies and episodes on iOS and macOS. Users can download content for offline viewing directly from the detail screens, track progress, manage storage in Settings, and have watched content auto-deleted. No download UI on tvOS.

## Implementation
- **`DownloadManager`** (`Services/Downloads/`) — `@MainActor @Observable` singleton wrapping `URLSession` download tasks. Manages a pending queue, enforces a configurable concurrent-download limit (default 1 via `AppStorage`), writes download status back to SwiftData via a static `nonisolated` helper using a background `ModelContext` (same pattern as `WatchProgressWriter`).
- **`DownloadsView`** + **`DownloadButton`** (`Views/Downloads/`) — management UI listing in-progress, pending, and completed downloads with play/delete actions; `DownloadButton` is the secondary action below Play on detail screens.
- **`PlayableMedia`** — patched to prefer the local file URL when a download is completed and the file exists on disk; falls back to streaming automatically.
- **`MovieDetailView`** — `DownloadButton` added below the primary play button; auto-delete triggered on mark-as-watched.
- **`EpisodeCard`** / **`SeriesDetailView`** — context-menu download/cancel/remove actions; auto-delete on mark-as-watched.
- **`SettingsView`** — Downloads section with a `NavigationLink` to `DownloadsView`, a stepper for max concurrent downloads (1–5), and a toggle for auto-delete after watching.
- All download UI is wrapped in `#if !os(tvOS)`.

## Testing
- [ ] Acceptance criteria met (download → progress → local playback → delete)
- [ ] Related tests pass
- [ ] Tests skipped: no existing test infrastructure for service singletons

## Translations
N/A

## API Collection
N/A