### PR TITLE
feat(search): rank search results by semantic similarity

### DIFF
--- a/Lume/LumeApp.swift
+++ b/Lume/LumeApp.swift
@@ -201,6 +201,10 @@ struct LumeApp: App {
                     // sync is running).
                     ContentIndexingService.shared.configure(container: sharedModelContainer)
                     ContentIndexingService.shared.kick()
+
+                    // Point semantic search at the same store so it can rank
+                    // the embeddings the indexer builds.
+                    await SemanticSearchService.shared.configure(container: sharedModelContainer)
                 }
                 .onChange(of: scenePhase) { _, phase in
                     cloudSync.handleScenePhaseChange(to: phase)

--- a/Lume/Services/Indexing/SemanticSearchService.swift
+++ b/Lume/Services/Indexing/SemanticSearchService.swift
@@ -1,0 +1,200 @@
+//
+//  SemanticSearchService.swift
+//  Lume
+//
+//  Ranks indexed movies and series by meaning, using the on-device
+//  NLContextualEmbedding vectors ContentIndexer stores in `embeddingData`.
+//  The query is embedded into the same vector space and compared against every
+//  indexed title by cosine similarity, so a search like "heist movie in a
+//  dream" surfaces Inception even though those words never appear in its title.
+//
+//  Runs as an actor off the main thread: embedding the query and scanning the
+//  catalog are both done on a background ModelContext, mirroring ContentIndexer,
+//  so typing stays smooth. When the embedding model can't load on this device
+//  the service reports itself unavailable and SearchView falls back to plain
+//  lexical matching.
+//
+
+import Accelerate
+import Foundation
+import OSLog
+import SwiftData
+
+actor SemanticSearchService {
+    static let shared = SemanticSearchService()
+
+    /// Minimum cosine similarity for a title to count as a semantic match.
+    /// Below this the relationship to the query is too weak to be useful and
+    /// only adds noise to the results.
+    private let minimumSimilarity: Float = 0.35
+
+    private var container: ModelContainer?
+    /// The query embedder, created and loaded lazily on first search and reused
+    /// across searches. Shares the model assets ContentIndexer downloads.
+    private var embedder: TextEmbedder?
+    /// nil until we first try to prepare the model; `false` once we know it
+    /// can't load on this device, so we stop retrying for the session.
+    private var modelAvailable: Bool?
+
+    private init() {}
+
+    func configure(container: ModelContainer) {
+        self.container = container
+    }
+
+    // MARK: - Results
+
+    /// A single ranked title: its persistent `id` and cosine score to the query.
+    struct Match {
+        let id: String
+        let score: Float
+    }
+
+    /// Ranked ids per content type, most relevant first.
+    struct Results {
+        var movies: [Match] = []
+        var series: [Match] = []
+    }
+
+    /// Ranks indexed movies/series by semantic similarity to `query`.
+    ///
+    /// Returns `nil` when semantic search is unavailable — the model can't load
+    /// on this device, or the query produced no embedding — signalling the
+    /// caller to rely on lexical matching alone. An empty `Results` means the
+    /// search ran but nothing cleared the similarity threshold.
+    func search(
+        query: String,
+        includeMovies: Bool,
+        includeSeries: Bool,
+        limit: Int
+    ) async -> Results? {
+        guard includeMovies || includeSeries, let container else { return nil }
+        guard let embedder = await preparedEmbedder() else { return nil }
+        guard let queryVector = try? embedder.vector(for: query) else { return nil }
+
+        let normalizedQuery = normalized(queryVector)
+        guard !normalizedQuery.isEmpty else { return nil }
+
+        let context = ModelContext(container)
+        var results = Results()
+        if includeMovies {
+            results.movies = rank(
+                MovieEmbeddings(context: context).rows(),
+                against: normalizedQuery,
+                limit: limit
+            )
+        }
+        if includeSeries {
+            results.series = rank(
+                SeriesEmbeddings(context: context).rows(),
+                against: normalizedQuery,
+                limit: limit
+            )
+        }
+        return results
+    }
+
+    // MARK: - Embedder lifecycle
+
+    /// Lazily loads the embedding model. Caches the result so a device without
+    /// the model isn't asked to download it on every keystroke.
+    private func preparedEmbedder() async -> TextEmbedder? {
+        if let embedder { return embedder }
+        if modelAvailable == false { return nil }
+
+        do {
+            let embedder = try TextEmbedder()
+            try await embedder.prepare()
+            self.embedder = embedder
+            modelAvailable = true
+            return embedder
+        } catch {
+            modelAvailable = false
+            Logger.indexing.error("Semantic search unavailable; falling back to lexical search: \(error)")
+            return nil
+        }
+    }
+
+    // MARK: - Ranking
+
+    /// Scores every candidate against the (already normalized) query vector and
+    /// returns the strongest matches, highest score first.
+    private func rank(
+        _ rows: [(id: String, data: Data)],
+        against normalizedQuery: [Float],
+        limit: Int
+    ) -> [Match] {
+        var matches: [Match] = []
+        matches.reserveCapacity(rows.count)
+        for row in rows {
+            let vector = TextEmbedder.decode(row.data)
+            guard vector.count == normalizedQuery.count else { continue }
+            let score = cosineToNormalized(normalizedQuery, vector)
+            if score >= minimumSimilarity {
+                matches.append(Match(id: row.id, score: score))
+            }
+        }
+        matches.sort { $0.score > $1.score }
+        return Array(matches.prefix(limit))
+    }
+
+    // MARK: - Vector math
+
+    /// Returns `vector` scaled to unit length, or an empty array if it has no
+    /// magnitude (so the caller can bail out instead of dividing by zero).
+    private func normalized(_ vector: [Float]) -> [Float] {
+        var sumOfSquares: Float = 0
+        vDSP_svesq(vector, 1, &sumOfSquares, vDSP_Length(vector.count))
+        let magnitude = sqrt(sumOfSquares)
+        guard magnitude > 0 else { return [] }
+        var divisor = magnitude
+        var result = [Float](repeating: 0, count: vector.count)
+        vDSP_vsdiv(vector, 1, &divisor, &result, 1, vDSP_Length(vector.count))
+        return result
+    }
+
+    /// Cosine similarity of a unit-length `normalizedQuery` to an arbitrary
+    /// `vector`: `dot(q, v) / |v|`. Equal counts are guaranteed by the caller.
+    private func cosineToNormalized(_ normalizedQuery: [Float], _ vector: [Float]) -> Float {
+        var dot: Float = 0
+        vDSP_dotpr(normalizedQuery, 1, vector, 1, &dot, vDSP_Length(vector.count))
+        var sumOfSquares: Float = 0
+        vDSP_svesq(vector, 1, &sumOfSquares, vDSP_Length(vector.count))
+        let magnitude = sqrt(sumOfSquares)
+        guard magnitude > 0 else { return 0 }
+        return dot / magnitude
+    }
+}
+
+// MARK: - Embedding fetches
+
+/// Snapshots the `(id, embeddingData)` of every indexed movie, leaving the rest
+/// of each row unfaulted so a whole-catalog scan stays cheap.
+private struct MovieEmbeddings {
+    let context: ModelContext
+
+    func rows() -> [(id: String, data: Data)] {
+        var descriptor = FetchDescriptor<Movie>(predicate: #Predicate { $0.embeddingData != nil })
+        descriptor.propertiesToFetch = [\.id, \.embeddingData]
+        let movies = (try? context.fetch(descriptor)) ?? []
+        return movies.compactMap { movie in
+            guard let data = movie.embeddingData else { return nil }
+            return (movie.id, data)
+        }
+    }
+}
+
+/// Same as `MovieEmbeddings`, for series.
+private struct SeriesEmbeddings {
+    let context: ModelContext
+
+    func rows() -> [(id: String, data: Data)] {
+        var descriptor = FetchDescriptor<Series>(predicate: #Predicate { $0.embeddingData != nil })
+        descriptor.propertiesToFetch = [\.id, \.embeddingData]
+        let series = (try? context.fetch(descriptor)) ?? []
+        return series.compactMap { item in
+            guard let data = item.embeddingData else { return nil }
+            return (item.id, data)
+        }
+    }
+}

--- a/Lume/Views/SearchView.swift
+++ b/Lume/Views/SearchView.swift
@@ -120,7 +120,7 @@ struct SearchView: View {
                 .task(id: SearchKey(text: debouncedSearchText, filter: selectedFilter)) {
                     // Re-run whenever the settled query or the filter changes.
                     // Filter changes are instant (no debounce on the segmented control).
-                    updateResults()
+                    await updateResults()
                 }
         }
         #if os(iOS)
@@ -149,24 +149,68 @@ struct SearchView: View {
 
     // MARK: - Searching
 
-    /// Runs the search against SwiftData using bounded, predicate-based fetches.
+    /// Runs a hybrid search: an exact lexical pass plus a semantic ranking pass.
     ///
-    /// Filtering happens in SQLite (via `localizedStandardContains`) instead of
-    /// loading every Movie/Series/LiveStream into memory and scanning on the main
-    /// thread. Combined with the debounce above, this keeps typing smooth no matter
-    /// how large the library is — the work runs once, after input settles, and
-    /// returns at most `resultLimit` rows per content type.
+    /// 1. **Lexical** — bounded `localizedStandardContains` fetches in SQLite,
+    ///    exactly as before. These always lead the results: they cover the
+    ///    "I know the title" case, live channels (which are never embedded), and
+    ///    titles the background indexer hasn't reached yet.
+    /// 2. **Semantic** — `SemanticSearchService` embeds the query and ranks the
+    ///    stored vectors by meaning, surfacing related titles whose name doesn't
+    ///    contain the query. Anything already shown lexically is skipped.
+    ///
+    /// The semantic pass runs off the main thread; when the embedding model is
+    /// unavailable it returns nil and the results are simply the lexical ones.
     @MainActor
-    private func updateResults() {
+    private func updateResults() async {
         let query = debouncedSearchText
         guard !query.isEmpty else {
             results = []
             return
         }
 
+        let includeMovies = selectedFilter == .all || selectedFilter == .movies
+        let includeSeries = selectedFilter == .all || selectedFilter == .series
+        let includeLive = selectedFilter == .all || selectedFilter == .liveTV
+
+        // 1. Lexical matches — fast, exact, always included.
+        var matches = lexicalMatches(
+            query: query,
+            includeMovies: includeMovies,
+            includeSeries: includeSeries,
+            includeLive: includeLive
+        )
+
+        // 2. Semantic matches — ranked by meaning, off the main thread.
+        let semantic = await SemanticSearchService.shared.search(
+            query: query,
+            includeMovies: includeMovies,
+            includeSeries: includeSeries,
+            limit: resultLimit
+        )
+
+        // The settled query or filter may have changed while we awaited; the
+        // .task(id:) cancels us then, so don't publish stale results.
+        guard !Task.isCancelled, debouncedSearchText == query else { return }
+
+        if let semantic {
+            matches.append(contentsOf: semanticMatches(semantic, excluding: matches, limit: resultLimit))
+        }
+
+        results = matches
+    }
+
+    /// The lexical (substring) matches, in name order per content type.
+    @MainActor
+    private func lexicalMatches(
+        query: String,
+        includeMovies: Bool,
+        includeSeries: Bool,
+        includeLive: Bool
+    ) -> [SearchResult] {
         var matches: [SearchResult] = []
 
-        if selectedFilter == .all || selectedFilter == .movies {
+        if includeMovies {
             var descriptor = FetchDescriptor<Movie>(
                 predicate: #Predicate { $0.name.localizedStandardContains(query) },
                 sortBy: [SortDescriptor(\.name)]
@@ -176,7 +220,7 @@ struct SearchView: View {
             matches.append(contentsOf: movies.map { .movie($0) })
         }
 
-        if selectedFilter == .all || selectedFilter == .series {
+        if includeSeries {
             var descriptor = FetchDescriptor<Series>(
                 predicate: #Predicate { $0.name.localizedStandardContains(query) },
                 sortBy: [SortDescriptor(\.name)]
@@ -186,7 +230,7 @@ struct SearchView: View {
             matches.append(contentsOf: series.map { .series($0) })
         }
 
-        if selectedFilter == .all || selectedFilter == .liveTV {
+        if includeLive {
             var descriptor = FetchDescriptor<LiveStream>(
                 predicate: #Predicate { $0.name.localizedStandardContains(query) },
                 sortBy: [SortDescriptor(\.name)]
@@ -196,7 +240,56 @@ struct SearchView: View {
             matches.append(contentsOf: streams.map { .liveStream($0) })
         }
 
-        results = matches
+        return matches
+    }
+
+    /// Turns the semantic ranking into `SearchResult`s, dropping anything
+    /// already present in `existing` and preserving the score order the service
+    /// returned. Capped at `limit` semantic-only additions.
+    @MainActor
+    private func semanticMatches(
+        _ semantic: SemanticSearchService.Results,
+        excluding existing: [SearchResult],
+        limit: Int
+    ) -> [SearchResult] {
+        let existingIDs = Set(existing.map(\.id))
+
+        // Re-fetch the ranked titles on the view context, preserving order.
+        let movies = fetchMovies(ids: semantic.movies.map(\.id)).map { SearchResult.movie($0) }
+        let series = fetchSeries(ids: semantic.series.map(\.id)).map { SearchResult.series($0) }
+
+        // Interleave the two ranked lists by their original score so the most
+        // relevant title of either type leads, then drop the lexical overlap.
+        let scoreByID = Dictionary(
+            (semantic.movies + semantic.series).map { ($0.id, $0.score) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let merged = (movies + series)
+            .filter { !existingIDs.contains($0.id) }
+            .sorted { (scoreByID[$0.id] ?? 0) > (scoreByID[$1.id] ?? 0) }
+
+        return Array(merged.prefix(limit))
+    }
+
+    /// Fetches movies by id and returns them in the given id order, applying the
+    /// content restriction. Realises semantic-search hits for display.
+    @MainActor
+    private func fetchMovies(ids: [String]) -> [Movie] {
+        guard !ids.isEmpty else { return [] }
+        let descriptor = FetchDescriptor<Movie>(predicate: #Predicate { ids.contains($0.id) })
+        let fetched = ((try? modelContext.fetch(descriptor)) ?? []).excludingRestricted(restriction)
+        let byID = Dictionary(fetched.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        return ids.compactMap { byID[$0] }
+    }
+
+    /// Fetches series by id, in the given id order, applying the restriction.
+    @MainActor
+    private func fetchSeries(ids: [String]) -> [Series] {
+        guard !ids.isEmpty else { return [] }
+        let descriptor = FetchDescriptor<Series>(predicate: #Predicate { ids.contains($0.id) })
+        let fetched = ((try? modelContext.fetch(descriptor)) ?? []).excludingRestricted(restriction)
+        let byID = Dictionary(fetched.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        return ids.compactMap { byID[$0] }
     }
 }
 


### PR DESCRIPTION
## What

Search now actually uses the on-device `NLContextualEmbedding` vectors that the background `ContentIndexer` already stores in `Movie.embeddingData` / `Series.embeddingData`. Until now those vectors were generated and persisted but **never read** — `TextEmbedder.decode` had no callers and search was pure substring matching.

## How

**`SemanticSearchService`** (new actor, singleton like `ContentIndexingService`)
- Lazily creates and `prepare()`s a `TextEmbedder`, reused across searches. If the model can't load on the device, it caches that fact and returns `nil` so search degrades gracefully — no repeated OTA download attempts.
- Embeds the query, then on a **background `ModelContext`** fetches every indexed title (`embeddingData != nil`, `propertiesToFetch` to avoid faulting whole rows), decodes each vector, and cosine-ranks with **Accelerate (vDSP)**.
- Returns ordered `(id, score)` lists above a `0.35` similarity threshold, capped per content type.

**`SearchView`** — now hybrid:
- The existing `localizedStandardContains` (lexical) pass still runs and **always leads** the results, so exact-title hits, **live channels** (never embedded), and **not-yet-indexed** titles always appear.
- Semantic-only matches are appended, deduped against the lexical set, and ordered by score across movies + series.
- Staleness-guarded after the `await` so debounced/cancelled queries don't publish stale results.

**`LumeApp`** — configures the service with the shared container at launch, alongside the indexer.

## Behavior

- "Inception" → still top, via lexical match.
- "heist inside a dream" / "movie about robots falling in love" → now surfaces conceptually-related titles whose names don't contain those words.
- Same 300ms debounce; the heavy scan runs off the main thread.

## Testing

- ✅ Builds clean on the iOS 26.5 simulator.
- ✅ Pre-commit gates (swiftformat + swiftlint) pass.
- ⚠️ Not runtime-verified for ranking quality — needs a library that's been through the background indexer (which downloads the embedding model OTA). The `0.35` threshold may want tuning against a real catalog.
- No unit tests added: ranking depends on the on-device ML model (non-deterministic to set up) and the vector math is private to the actor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)