### PR TITLE
Support StoreKit offer codes (coupons)

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -3966,6 +3966,16 @@
         }
       }
     },
+    "Redeem Code" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code einlösen"
+          }
+        }
+      }
+    },
     "Refresh" : {
       "localizations" : {
         "de" : {
@@ -5420,6 +5430,7 @@
       }
     },
     "Watched movies and episodes sync to your Trakt history." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/Lume/Views/Premium/PaywallView.swift
+++ b/Lume/Views/Premium/PaywallView.swift
@@ -8,6 +8,7 @@
 //  builds (those are always Premium).
 //
 
+import OSLog
 import StoreKit
 import SwiftUI
 
@@ -19,6 +20,15 @@ struct PaywallView: View {
     @State private var premium = PremiumManager.shared
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
+
+    #if !os(tvOS)
+        /// Drives the system offer-code redemption sheet. Offer codes let users
+        /// unlock Pro with a coupon issued in App Store Connect. The redeemed
+        /// transaction also arrives via `Transaction.updates`, but we refresh on
+        /// completion so the paywall dismisses immediately. tvOS has no in-app
+        /// sheet — those users redeem in the App Store.
+        @State private var showRedeemCode = false
+    #endif
 
     /// Apple's standard EULA, plus Lume's privacy policy. Subscriptions must link
     /// to terms of use and a privacy policy on the purchase screen.
@@ -49,6 +59,7 @@ struct PaywallView: View {
                         header
                         benefitsList
                         planButtons
+                        redeemButton
                         legalFooter
                     }
                     .padding(.horizontal, 20)
@@ -74,10 +85,26 @@ struct PaywallView: View {
                     .onChange(of: premium.isPremium) { _, isPremium in
                         if isPremium { dismiss() }
                     }
+                    .offerCodeRedemption(isPresented: $showRedeemCode) { result in
+                        if case let .failure(error) = result {
+                            Logger.premium.error(
+                                "Offer code redemption failed: \(error.localizedDescription, privacy: .public)"
+                            )
+                        }
+                        Task { await premium.refreshEntitlements() }
+                    }
             }
             #if os(macOS)
             .frame(minWidth: 460, idealWidth: 520, minHeight: 560, idealHeight: 680)
             #endif
+        }
+
+        private var redeemButton: some View {
+            Button("Redeem Code") { showRedeemCode = true }
+                .font(.callout.weight(.medium))
+                .buttonStyle(.plain)
+                .foregroundStyle(.tint)
+                .disabled(premium.isWorking)
         }
 
         private var header: some View {


### PR DESCRIPTION
## Summary

Adds in-app redemption of App Store **offer codes** (coupons) to the Lume Pro paywall, built on the app's existing StoreKit 2 setup.

- New **"Redeem Code"** button in `PaywallView` presents the system offer-code redemption sheet via SwiftUI's `.offerCodeRedemption(isPresented:onCompletion:)`.
- On completion, `PremiumManager.refreshEntitlements()` runs so Pro unlocks immediately. The redeemed transaction also flows through the existing `Transaction.updates` listener (which grants + finishes it), so no new transaction-handling code was needed.
- Scoped to `#if !os(tvOS)` — the modifier is available on iOS, iPadOS, macOS, and visionOS, matching the existing `standardBody`. tvOS has no in-app redemption sheet; those users redeem in the App Store.
- Added the `"Redeem Code"` string with German translation (`Code einlösen`) and normalized `Localizable.xcstrings`.

## Testing

- `xcodebuild build` succeeds on the iPhone 17 Pro simulator.
- Pre-commit hooks pass (normalize-xcstrings, swiftformat, swiftlint).
- The `.storekit` config already exposes the **Offer Code Redeem Sheet** testing toggle and `codeOffers` arrays, so redemption can be exercised locally via Debug ▸ StoreKit ▸ Manage Transactions.

## Notes / follow-ups

- Real coupons require creating offer codes in App Store Connect (offer codes support both the lifetime non-consumable and the monthly subscription).
- No tvOS entry point added (no API) — could add a "Redeem in the App Store" hint if desired.
- visionOS targeted via the shared code path but only compile-verified on the iOS simulator.