### PR TITLE
fix(home): reload hero items after first-sync completes

### DIFF
--- a/Lume/Views/Home/HomeView.swift
+++ b/Lume/Views/Home/HomeView.swift
@@ -178,7 +178,7 @@ struct HomeView: View {
                     }
                 }
             #endif
-                .task(id: "\(playlists.count)-\(selectedPlaylistID)") {
+                .task(id: "\(playlists.count)-\(selectedPlaylistID)-\(activePlaylist?.lastSyncDate?.timeIntervalSince1970 ?? 0)") {
                     await loadTrending()
                 }
                 .task(id: "watchlist-\(trakt.isConnected)-\(selectedPlaylistID)") {


### PR DESCRIPTION
## Summary

- `loadTrending()` fired immediately when a playlist was added, before the background sync had written any movies/series to SwiftData — so `fetchMovie(tmdbId:)` returned nil for every trending title and `heroItems` stayed empty
- Appended `activePlaylist?.lastSyncDate` to the `.task(id:)` key; `ContentSyncManager` sets `lastSyncDate` only after all batched inserts are committed, so the re-triggered fetch is guaranteed to see the synced content
- One-line change, no new state

Fixes #41

## Test plan

- [ ] Add a fresh playlist, stay on Home — hero carousel should populate once sync finishes (no navigation needed)
- [ ] Switch between playlists — hero still reloads correctly per playlist
- [ ] Re-open the app with an existing playlist — no spurious extra reload (lastSyncDate unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)