### PR TITLE
feat(trakt): import watched history from Trakt

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -1139,6 +1139,16 @@
         }
       }
     },
+    "Couldn't import from Trakt. Please try again." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Import von Trakt fehlgeschlagen. Bitte versuche es erneut."
+          }
+        }
+      }
+    },
     "Creator" : {
       "localizations" : {
         "de" : {
@@ -2224,6 +2234,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bild-Cache"
+          }
+        }
+      }
+    },
+    "Import Watched from Trakt" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Angesehenes von Trakt importieren"
+          }
+        }
+      }
+    },
+    "Imported %lld movie%@ and %lld episode%@." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld Filme und %3$lld Episoden importiert."
           }
         }
       }
@@ -5399,6 +5429,16 @@
         }
       }
     },
+    "Watched movies and episodes sync to your Trakt history. Import marks titles you've already watched on Trakt as watched here." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesehene Filme und Episoden werden mit deinem Trakt-Verlauf synchronisiert. Beim Import werden Titel, die du auf Trakt bereits gesehen hast, hier als gesehen markiert."
+          }
+        }
+      }
+    },
     "Website" : {
       "localizations" : {
         "de" : {
@@ -5479,6 +5519,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Deine Wiedergabelisten, Fortschritt, Favoriten und Merkliste werden über deinen privaten iCloud-Account auf deinen Geräten synchronisiert. Der Videokatalog wird auf jedem Gerät abgerufen und nicht hochgeladen."
+          }
+        }
+      }
+    },
+    "Your watched history is already up to date." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dein Verlauf ist bereits auf dem neuesten Stand."
           }
         }
       }

--- a/Lume/Services/Network/Trakt/TraktClient.swift
+++ b/Lume/Services/Network/Trakt/TraktClient.swift
@@ -157,6 +157,20 @@ nonisolated struct TraktClient {
         try await get("/sync/watchlist?extended=full", accessToken: accessToken)
     }
 
+    // MARK: - Watched history (import)
+
+    /// Every movie in the user's watched history, each carrying its TMDB id so
+    /// the import can match it against the local library.
+    func watchedMovies(accessToken: String) async throws -> [TraktWatchedMovie] {
+        try await get("/sync/watched/movies", accessToken: accessToken)
+    }
+
+    /// Every show in the user's watched history with the watched seasons and
+    /// episodes nested, so the import can mark the matching local episodes.
+    func watchedShows(accessToken: String) async throws -> [TraktWatchedShow] {
+        try await get("/sync/watched/shows", accessToken: accessToken)
+    }
+
     // MARK: - Networking
 
     private func get<T: Decodable>(_ path: String, accessToken: String? = nil) async throws -> T {
@@ -346,6 +360,48 @@ struct TraktWatchlistItem: Decodable {
 struct TraktWatchlistMedia: Decodable {
     let title: String?
     let year: Int?
+    let ids: TraktIDs
+}
+
+// MARK: - Watched history
+
+/// One entry from `/sync/watched/movies`. `lastWatchedAt` is kept as the raw
+/// ISO-8601 string (Trakt includes fractional seconds); the importer parses it.
+struct TraktWatchedMovie: Decodable {
+    let movie: TraktWatchedMedia
+    let lastWatchedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case movie
+        case lastWatchedAt = "last_watched_at"
+    }
+}
+
+/// One entry from `/sync/watched/shows`, with the watched seasons and episodes
+/// nested beneath it.
+struct TraktWatchedShow: Decodable {
+    let show: TraktWatchedMedia
+    let seasons: [TraktWatchedSeason]
+}
+
+struct TraktWatchedSeason: Decodable {
+    let number: Int
+    let episodes: [TraktWatchedEpisode]
+}
+
+struct TraktWatchedEpisode: Decodable {
+    let number: Int
+    let lastWatchedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case number
+        case lastWatchedAt = "last_watched_at"
+    }
+}
+
+/// The id bag shared by watched movies and shows. Only the TMDB id is used to
+/// match against the local library.
+struct TraktWatchedMedia: Decodable {
     let ids: TraktIDs
 }
 

--- a/Lume/Services/Network/Trakt/TraktService.swift
+++ b/Lume/Services/Network/Trakt/TraktService.swift
@@ -14,6 +14,7 @@
 //
 
 import Foundation
+import SwiftData
 import SwiftUI
 
 @MainActor
@@ -33,6 +34,13 @@ final class TraktService {
 
     /// Whether a device-code authorization is currently being polled.
     private(set) var isConnecting = false
+
+    /// Whether a watched-history import is currently running.
+    private(set) var isImporting = false
+
+    /// The result of the most recent import, surfaced in the Settings UI.
+    /// Cleared when a new import begins.
+    private(set) var lastImport: TraktImportSummary?
 
     private var tokens: TraktTokens?
     private var pollingTask: Task<Void, Never>?
@@ -209,6 +217,32 @@ final class TraktService {
     func fetchWatchlist() async -> [TraktWatchlistItem] {
         guard let accessToken = await validAccessToken() else { return [] }
         return await (try? client.watchlist(accessToken: accessToken)) ?? []
+    }
+
+    // MARK: - Watched import
+
+    /// Imports the user's Trakt watched history into the local catalog, marking
+    /// matching movies and episodes as watched. Writes through `context` (the
+    /// catalog container's context the UI binds to); the iCloud reconciler then
+    /// mirrors the change to the user's other devices. No-ops when not connected
+    /// or an import is already running.
+    func importWatched(into context: ModelContext) async {
+        guard isConnected, !isImporting else { return }
+        isImporting = true
+        lastImport = nil
+        defer { isImporting = false }
+
+        guard let accessToken = await validAccessToken() else {
+            lastImport = .failure
+            return
+        }
+        do {
+            let movies = try await client.watchedMovies(accessToken: accessToken)
+            let shows = try await client.watchedShows(accessToken: accessToken)
+            lastImport = TraktWatchedImporter.apply(movies: movies, shows: shows, in: context)
+        } catch {
+            lastImport = .failure
+        }
     }
 
     // MARK: - Tokens

--- a/Lume/Services/Network/Trakt/TraktWatchedImporter.swift
+++ b/Lume/Services/Network/Trakt/TraktWatchedImporter.swift
@@ -1,0 +1,144 @@
+//
+//  TraktWatchedImporter.swift
+//  Lume
+//
+//  Applies the watched history fetched from Trakt onto the local catalog: marks
+//  matching movies and episodes as watched. The reverse direction of the
+//  fire-and-forget scrobbling in `TraktService`, run on demand from the Trakt
+//  settings screen.
+//
+//  Matching is by TMDB id (the only external id the library carries), so titles
+//  without a resolved `tmdbId` are skipped. Already-watched items are left
+//  untouched so the import is idempotent and the returned counts reflect only
+//  what actually changed.
+//
+
+import Foundation
+import SwiftData
+
+/// The outcome of an import, surfaced in the settings UI.
+struct TraktImportSummary: Equatable {
+    var moviesMarked = 0
+    var episodesMarked = 0
+    var failed = false
+
+    static let failure = TraktImportSummary(failed: true)
+
+    var markedNothing: Bool {
+        !failed && moviesMarked == 0 && episodesMarked == 0
+    }
+}
+
+enum TraktWatchedImporter {
+    /// Marks the local movies and episodes that Trakt reports as watched, writing
+    /// through the given catalog context. Returns what changed.
+    static func apply(
+        movies: [TraktWatchedMovie],
+        shows: [TraktWatchedShow],
+        in context: ModelContext
+    ) -> TraktImportSummary {
+        let moviesMarked = importMovies(movies, in: context)
+        let episodesMarked = importShows(shows, in: context)
+
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                return TraktImportSummary(moviesMarked: moviesMarked, episodesMarked: episodesMarked, failed: true)
+            }
+        }
+        return TraktImportSummary(moviesMarked: moviesMarked, episodesMarked: episodesMarked, failed: false)
+    }
+
+    // MARK: - Movies
+
+    private static func importMovies(_ watched: [TraktWatchedMovie], in context: ModelContext) -> Int {
+        var watchedIDs = Set<Int>()
+        var dates: [Int: Date] = [:]
+        for item in watched {
+            guard let tmdb = item.movie.ids.tmdb else { continue }
+            watchedIDs.insert(tmdb)
+            if let date = parse(item.lastWatchedAt) { dates[tmdb] = date }
+        }
+        guard !watchedIDs.isEmpty else { return 0 }
+
+        let descriptor = FetchDescriptor<Movie>(predicate: #Predicate { $0.tmdbId != nil })
+        let candidates = (try? context.fetch(descriptor)) ?? []
+
+        var count = 0
+        for movie in candidates where !movie.isWatched {
+            guard let tmdb = movie.tmdbId, watchedIDs.contains(tmdb) else { continue }
+            movie.isWatched = true
+            movie.watchProgress = Double(movie.durationSecs ?? 0)
+            if let date = dates[tmdb] { movie.lastWatchedDate = date }
+            count += 1
+        }
+        return count
+    }
+
+    // MARK: - Shows
+
+    private struct SeasonEpisode: Hashable {
+        let season: Int
+        let episode: Int
+    }
+
+    private static func importShows(_ watched: [TraktWatchedShow], in context: ModelContext) -> Int {
+        var showsByTMDB: [Int: TraktWatchedShow] = [:]
+        for show in watched {
+            guard let tmdb = show.show.ids.tmdb else { continue }
+            showsByTMDB[tmdb] = show
+        }
+        guard !showsByTMDB.isEmpty else { return 0 }
+
+        let descriptor = FetchDescriptor<Series>(predicate: #Predicate { $0.tmdbId != nil })
+        let candidates = (try? context.fetch(descriptor)) ?? []
+
+        var count = 0
+        for series in candidates {
+            guard let tmdb = series.tmdbId, let show = showsByTMDB[tmdb] else { continue }
+            count += markEpisodes(of: series, against: show)
+        }
+        return count
+    }
+
+    /// Marks the episodes of `series` that `show` reports as watched, returning
+    /// how many changed.
+    private static func markEpisodes(of series: Series, against show: TraktWatchedShow) -> Int {
+        var watchedKeys = Set<SeasonEpisode>()
+        var dates: [SeasonEpisode: Date] = [:]
+        for season in show.seasons {
+            for episode in season.episodes {
+                let key = SeasonEpisode(season: season.number, episode: episode.number)
+                watchedKeys.insert(key)
+                if let date = parse(episode.lastWatchedAt) { dates[key] = date }
+            }
+        }
+
+        var count = 0
+        for episode in series.episodes where !episode.isWatched {
+            let key = SeasonEpisode(season: episode.seasonNum, episode: episode.episodeNum)
+            guard watchedKeys.contains(key) else { continue }
+            episode.isWatched = true
+            episode.watchProgress = Double(episode.durationSecs ?? 0)
+            if let date = dates[key] { episode.lastWatchedDate = date }
+            count += 1
+        }
+        return count
+    }
+
+    // MARK: - Dates
+
+    /// Parses Trakt's ISO-8601 timestamps, which carry fractional seconds
+    /// (e.g. `2014-10-11T17:00:54.000Z`).
+    private static let formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static func parse(_ string: String?) -> Date? {
+        guard let string else { return nil }
+        return formatter.date(from: string)
+    }
+}

--- a/Lume/Views/Settings/TVTraktIntegrationView.swift
+++ b/Lume/Views/Settings/TVTraktIntegrationView.swift
@@ -16,6 +16,7 @@
         /// Trakt is a Premium feature.
         @State private var premium = PremiumManager.shared
         @State private var showPaywall = false
+        @Environment(\.modelContext) private var modelContext
 
         var body: some View {
             VStack(alignment: .leading, spacing: 8) {
@@ -117,10 +118,30 @@
             VStack(alignment: .leading, spacing: 16) {
                 TVSettingsValueRow("Connected", value: trakt.username.map { "@\($0)" } ?? "—")
 
-                Text("Watched movies and episodes sync to your Trakt history.")
+                Text("Watched movies and episodes sync to your Trakt history. Import marks titles you've already watched on Trakt as watched here.")
                     .font(.system(size: 22))
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, TVSettingsMetrics.rowHPadding)
+
+                Button {
+                    Task { await trakt.importWatched(into: modelContext) }
+                } label: {
+                    HStack(spacing: 16) {
+                        Image(systemName: "arrow.down.circle")
+                            .font(.system(size: 22, weight: .medium))
+                        Text("Import Watched from Trakt")
+                        Spacer(minLength: 0)
+                        if trakt.isImporting {
+                            ProgressView()
+                        }
+                    }
+                }
+                .buttonStyle(TVSettingsRowButtonStyle())
+                .disabled(trakt.isImporting)
+
+                if let summary = trakt.lastImport {
+                    importStatus(summary)
+                }
 
                 Button {
                     Task { await trakt.disconnect() }
@@ -134,6 +155,21 @@
                 }
                 .buttonStyle(TVSettingsRowButtonStyle(isDestructive: true))
             }
+        }
+
+        @ViewBuilder
+        private func importStatus(_ summary: TraktImportSummary) -> some View {
+            let text = if summary.failed {
+                Text("Couldn't import from Trakt. Please try again.")
+            } else if summary.markedNothing {
+                Text("Your watched history is already up to date.")
+            } else {
+                Text("Imported \(summary.moviesMarked) movie\(summary.moviesMarked == 1 ? "" : "s") and \(summary.episodesMarked) episode\(summary.episodesMarked == 1 ? "" : "s").")
+            }
+            text
+                .font(.system(size: 22))
+                .foregroundStyle(summary.failed ? .red : .green)
+                .padding(.horizontal, TVSettingsMetrics.rowHPadding)
         }
     }
 

--- a/Lume/Views/Settings/TraktIntegrationView.swift
+++ b/Lume/Views/Settings/TraktIntegrationView.swift
@@ -18,6 +18,7 @@
         @State private var premium = PremiumManager.shared
         @State private var showPaywall = false
         @Environment(\.openURL) private var openURL
+        @Environment(\.modelContext) private var modelContext
 
         var body: some View {
             List {
@@ -126,6 +127,20 @@
                     Spacer()
                 }
 
+                Button {
+                    Task { await trakt.importWatched(into: modelContext) }
+                } label: {
+                    HStack {
+                        Label("Import Watched from Trakt", systemImage: "arrow.down.circle")
+                        if trakt.isImporting {
+                            Spacer()
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    }
+                }
+                .disabled(trakt.isImporting)
+
                 Button(role: .destructive) {
                     Task { await trakt.disconnect() }
                 } label: {
@@ -134,7 +149,26 @@
             } header: {
                 Text("Trakt")
             } footer: {
-                Text("Watched movies and episodes sync to your Trakt history.")
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Watched movies and episodes sync to your Trakt history. Import marks titles you've already watched on Trakt as watched here.")
+                    if let summary = trakt.lastImport {
+                        importStatus(summary)
+                    }
+                }
+            }
+        }
+
+        @ViewBuilder
+        private func importStatus(_ summary: TraktImportSummary) -> some View {
+            if summary.failed {
+                Text("Couldn't import from Trakt. Please try again.")
+                    .foregroundStyle(.red)
+            } else if summary.markedNothing {
+                Text("Your watched history is already up to date.")
+                    .foregroundStyle(.green)
+            } else {
+                Text("Imported \(summary.moviesMarked) movie\(summary.moviesMarked == 1 ? "" : "s") and \(summary.episodesMarked) episode\(summary.episodesMarked == 1 ? "" : "s").")
+                    .foregroundStyle(.green)
             }
         }
     }

--- a/LumeTests/Services/TraktWatchedImporterTests.swift
+++ b/LumeTests/Services/TraktWatchedImporterTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+@MainActor
+struct TraktWatchedImporterTests {
+    private func makeContext() throws -> ModelContext {
+        try ModelContext(makeTestContainer())
+    }
+
+    private func makeMovie(id: String, tmdbId: Int?, duration: Int? = 7200) -> Movie {
+        let movie = Movie(id: id, streamId: 1, name: "Movie \(id)")
+        movie.tmdbId = tmdbId
+        movie.durationSecs = duration
+        return movie
+    }
+
+    private func watchedMovie(tmdb: Int, lastWatchedAt: String? = nil) -> TraktWatchedMovie {
+        TraktWatchedMovie(movie: TraktWatchedMedia(ids: TraktIDs(tmdb: tmdb, trakt: nil)), lastWatchedAt: lastWatchedAt)
+    }
+
+    @Test func `marks matching movies watched and leaves the rest untouched`() throws {
+        let context = try makeContext()
+        let match = makeMovie(id: "a", tmdbId: 100)
+        let other = makeMovie(id: "b", tmdbId: 200)
+        context.insert(match)
+        context.insert(other)
+
+        let summary = TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
+
+        #expect(summary.moviesMarked == 1)
+        #expect(match.isWatched == true)
+        #expect(match.watchProgress == 7200)
+        #expect(other.isWatched == false)
+    }
+
+    @Test func `applies the trakt last-watched date when present`() throws {
+        let context = try makeContext()
+        let movie = makeMovie(id: "a", tmdbId: 100)
+        context.insert(movie)
+
+        let summary = TraktWatchedImporter.apply(
+            movies: [watchedMovie(tmdb: 100, lastWatchedAt: "2014-10-11T17:00:54.000Z")],
+            shows: [],
+            in: context
+        )
+
+        #expect(summary.moviesMarked == 1)
+        let expected = ISO8601DateFormatter().date(from: "2014-10-11T17:00:54Z")
+        #expect(movie.lastWatchedDate == expected)
+    }
+
+    @Test func `already-watched movies are not re-counted`() throws {
+        let context = try makeContext()
+        let movie = makeMovie(id: "a", tmdbId: 100)
+        movie.isWatched = true
+        context.insert(movie)
+
+        let summary = TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
+
+        #expect(summary.moviesMarked == 0)
+        #expect(summary.markedNothing == true)
+    }
+
+    @Test func `marks only the episodes trakt reports watched`() throws {
+        let context = try makeContext()
+        let series = Series(id: "s1", seriesId: 1, name: "Show")
+        series.tmdbId = 300
+        let ep1 = Episode(id: "s1-1", episodeId: "1", title: "E1", containerExtension: "mkv", seasonNum: 1, episodeNum: 1)
+        let ep2 = Episode(id: "s1-2", episodeId: "2", title: "E2", containerExtension: "mkv", seasonNum: 1, episodeNum: 2)
+        ep1.durationSecs = 1200
+        ep1.series = series
+        ep2.series = series
+        series.episodes = [ep1, ep2]
+        context.insert(series)
+
+        let show = TraktWatchedShow(
+            show: TraktWatchedMedia(ids: TraktIDs(tmdb: 300, trakt: nil)),
+            seasons: [TraktWatchedSeason(number: 1, episodes: [TraktWatchedEpisode(number: 1, lastWatchedAt: nil)])]
+        )
+        let summary = TraktWatchedImporter.apply(movies: [], shows: [show], in: context)
+
+        #expect(summary.episodesMarked == 1)
+        #expect(ep1.isWatched == true)
+        #expect(ep1.watchProgress == 1200)
+        #expect(ep2.isWatched == false)
+    }
+
+    @Test func `titles without a tmdb id are skipped`() throws {
+        let context = try makeContext()
+        let movie = makeMovie(id: "a", tmdbId: nil)
+        context.insert(movie)
+
+        let summary = TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
+
+        #expect(summary.moviesMarked == 0)
+        #expect(movie.isWatched == false)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Metacritic), and your viewing activity can be scrobbled to **Trakt**.
 - Automatic resume playback and progress tracking
 - Auto-mark-as-watched at 90% completion
 - **Next Up** overlay with auto-play for series episodes
-- Optional **Trakt** scrobbling and **TMDB** metadata enrichment
+- Optional **Trakt** scrobbling — plus one-tap import of your existing Trakt watched history — and **TMDB** metadata enrichment
 
 #### 👤 Profiles
 - Multiple **user profiles**, each with its own watch history, progress, and favorites


### PR DESCRIPTION
## Summary
The Trakt integration was one-way: titles watched in Lume scrobble to Trakt, but content already marked watched on Trakt never reflected back into the app. This adds an **Import Watched from Trakt** button to the Trakt settings screen that pulls your Trakt watched history and marks the matching movies and episodes as watched locally — exactly the reverse direction requested in #69.

## Implementation
- `TraktClient` gains `watchedMovies` / `watchedShows` fetches (`/sync/watched/movies`, `/sync/watched/shows`) plus their DTOs.
- `TraktWatchedImporter` matches the fetched history against the local catalog by TMDB id, marking unwatched movies/episodes as watched (full progress + Trakt's `last_watched_at` when present). It's idempotent — already-watched items are skipped, so the returned counts reflect only what changed.
- `TraktService.importWatched(into:)` orchestrates the fetch + apply and exposes observable `isImporting` / `lastImport` state. Writes go through the catalog container's context (what the UI binds to); the existing iCloud reconciler mirrors the change to other devices — same write path as the detail-screen watched toggle.
- Both the iOS/macOS (`TraktIntegrationView`) and tvOS (`TVTraktIntegrationView`) settings surfaces get the button, an in-progress spinner, and a result message.

## Testing
- [x] Acceptance criteria met
- [x] Tests pass (`xcodebuild test -scheme Lume -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' -only-testing:LumeTests/TraktWatchedImporterTests`)
- [x] SwiftLint clean (pre-commit hooks pass)
- [x] Tests added — `TraktWatchedImporterTests` covers movie/episode matching, date application, idempotency, and titles without a TMDB id

## Platforms
- [x] iOS / iPadOS
- [x] tvOS
- [x] macOS
- [x] visionOS
<!-- iOS + tvOS builds verified; macOS/visionOS share the non-tvOS code path -->

## Related
Closes #69