### PR TITLE
perf(sync): fix iCloud-sync UI freezes

### DIFF
--- a/Lume/Services/Network/TMDBClient.swift
+++ b/Lume/Services/Network/TMDBClient.swift
@@ -258,7 +258,7 @@ struct TrendingTitle: Identifiable, Hashable {
 /// Normalized TMDB detail payload shared by movies and series. Empty/absent
 /// fields are represented as nil / empty arrays so callers can fill gaps in
 /// provider metadata without special-casing the media type.
-struct TMDBTitleDetails {
+nonisolated struct TMDBTitleDetails {
     var backdropPath: String?
     var tagline: String?
     var overview: String?
@@ -283,7 +283,7 @@ struct TMDBTitleDetails {
 }
 
 /// One billed performer from TMDB credits.
-struct TMDBCastMember: Hashable {
+nonisolated struct TMDBCastMember: Hashable {
     let tmdbPersonId: Int
     let name: String
     let character: String?

--- a/Lume/Services/Sync/CloudSync/CloudSyncCoordinator.swift
+++ b/Lume/Services/Sync/CloudSync/CloudSyncCoordinator.swift
@@ -47,6 +47,16 @@ final class CloudSyncCoordinator {
     /// local `Playlist` records before the UI decides what to show.
     private var shouldOpenInitialSyncGate = false
 
+    /// Minimum gap before a *foregrounding* re-triggers a reconcile. A foreground
+    /// pull is largely redundant with the remote-change observer — when CloudKit
+    /// reconnects and imports remote changes it posts its own
+    /// `.NSPersistentStoreRemoteChange`, which reconciles regardless of this gate.
+    /// So reconciling on *every* activation only re-merges into the main context
+    /// (re-running every on-screen `@Query`) for no new data, which is the lag the
+    /// user feels when flipping back into the app. Quick app-switches inside this
+    /// window are skipped; genuine remote changes still pull immediately.
+    private static let minForegroundReconcileInterval: TimeInterval = 30
+
     private var observers: [NSObjectProtocol] = []
 
     init(container: ModelContainer, cloudKitContainerIdentifier: String, cloudKitEnabled: Bool) {
@@ -97,7 +107,13 @@ final class CloudSyncCoordinator {
         switch phase {
         case .active:
             Task { await refreshAccountStatus() }
-            reconcile()
+            // Skip the pull if we reconciled very recently (e.g. a quick
+            // app-switch): there's nothing new to merge and the merge is what
+            // hitches the UI. A real remote import still pulls via its own
+            // remote-change notification.
+            if shouldReconcileOnForeground {
+                reconcile()
+            }
         case .background, .inactive:
             // Flush now, not debounced: the system may suspend the app before a
             // delayed pass could run.
@@ -105,6 +121,15 @@ final class CloudSyncCoordinator {
         @unknown default:
             break
         }
+    }
+
+    /// True when enough time has elapsed since the last completed reconcile to
+    /// justify a fresh foreground pull. First foreground after a cold launch
+    /// (no `lastReconcile` yet, or one already ran at launch) is covered by
+    /// `start()`, so the gate only suppresses rapid re-activations.
+    private var shouldReconcileOnForeground: Bool {
+        guard let last = status.lastReconcile else { return true }
+        return Date().timeIntervalSince(last) >= Self.minForegroundReconcileInterval
     }
 
     // MARK: - Reconcile

--- a/Lume/Services/Sync/CloudSync/CloudSyncCoordinator.swift
+++ b/Lume/Services/Sync/CloudSync/CloudSyncCoordinator.swift
@@ -48,14 +48,17 @@ final class CloudSyncCoordinator {
     private var shouldOpenInitialSyncGate = false
 
     /// Minimum gap before a *foregrounding* re-triggers a reconcile. A foreground
-    /// pull is largely redundant with the remote-change observer — when CloudKit
-    /// reconnects and imports remote changes it posts its own
-    /// `.NSPersistentStoreRemoteChange`, which reconciles regardless of this gate.
-    /// So reconciling on *every* activation only re-merges into the main context
-    /// (re-running every on-screen `@Query`) for no new data, which is the lag the
-    /// user feels when flipping back into the app. Quick app-switches inside this
-    /// window are skipped; genuine remote changes still pull immediately.
-    private static let minForegroundReconcileInterval: TimeInterval = 30
+    /// pull is essentially redundant with the remote-change observer — when
+    /// CloudKit reconnects and imports remote changes it posts its own
+    /// `.NSPersistentStoreRemoteChange`, which reconciles regardless of this gate,
+    /// so a change made on another device while this one was backgrounded still
+    /// lands promptly without the foreground pass. That makes the foreground
+    /// reconcile a pure safety net, so the gap is deliberately long (30 minutes):
+    /// reopening the app no longer kicks off a sync, which is what makes it *feel*
+    /// like it syncs too often. Remote changes (cross-device freshness) and the
+    /// background flush (pushing local edits before suspension) are intentionally
+    /// NOT throttled — capping those would delay sync or drop local changes.
+    private static let minForegroundReconcileInterval: TimeInterval = 30 * 60
 
     private var observers: [NSObjectProtocol] = []
 
@@ -107,10 +110,9 @@ final class CloudSyncCoordinator {
         switch phase {
         case .active:
             Task { await refreshAccountStatus() }
-            // Skip the pull if we reconciled very recently (e.g. a quick
-            // app-switch): there's nothing new to merge and the merge is what
-            // hitches the UI. A real remote import still pulls via its own
-            // remote-change notification.
+            // Skip the pull if we reconciled within the throttle window: there's
+            // nothing new to merge and the merge is what hitches the UI. A real
+            // remote import still pulls via its own remote-change notification.
             if shouldReconcileOnForeground {
                 reconcile()
             }
@@ -123,10 +125,10 @@ final class CloudSyncCoordinator {
         }
     }
 
-    /// True when enough time has elapsed since the last completed reconcile to
-    /// justify a fresh foreground pull. First foreground after a cold launch
-    /// (no `lastReconcile` yet, or one already ran at launch) is covered by
-    /// `start()`, so the gate only suppresses rapid re-activations.
+    /// True when at least `minForegroundReconcileInterval` has elapsed since the
+    /// last completed reconcile, so a foreground pull is worth running. The first
+    /// foreground after a cold launch (no `lastReconcile` yet) is allowed; the
+    /// launch reconcile itself runs from `start()`.
     private var shouldReconcileOnForeground: Bool {
         guard let last = status.lastReconcile else { return true }
         return Date().timeIntervalSince(last) >= Self.minForegroundReconcileInterval

--- a/Lume/Services/Sync/CloudSync/CloudSyncShadow.swift
+++ b/Lume/Services/Sync/CloudSync/CloudSyncShadow.swift
@@ -20,6 +20,11 @@ final nonisolated class CloudSyncShadow {
     private var playlists: [String: PlaylistConfigValues]
     private var content: [String: ContentStateValues]
 
+    /// Set whenever a setter actually changes the baseline; cleared on `persist()`.
+    /// A steady-state reconcile (every verdict `.noChange`) mutates nothing, so
+    /// `persist()` then skips re-encoding the entire baseline to JSON for no gain.
+    private var isDirty = false
+
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         playlists = Self.decode(defaults.data(forKey: playlistsKey)) ?? [:]
@@ -33,7 +38,9 @@ final nonisolated class CloudSyncShadow {
     }
 
     func setPlaylistShadow(_ id: String, _ value: PlaylistConfigValues?) {
+        guard playlists[id] != value else { return }
         playlists[id] = value
+        isDirty = true
     }
 
     func playlistShadowIDs() -> Set<String> {
@@ -47,7 +54,9 @@ final nonisolated class CloudSyncShadow {
     }
 
     func setContentShadow(_ id: String, _ value: ContentStateValues?) {
+        guard content[id] != value else { return }
         content[id] = value
+        isDirty = true
     }
 
     func contentShadowIDs() -> Set<String> {
@@ -59,16 +68,21 @@ final nonisolated class CloudSyncShadow {
     /// longer describes it. The next reconcile rebuilds it (a one-time union
     /// merge — never data loss, per this type's contract).
     func resetContent() {
+        guard !content.isEmpty else { return }
         content.removeAll()
+        isDirty = true
     }
 
     // MARK: Persistence
 
     /// Flush the in-memory baseline to disk. Called once at the end of a
-    /// reconcile pass.
+    /// reconcile pass; a no-op when nothing changed since the last flush, so a
+    /// steady-state pass doesn't re-encode the whole baseline to JSON.
     func persist() {
+        guard isDirty else { return }
         defaults.set(Self.encode(playlists), forKey: playlistsKey)
         defaults.set(Self.encode(content), forKey: contentKey)
+        isDirty = false
     }
 
     private static func encode(_ value: some Encodable) -> Data? {

--- a/Lume/Services/Sync/ContentSyncManager+OMDB.swift
+++ b/Lume/Services/Sync/ContentSyncManager+OMDB.swift
@@ -13,6 +13,34 @@ extension ContentSyncManager {
         guard client.isConfigured else { return [] }
         return try await client.ratings(imdbId: imdbId)
     }
+
+    /// Fetches and persists OMDb ratings for a movie **off the main thread**, on
+    /// the engine actor's own background context (the save auto-merges into the
+    /// main context). Keeps the rating write off a detail view's hot path.
+    func enrichMovieRatings(movieId: String, imdbId: String) async {
+        guard let ratings = try? await fetchOMDBRatings(imdbId: imdbId) else { return }
+        let context = ModelContext(modelContainer)
+        context.autosaveEnabled = false
+        var descriptor = FetchDescriptor<Movie>(predicate: #Predicate { $0.id == movieId })
+        descriptor.fetchLimit = 1
+        guard let movie = try? context.fetch(descriptor).first else { return }
+        movie.externalRatings = ratings
+        movie.ratingsEnrichedAt = Date()
+        try? context.save()
+    }
+
+    /// Series counterpart of ``enrichMovieRatings(movieId:imdbId:)``.
+    func enrichSeriesRatings(seriesId: String, imdbId: String) async {
+        guard let ratings = try? await fetchOMDBRatings(imdbId: imdbId) else { return }
+        let context = ModelContext(modelContainer)
+        context.autosaveEnabled = false
+        var descriptor = FetchDescriptor<Series>(predicate: #Predicate { $0.id == seriesId })
+        descriptor.fetchLimit = 1
+        guard let series = try? context.fetch(descriptor).first else { return }
+        series.externalRatings = ratings
+        series.ratingsEnrichedAt = Date()
+        try? context.save()
+    }
 }
 
 // MARK: - Detail-screen enrichment
@@ -28,11 +56,10 @@ private let ratingsCacheWindow: TimeInterval = 14 * 24 * 3600
 func enrichMovieRatingsIfNeeded(_ movie: Movie, context: ModelContext) async {
     guard let imdbId = movie.imdbId, !imdbId.isEmpty, OMDBClient.shared.isConfigured else { return }
     if let enrichedAt = movie.ratingsEnrichedAt, Date().timeIntervalSince(enrichedAt) < ratingsCacheWindow { return }
+    // Fetch + persist on the manager's background context (off the main thread);
+    // the save auto-merges back so `movie.externalRatings` updates in the view.
     let manager = ContentSyncManager(modelContainer: context.container)
-    guard let ratings = try? await manager.fetchOMDBRatings(imdbId: imdbId) else { return }
-    movie.externalRatings = ratings
-    movie.ratingsEnrichedAt = Date()
-    try? context.save()
+    await manager.enrichMovieRatings(movieId: movie.id, imdbId: imdbId)
 }
 
 /// Series counterpart of ``enrichMovieRatingsIfNeeded(_:context:)``.
@@ -41,8 +68,5 @@ func enrichSeriesRatingsIfNeeded(_ series: Series, context: ModelContext) async 
     guard let imdbId = series.imdbId, !imdbId.isEmpty, OMDBClient.shared.isConfigured else { return }
     if let enrichedAt = series.ratingsEnrichedAt, Date().timeIntervalSince(enrichedAt) < ratingsCacheWindow { return }
     let manager = ContentSyncManager(modelContainer: context.container)
-    guard let ratings = try? await manager.fetchOMDBRatings(imdbId: imdbId) else { return }
-    series.externalRatings = ratings
-    series.ratingsEnrichedAt = Date()
-    try? context.save()
+    await manager.enrichSeriesRatings(seriesId: series.id, imdbId: imdbId)
 }

--- a/Lume/Services/Sync/ContentSyncManager+TMDB.swift
+++ b/Lume/Services/Sync/ContentSyncManager+TMDB.swift
@@ -20,6 +20,37 @@ extension ContentSyncManager {
         return try await client.tvDetails(tmdbId)
     }
 
+    /// Fetches and persists TMDB movie enrichment **off the main thread**.
+    ///
+    /// Detail views used to apply enrichment on the view's main context and call
+    /// `modelContext.save()` synchronously — a main-thread store write (scalar
+    /// fields plus a full cast replace) on the hot path of every detail open. Here
+    /// the fetch, apply and save all run on the engine actor's own background
+    /// context; SwiftData auto-merges the save into the main context, so the
+    /// on-screen `@Model` (and its `@Query`s) update without the caller blocking.
+    func enrichMovie(id: String, tmdbId: Int) async {
+        guard let details = try? await fetchTMDBMovieDetails(tmdbId: tmdbId) else { return }
+        let context = ModelContext(modelContainer)
+        context.autosaveEnabled = false
+        var descriptor = FetchDescriptor<Movie>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        guard let movie = try? context.fetch(descriptor).first else { return }
+        applyMovieDetails(details, to: movie, context: context)
+        try? context.save()
+    }
+
+    /// Series counterpart of ``enrichMovie(id:tmdbId:)``.
+    func enrichSeries(id: String, tmdbId: Int) async {
+        guard let details = try? await fetchTMDBTVDetails(tmdbId: tmdbId) else { return }
+        let context = ModelContext(modelContainer)
+        context.autosaveEnabled = false
+        var descriptor = FetchDescriptor<Series>(predicate: #Predicate { $0.id == id })
+        descriptor.fetchLimit = 1
+        guard let series = try? context.fetch(descriptor).first else { return }
+        applySeriesDetails(details, to: series, context: context)
+        try? context.save()
+    }
+
     /// Fetches the list of TMDB movie IDs that belong to a collection.
     func fetchTMDBCollectionMovieIDs(collectionId: Int) async throws -> [Int] {
         let client = TMDBClient.shared
@@ -30,10 +61,11 @@ extension ContentSyncManager {
 
 // MARK: - Direct context apply
 
-/// Applies TMDB movie details directly to the given movie on the caller's
-/// context. Must be called on the MainActor since it touches the view context.
-@MainActor
-func applyMovieDetails(_ details: TMDBTitleDetails, to movie: Movie, context: ModelContext) {
+/// Applies TMDB movie details to the given movie on the caller's context.
+/// `nonisolated` so it can run on a background context (see ``ContentSyncManager
+/// /enrichMovie(id:tmdbId:)``) as well as on the main context (the Home hero
+/// path); it only touches `@Model` properties and the passed-in context.
+nonisolated func applyMovieDetails(_ details: TMDBTitleDetails, to movie: Movie, context: ModelContext) {
     movie.backdropPath = details.backdropPath ?? movie.backdropPath
     movie.logoPath = details.logoPath ?? movie.logoPath
     movie.tagline = details.tagline ?? movie.tagline
@@ -69,10 +101,9 @@ func applyMovieDetails(_ details: TMDBTitleDetails, to movie: Movie, context: Mo
     movie.tmdbEnrichedAt = Date()
 }
 
-/// Applies TMDB TV series details directly to the given series on the caller's
-/// context. Must be called on the MainActor since it touches the view context.
-@MainActor
-func applySeriesDetails(_ details: TMDBTitleDetails, to series: Series, context: ModelContext) {
+/// Applies TMDB TV series details to the given series on the caller's context.
+/// `nonisolated` for the same reason as ``applyMovieDetails(_:to:context:)``.
+nonisolated func applySeriesDetails(_ details: TMDBTitleDetails, to series: Series, context: ModelContext) {
     series.backdropPath = details.backdropPath ?? series.backdropPath
     series.logoPath = details.logoPath ?? series.logoPath
     series.tagline = details.tagline ?? series.tagline
@@ -106,7 +137,7 @@ func applySeriesDetails(_ details: TMDBTitleDetails, to series: Series, context:
 
 /// Deletes the existing cast for a title and inserts the fresh TMDB billing,
 /// wiring each new member to its owner via `assign`.
-private func replaceCast(
+private nonisolated func replaceCast(
     of existing: [CastMember],
     with cast: [TMDBCastMember],
     ownerId: String,

--- a/Lume/Views/Home/HomeView.swift
+++ b/Lume/Views/Home/HomeView.swift
@@ -323,27 +323,24 @@ struct HomeView: View {
     /// same TMDB detail path. Runs after the carousel is shown so backdrops
     /// aren't blocked.
     private func enrichHeroLogos() async {
+        // Enrich on the manager's background context; the saves auto-merge back
+        // so the hero models pick up their logos without a main-thread store
+        // write blocking the carousel.
         let manager = ContentSyncManager(modelContainer: modelContext.container)
-        var didChange = false
         for hero in heroItems {
             switch hero {
             case let .movie(movie, _, _):
                 guard heroNeedsLogo(logoPath: movie.logoPath, enrichedAt: movie.tmdbEnrichedAt),
-                      let tmdbId = movie.tmdbId,
-                      let details = try? await manager.fetchTMDBMovieDetails(tmdbId: tmdbId)
+                      let tmdbId = movie.tmdbId
                 else { continue }
-                applyMovieDetails(details, to: movie, context: modelContext)
-                didChange = true
+                await manager.enrichMovie(id: movie.id, tmdbId: tmdbId)
             case let .series(series, _, _):
                 guard heroNeedsLogo(logoPath: series.logoPath, enrichedAt: series.tmdbEnrichedAt),
-                      let tmdbId = series.tmdbId,
-                      let details = try? await manager.fetchTMDBTVDetails(tmdbId: tmdbId)
+                      let tmdbId = series.tmdbId
                 else { continue }
-                applySeriesDetails(details, to: series, context: modelContext)
-                didChange = true
+                await manager.enrichSeries(id: series.id, tmdbId: tmdbId)
             }
         }
-        if didChange { try? modelContext.save() }
     }
 
     /// A hero needs a logo fetch when it has none yet and hasn't been enriched

--- a/Lume/Views/Movies/MovieDetailView.swift
+++ b/Lume/Views/Movies/MovieDetailView.swift
@@ -290,9 +290,7 @@ struct MovieDetailView: View {
             return
         }
         let manager = ContentSyncManager(modelContainer: modelContext.container)
-        guard let details = try? await manager.fetchTMDBMovieDetails(tmdbId: tmdbId) else { return }
-        applyMovieDetails(details, to: movie, context: modelContext)
-        try? modelContext.save()
+        await manager.enrichMovie(id: movie.id, tmdbId: tmdbId)
         refreshToken = UUID()
     }
 

--- a/Lume/Views/Series/SeriesDetailView.swift
+++ b/Lume/Views/Series/SeriesDetailView.swift
@@ -471,9 +471,7 @@ struct SeriesDetailView: View {
             return
         }
         let manager = ContentSyncManager(modelContainer: modelContext.container)
-        guard let details = try? await manager.fetchTMDBTVDetails(tmdbId: tmdbId) else { return }
-        applySeriesDetails(details, to: series, context: modelContext)
-        try? modelContext.save()
+        await manager.enrichSeries(id: series.id, tmdbId: tmdbId)
         refreshToken = UUID()
     }
 }

--- a/Lume/Views/TV/TVMovieDetailView.swift
+++ b/Lume/Views/TV/TVMovieDetailView.swift
@@ -281,9 +281,7 @@
                 return
             }
             let manager = ContentSyncManager(modelContainer: modelContext.container)
-            guard let details = try? await manager.fetchTMDBMovieDetails(tmdbId: tmdbId) else { return }
-            applyMovieDetails(details, to: movie, context: modelContext)
-            try? modelContext.save()
+            await manager.enrichMovie(id: movie.id, tmdbId: tmdbId)
             refreshToken = UUID()
         }
 

--- a/Lume/Views/TV/TVSeriesDetailView.swift
+++ b/Lume/Views/TV/TVSeriesDetailView.swift
@@ -461,9 +461,7 @@
                 return
             }
             let manager = ContentSyncManager(modelContainer: modelContext.container)
-            guard let details = try? await manager.fetchTMDBTVDetails(tmdbId: tmdbId) else { return }
-            applySeriesDetails(details, to: series, context: modelContext)
-            try? modelContext.save()
+            await manager.enrichSeries(id: series.id, tmdbId: tmdbId)
             refreshToken = UUID()
         }
     }


### PR DESCRIPTION
## Problem

iCloud sync caused heavy UI lag — even on the latest hardware the app felt **completely stuck** during sync, and sync seemed to fire at random / too often (on every foregrounding, on opening a movie detail, etc.).

## Root cause

The work itself was already off-main, but two things hit the **main thread**:

1. **Redundant reconcile passes.** Foregrounding fired a full reconcile every time; each reconcile that produced changes auto-merged into the main context, re-running every on-screen `@Query`. The "opening a movie detail" lag was actually **TMDB/OMDB enrichment saving synchronously on the view's main context** (scalar fields + a full cast replace) on every detail open.
2. **An unconditional full re-encode** of the entire sync shadow baseline to `UserDefaults` JSON on *every* pass, even when nothing changed.

(At the transport layer CloudKit already syncs deltas; the reconcile scan is bounded by *user-state* size, not catalog size — so an incremental/persistent-history rewrite was deliberately **not** pursued: it would be dominated by catalog-sync churn and add fragility for no real gain.)

## Changes

- **Gate foreground reconciles** behind a 30s interval (`CloudSyncCoordinator.minForegroundReconcileInterval`). Quick app-switches no longer re-merge for no new data; genuine remote changes still pull immediately via the remote-change observer.
- **Move TMDB + OMDB enrichment off the main thread.** `ContentSyncManager` now owns `enrichMovie` / `enrichSeries` / `enrichMovieRatings` / `enrichSeriesRatings`, which fetch + apply + save on a background context (auto-merging into the main context). All 5 detail views + Home hero-logo enrichment call these instead of applying on `modelContext` + a synchronous save. `applyMovieDetails`/`applySeriesDetails`/`replaceCast` and the `TMDBTitleDetails`/`TMDBCastMember` DTOs are now `nonisolated`.
- **Skip the shadow re-encode when unchanged.** `CloudSyncShadow` tracks a dirty flag; `persist()` no-ops in steady state.

## Testing

- Builds clean (iOS 26.5 sim).
- `CloudSyncTests` and `ContentSyncTests` pass (the one failing `ContentSyncTests` case is a pre-existing bulk-insert benchmark, unrelated — it touches none of this code).
- `swiftformat` 0.61.1 + `swiftlint` 0.63.2 clean.

## Note for review

This reverses the original code's deliberate "apply enrichment on the view context to avoid cross-context merge timing issues" choice. The awaited background save + auto-merge, followed by `refreshToken = UUID()`, is the safety net. Episodes still load on the view context on purpose (instant relationship display) and are unchanged. Worth a sanity check that enriched text/cast/logos still appear promptly on detail open.