### PR TITLE
fix(ci): select Xcode via setup-xcode instead of hardcoded path

### DIFF
--- a/.github/workflows/sideload-release.yml
+++ b/.github/workflows/sideload-release.yml
@@ -28,7 +28,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.app
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       # ── Inject API key secrets (optional) ───────────────────────────────────
       # Features degrade gracefully when absent (see Scripts/inject-env.sh).


### PR DESCRIPTION
## Problem

The `Sideload Release` workflow (triggered on release publish) failed every job — iOS, tvOS, macOS — at the **Select Xcode** step:

```
xcode-select: error: invalid developer directory '/Applications/Xcode_26.app'
```

GitHub runner images don't ship a bare `Xcode_26.app`; Xcode installs are versioned (`Xcode_26.0.app`, `Xcode_26.1.app`, …). The hardcoded path never resolves.

## Fix

Replace the hardcoded `xcode-select` with the standard `maxim-lobanov/setup-xcode@v1` action using `latest-stable`, so the workflow selects whatever current Xcode the runner image provides.

## Note

This assumes the `macos-15` runner image still ships an Xcode with the iOS/tvOS 26.4 SDK. If the build steps later fail on SDK availability, bump the runner to `macos-26`.