### PR TITLE
feat(tvos): switch the active playlist from the Settings pane

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -3457,6 +3457,16 @@
         }
       }
     },
+    "Switching playlist changes the content shown across Home, Movies, Series and Live TV." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beim Wechsel der Playlist ändern sich die Inhalte in Start, Filme, Serien und Live-TV."
+          }
+        }
+      }
+    },
     "Switching to %@" : {
       "comment" : "Loading message shown while the app switches to another IPTV playlist",
       "localizations" : {

--- a/Lume/Views/Settings/SettingsView+Playlists.swift
+++ b/Lume/Views/Settings/SettingsView+Playlists.swift
@@ -1,0 +1,120 @@
+//
+//  SettingsView+Playlists.swift
+//  Lume
+//
+//  The tvOS Playlists settings pane. tvOS has no toolbar playlist switcher (the
+//  immersive home has no toolbar), so Settings is the entry point for switching
+//  the active playlist, adding new ones and editing them — mirroring the Profiles
+//  pane. iOS/macOS use the PlaylistSwitcher in the library toolbar instead.
+//
+
+import SwiftUI
+
+#if os(tvOS)
+
+    extension SettingsView {
+        var tvPlaylistsDetail: some View {
+            VStack(alignment: .leading, spacing: 36) {
+                tvPlaylistsList
+                tvAutoSyncSection
+                TVCloudSyncSection()
+            }
+        }
+
+        private var tvPlaylistsList: some View {
+            VStack(alignment: .leading, spacing: 8) {
+                TVSettingsSectionLabel("Playlists")
+
+                if playlists.isEmpty {
+                    Text("No playlists yet. Add your IPTV provider to start streaming.")
+                        .font(.system(size: 24))
+                        .foregroundStyle(.secondary)
+                        .padding(.vertical, 8)
+                } else {
+                    ForEach(playlists) { playlist in
+                        tvPlaylistRow(playlist)
+                    }
+                }
+
+                Button {
+                    showingAddPlaylist = true
+                } label: {
+                    HStack(spacing: 16) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 22, weight: .medium))
+                        Text("Add Playlist")
+                        Spacer(minLength: 0)
+                    }
+                }
+                .buttonStyle(TVSettingsRowButtonStyle())
+
+                if playlists.count > 1 {
+                    Text("Switching playlist changes the content shown across Home, Movies, Series and Live TV.")
+                        .font(.system(size: 20))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, TVSettingsMetrics.rowHPadding)
+                        .padding(.top, 6)
+                }
+            }
+        }
+
+        /// A playlist row mirroring the Profiles pane: tapping the row makes the
+        /// playlist active (checkmark marks the current one); the pencil drills
+        /// into its settings. The active id resolves through the same empty /
+        /// deleted fallback the content tabs use, so the first playlist reads as
+        /// active by default.
+        private func tvPlaylistRow(_ playlist: Playlist) -> some View {
+            let isActive = playlist.id.uuidString == effectivePlaylistID
+            return HStack(spacing: 16) {
+                Button {
+                    switchPlaylist(to: playlist)
+                } label: {
+                    HStack(spacing: 16) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(playlist.name)
+                            Text(playlist.serverURL)
+                                .font(.system(size: 20))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                        Spacer(minLength: 0)
+                        if isActive {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 22, weight: .semibold))
+                                .foregroundStyle(.tint)
+                        }
+                    }
+                }
+                .buttonStyle(TVSettingsRowButtonStyle())
+
+                Button {
+                    selectedPlaylist = playlist
+                } label: {
+                    Image(systemName: "pencil")
+                }
+                .buttonStyle(TVContentIconButtonStyle())
+                .accessibilityLabel("Edit \(playlist.name)")
+            }
+        }
+
+        /// The active playlist's id, accounting for the empty-default / deleted
+        /// fallback to the first playlist (matches `[Playlist].active(for:)`).
+        private var effectivePlaylistID: String {
+            playlists.active(for: selectedPlaylistID)?.id.uuidString ?? ""
+        }
+
+        /// Switches the global selection, routing through the blocking overlay when
+        /// the switch model is available (same path as the iOS toolbar switcher).
+        private func switchPlaylist(to playlist: Playlist) {
+            let id = playlist.id.uuidString
+            guard id != effectivePlaylistID else { return }
+            if let playlistSwitch {
+                playlistSwitch.switchTo(name: playlist.name) { selectedPlaylistID = id }
+            } else {
+                selectedPlaylistID = id
+            }
+        }
+    }
+
+#endif

--- a/Lume/Views/Settings/SettingsView.swift
+++ b/Lume/Views/Settings/SettingsView.swift
@@ -6,9 +6,10 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     /// Not `private`: read by the SettingsView+Profiles extension (separate file).
     @Environment(ProfileManager.self) var profileManager: ProfileManager?
-    // Not `private`: read by the SettingsView+AutoSync extension (separate file).
+    /// Not `private`: read by the SettingsView+AutoSync extension (separate file).
     @Query var playlists: [Playlist]
-    @State private var showingAddPlaylist = false
+    /// Not `private`: read by the SettingsView+Playlists extension (separate file).
+    @State var showingAddPlaylist = false
     @State private var trakt = TraktService.shared
     /// Legacy single-engine key, kept in sync with the primary engine so a
     /// downgrade still finds the user's preferred engine, and read as the
@@ -30,6 +31,14 @@ struct SettingsView: View {
     #endif
 
     #if os(tvOS)
+        /// The globally-selected playlist, shared with the content tabs. tvOS has
+        /// no toolbar switcher, so the Playlists settings pane is where the active
+        /// playlist is chosen. Not `private`: read by the SettingsView+Playlists
+        /// extension (separate file).
+        @AppStorage(PlaylistSelectionStore.key) var selectedPlaylistID: String = ""
+        /// Routes the switch through the blocking overlay (see PlaylistSwitchModel).
+        /// Not `private`: read by the SettingsView+Playlists extension.
+        @Environment(PlaylistSwitchModel.self) var playlistSwitch: PlaylistSwitchModel?
         /// The category whose content is shown in the right pane. Follows focus
         /// in the sidebar (Apple TV Settings behaviour) and persists once focus
         /// moves into the detail pane.
@@ -38,8 +47,9 @@ struct SettingsView: View {
         /// The playlist drilled into within the Playlists category. When set, its
         /// settings replace the playlist list *in the detail pane* rather than
         /// pushing a full-screen view — a push hides the header tab bar and
-        /// strands remote focus once the content scrolls.
-        @State private var selectedPlaylist: Playlist?
+        /// strands remote focus once the content scrolls. Not `private`: read by
+        /// the SettingsView+Playlists extension (separate file).
+        @State var selectedPlaylist: Playlist?
         /// The engine whose options are drilled into within the Player category,
         /// replacing the player detail in place (same reasoning as `selectedPlaylist`).
         @State private var selectedEngineOptions: PlayerEngineKind?
@@ -420,61 +430,6 @@ struct SettingsView: View {
                 .padding(.vertical, 72)
             }
             .focusSection()
-        }
-
-        private var tvPlaylistsDetail: some View {
-            VStack(alignment: .leading, spacing: 36) {
-                tvPlaylistsList
-                tvAutoSyncSection
-                TVCloudSyncSection()
-            }
-        }
-
-        private var tvPlaylistsList: some View {
-            VStack(alignment: .leading, spacing: 8) {
-                TVSettingsSectionLabel("Playlists")
-
-                if playlists.isEmpty {
-                    Text("No playlists yet. Add your IPTV provider to start streaming.")
-                        .font(.system(size: 24))
-                        .foregroundStyle(.secondary)
-                        .padding(.vertical, 8)
-                } else {
-                    ForEach(playlists) { playlist in
-                        Button {
-                            selectedPlaylist = playlist
-                        } label: {
-                            HStack(spacing: 16) {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(playlist.name)
-                                    Text(playlist.serverURL)
-                                        .font(.system(size: 20))
-                                        .foregroundStyle(.secondary)
-                                        .lineLimit(1)
-                                        .truncationMode(.middle)
-                                }
-                                Spacer(minLength: 0)
-                                Image(systemName: "chevron.right")
-                                    .font(.system(size: 20, weight: .semibold))
-                                    .foregroundStyle(.tertiary)
-                            }
-                        }
-                        .buttonStyle(TVSettingsRowButtonStyle())
-                    }
-                }
-
-                Button {
-                    showingAddPlaylist = true
-                } label: {
-                    HStack(spacing: 16) {
-                        Image(systemName: "plus")
-                            .font(.system(size: 22, weight: .medium))
-                        Text("Add Playlist")
-                        Spacer(minLength: 0)
-                    }
-                }
-                .buttonStyle(TVSettingsRowButtonStyle())
-            }
         }
 
         private var tvIntegrationsDetail: some View {


### PR DESCRIPTION
## Summary
tvOS had no way to switch the active playlist — the Settings → Playlists rows only drilled into a playlist's edit screen, and the toolbar `PlaylistSwitcher` is skipped on tvOS. This makes those rows switch the active playlist, mirroring the Profiles pane: tapping a row makes that playlist active (a checkmark marks the current one), while a dedicated pencil button drills into its detail/edit screen.

## Implementation
- The Playlists settings rows now route through the shared `PlaylistSwitchModel`, so switching shows the same blocking "Switching to …" overlay used on iOS/macOS (the overlay already covers the whole tvOS `TabView`, including the Settings tab).
- The active playlist is resolved via the existing `[Playlist].active(for:)` fallback, so the first playlist reads as active by default — consistent with how the content tabs scope their catalog.
- Extracted the tvOS playlist pane into `SettingsView+Playlists.swift`, matching the existing `SettingsView+Profiles.swift` layout and keeping `SettingsView.swift` under the file-length lint cap. A few `SettingsView` properties dropped `private` so the new extension can read them (the same convention already used by the AutoSync/Profiles extensions).
- Added one localized string (en + de) for the explanatory footer; all other strings reused existing keys.

## Testing
- [x] Acceptance criteria met
- [x] Tests pass — tvOS build succeeds (`xcodebuild build -scheme Lume -destination 'platform=tvOS Simulator,name=Apple TV'`)
- [x] SwiftLint clean (pre-commit `--strict` gate passed)
- [ ] Tests added — skipped: change is view wiring that delegates entirely to the already-existing `PlaylistSwitchModel` and `active(for:)` helper; no new isolatable logic.

## Platforms
- [ ] iOS / iPadOS
- [x] tvOS
- [ ] macOS
- [ ] visionOS
<!-- tvOS build verified; manual focus/visual pass recommended on an Apple TV sim. -->

## Related
<!-- No linked issue (free-form feature request). -->