### PR TITLE
feat(live-tv): lazily page the channel list for large categories

### DIFF
--- a/Lume/Views/LiveTV/LiveTVSection.swift
+++ b/Lume/Views/LiveTV/LiveTVSection.swift
@@ -98,6 +98,12 @@ enum LiveChannelQuery {
     /// bounded but we don't want it to grow without limit.
     static let recentLimit = 50
 
+    /// Channel lists mount in pages as they scroll. A live category can hold
+    /// hundreds of channels; building every row — and resolving now/next EPG
+    /// for every channel — before the first paint stalls the browse. The list
+    /// renders a window that grows by this many channels as it nears the end.
+    static let pageSize = 50
+
     /// Builds the `@Query` descriptor for a scope. The category scope sorts by
     /// the user's content-sort choice; the virtual collections have an intrinsic
     /// order (favorites by their own custom order, recents by most-recent-first).

--- a/Lume/Views/LiveTV/LiveTVTVComponents.swift
+++ b/Lume/Views/LiveTV/LiveTVTVComponents.swift
@@ -24,6 +24,9 @@
         @State private var epgByChannel: [String: ChannelEPG] = [:]
         /// Observed so the EPG lookup refreshes when a guide import finishes.
         @State private var epgSync = EPGSyncService.shared
+        /// How many channels are currently rendered. Grows by a page as the list
+        /// nears its end so a large category loads lazily instead of all at once.
+        @State private var visibleCount = LiveChannelQuery.pageSize
 
         init(scope: LiveChannelScope, playlistPrefix: String, sort: ContentSortOption, onPlay: @escaping (LiveStream) -> Void) {
             self.scope = scope
@@ -38,6 +41,7 @@
 
         var body: some View {
             let channels = scopedStreams
+            let visible = Array(channels.prefix(visibleCount))
             ScrollView {
                 LazyVStack(spacing: 14) {
                     if channels.isEmpty {
@@ -48,13 +52,18 @@
                         )
                         .padding(.top, 80)
                     } else {
-                        ForEach(channels) { stream in
+                        ForEach(visible) { stream in
                             TVChannelRow(
                                 stream: stream,
                                 epg: epgByChannel[stream.epgChannelId ?? ""],
                                 onRemove: scope == .recentlyWatched ? { removeFromRecentlyWatched(stream) } : nil
                             ) {
                                 onPlay(stream)
+                            }
+                            .onAppear {
+                                if stream.id == visible.last?.id, visibleCount < channels.count {
+                                    visibleCount = min(visibleCount + LiveChannelQuery.pageSize, channels.count)
+                                }
                             }
                         }
                     }
@@ -63,9 +72,10 @@
                 .padding(.vertical, 40)
             }
             .focusSection()
-            // Reload when the channel set changes or a guide import settles.
-            .task(id: "\(channels.count)-\(epgSync.isSyncing)") {
-                await loadEPG(for: channels)
+            // Reload when the visible window or channel set changes, or a guide
+            // import settles — EPG is resolved only for the channels on screen.
+            .task(id: "\(channels.count)-\(visible.count)-\(epgSync.isSyncing)") {
+                await loadEPG(for: visible)
             }
         }
 

--- a/Lume/Views/LiveTV/LiveTVView.swift
+++ b/Lume/Views/LiveTV/LiveTVView.swift
@@ -411,6 +411,9 @@ struct ChannelsList: View {
     @State private var epgByChannel: [String: ChannelEPG] = [:]
     /// Observed so the EPG lookup refreshes when a guide import finishes.
     @State private var epgSync = EPGSyncService.shared
+    /// How many channels are currently rendered. Grows by a page as the list
+    /// nears its end so a large category loads lazily instead of all at once.
+    @State private var visibleCount = LiveChannelQuery.pageSize
 
     init(scope: LiveChannelScope, playlistPrefix: String, sort: ContentSortOption, onPlay: @escaping (LiveStream) -> Void) {
         self.scope = scope
@@ -433,6 +436,7 @@ struct ChannelsList: View {
 
     var body: some View {
         let channels = scopedStreams
+        let visible = Array(channels.prefix(visibleCount))
         ScrollView {
             LazyVStack(spacing: 0) {
                 if channels.isEmpty {
@@ -442,7 +446,7 @@ struct ChannelsList: View {
                         description: Text("This category has no channels")
                     )
                 } else {
-                    ForEach(channels) { stream in
+                    ForEach(visible) { stream in
                         Button {
                             onPlay(stream)
                         } label: {
@@ -452,6 +456,11 @@ struct ChannelsList: View {
                         }
                         .buttonStyle(.plain)
                         .recentlyWatchedRemoveMenu(scope == .recentlyWatched ? { removeFromRecentlyWatched(stream) } : nil)
+                        .onAppear {
+                            if stream.id == visible.last?.id, visibleCount < channels.count {
+                                visibleCount = min(visibleCount + LiveChannelQuery.pageSize, channels.count)
+                            }
+                        }
 
                         Divider()
                             .padding(.leading, 88)
@@ -459,9 +468,10 @@ struct ChannelsList: View {
                 }
             }
         }
-        // Reload when the channel set changes or a guide import settles.
-        .task(id: "\(channels.count)-\(epgSync.isSyncing)") {
-            await loadEPG(for: channels)
+        // Reload when the visible window or channel set changes, or a guide
+        // import settles — EPG is resolved only for the channels on screen.
+        .task(id: "\(channels.count)-\(visible.count)-\(epgSync.isSyncing)") {
+            await loadEPG(for: visible)
         }
     }
 


### PR DESCRIPTION
## Summary
Large live categories could hold hundreds of channels, and the channel list hydrated and built a row for every one — and resolved now/next EPG for every channel — before the first paint. This lazily pages the list so only the channels on screen are rendered and have their EPG resolved, keeping the Live TV browse responsive on big playlists.

## Implementation
`ChannelsList` (iOS/macOS) and `TVChannelsList` (tvOS) now render a window of channels that grows by a page (`LiveChannelQuery.pageSize` = 50) as the last visible row appears — the same `.onAppear`-paginates convention already used by `CategoryContentGrid` for the Movies/Series grids. The EPG lookup is keyed to the visible window, so now/next data is fetched only for the channels currently shown rather than the whole category. The reactive `@Query` is kept intact, so favorites/recently-watched updates and the recently-watched removal still refresh live; per-section view identity resets the window on category/sort switch.

## Testing
- [x] Acceptance criteria met (channel categories load lazily)
- [x] Tests pass (builds clean; `xcodebuild build -scheme Lume -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`)
- [x] SwiftLint clean
- [ ] Tests added — skipped: change is view-render windowing state with no isolated testable unit; no existing tests cover these views

## Platforms
- [x] iOS / iPadOS
- [ ] tvOS
- [x] macOS
- [ ] visionOS
<!-- Code paths updated for all platforms (shared ChannelsList for iOS/iPadOS/macOS, TVChannelsList for tvOS); compile-verified on the iOS Simulator. -->

## Related
Closes #84