### PR TITLE
fix(ci): grant contents:write so release assets can upload

### DIFF
--- a/.github/workflows/sideload-release.yml
+++ b/.github/workflows/sideload-release.yml
@@ -4,6 +4,13 @@ on:
   release:
     types: [published]
 
+# The build jobs attach assets to the release, which requires write access to
+# repo contents. The default GITHUB_TOKEN is read-only when the repo's default
+# workflow permissions are restricted, causing "Resource not accessible by
+# integration" on upload.
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build ${{ matrix.platform }} Sideload


### PR DESCRIPTION
## Problem

With the Xcode-select fix in place (#72), the Sideload Release workflow now builds and packages all three platforms successfully, but every job fails at the final **Upload to release** step:

```
Resource not accessible by integration — update-a-release
```

`softprops/action-gh-release` needs write access to repo contents to attach assets, but this repo's default `GITHUB_TOKEN` is read-only.

## Fix

Add a top-level `permissions: contents: write` block so the token can update the release.

This is the last blocker — Xcode select, archive, and IPA/zip packaging already succeed (confirmed building against Xcode 26.3 on the runner).