### PR TITLE
chore: open-source readiness — fix CI secret injection, add community files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Lume — local secrets template.
+#
+# Copy this file to `.env` in the repo root (`cp .env.example .env`) and fill in
+# the values you have. `.env` is gitignored. Scripts/inject-env.sh reads these
+# keys during the build and injects them into the app's Info.plist.
+#
+# Every key is OPTIONAL — if one is missing, the dependent feature degrades
+# gracefully (e.g. the Trending rail hides, extra ratings disappear). Lume runs
+# fine with an empty .env or none at all.
+
+# TMDB — metadata, artwork & trailers.
+# A v4 read access token from https://www.themoviedb.org/settings/api
+TMDB_ACCESS_TOKEN=
+
+# OMDb — IMDb, Rotten Tomatoes & Metacritic ratings.
+# An API key from https://www.omdbapi.com/apikey.aspx
+OMDB_API_KEY=
+
+# IntroDB — crowd-sourced intro / recap skip windows (https://introdb.app).
+# Read access works unauthenticated; this key is only needed for higher limits.
+INTRO_DB_API_KEY=
+
+# Trakt — watch scrobbling via the device OAuth flow.
+# Create an application at https://trakt.tv/oauth/applications
+TRAKT_CLIENT_ID=
+TRAKT_CLIENT_SECRET=

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [bilipp]

--- a/.github/workflows/sideload-release.yml
+++ b/.github/workflows/sideload-release.yml
@@ -46,14 +46,17 @@ jobs:
       # Features degrade gracefully when absent (see Scripts/inject-env.sh).
       - name: Write .env
         env:
-          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+          # Key names MUST match what Scripts/inject-env.sh reads (read_env …).
+          TMDB_ACCESS_TOKEN: ${{ secrets.TMDB_ACCESS_TOKEN }}
           OMDB_API_KEY: ${{ secrets.OMDB_API_KEY }}
+          INTRO_DB_API_KEY: ${{ secrets.INTRO_DB_API_KEY }}
           TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           TRAKT_CLIENT_SECRET: ${{ secrets.TRAKT_CLIENT_SECRET }}
         run: |
           {
-            [ -n "$TMDB_API_KEY" ]        && echo "TMDB_API_KEY=$TMDB_API_KEY"
+            [ -n "$TMDB_ACCESS_TOKEN" ]   && echo "TMDB_ACCESS_TOKEN=$TMDB_ACCESS_TOKEN"
             [ -n "$OMDB_API_KEY" ]        && echo "OMDB_API_KEY=$OMDB_API_KEY"
+            [ -n "$INTRO_DB_API_KEY" ]    && echo "INTRO_DB_API_KEY=$INTRO_DB_API_KEY"
             [ -n "$TRAKT_CLIENT_ID" ]     && echo "TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID"
             [ -n "$TRAKT_CLIENT_SECRET" ] && echo "TRAKT_CLIENT_SECRET=$TRAKT_CLIENT_SECRET"
           } > .env || true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,135 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Requesting, sharing, or linking to pirated streams, playlists, or credentials
+  (see [ANTI_PIRACY.md](ANTI_PIRACY.md))
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**p.bischoff@innoloft.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ The easiest way to use Lume is to [**download it from the App Store**](https://a
 - *(Optional)* a [TMDB](https://www.themoviedb.org/settings/api) API access token for metadata enrichment
 - *(Optional)* a [Trakt](https://trakt.tv/oauth/applications) application for scrobbling
 - *(Optional)* an [OMDb](https://www.omdbapi.com/apikey.aspx) API key for IMDb / Rotten Tomatoes / Metacritic ratings
+- *(Optional)* an [IntroDB](https://introdb.app) API key for intro / recap skip windows
 
 ### Build & run
 
@@ -254,17 +255,27 @@ or import an M3U playlist, and Lume will sync your catalog.
 
 > Dependencies are resolved automatically by Swift Package Manager on first build.
 
+**Code signing.** The project ships with the maintainer's Development Team
+(`DEVELOPMENT_TEAM`) and bundle identifier (`com.bilipp.lume`). Simulator builds run as
+is. To run on a physical device, open **Signing & Capabilities** for each target and set
+your own team (and, if needed, a unique bundle identifier) — or clear the team for a
+simulator-only build. Don't commit these personal signing changes back to the repo.
+
 ---
 
 ## Configuration
 
-Optional integrations (TMDB and Trakt) are configured through a repo-root `.env` file.
-The `Scripts/inject-env.sh` build phase reads it and injects the values into the built
-app's `Info.plist` — keeping secrets out of source control. `.env` is gitignored, and
-if it is missing the dependent features simply degrade gracefully (e.g. the Trending
-rail hides).
+Optional integrations (TMDB, OMDb, IntroDB, and Trakt) are configured through a
+repo-root `.env` file. The `Scripts/inject-env.sh` build phase reads it and injects the
+values into the built app's `Info.plist` — keeping secrets out of source control. `.env`
+is gitignored, and if it is missing the dependent features simply degrade gracefully
+(e.g. the Trending rail hides).
 
-Create a `.env` file in the project root:
+Copy the template and fill in the keys you have:
+
+```bash
+cp .env.example .env
+```
 
 ```dotenv
 # TMDB — metadata, artwork & trailers
@@ -273,10 +284,15 @@ TMDB_ACCESS_TOKEN=your_tmdb_v4_read_access_token
 # OMDb — IMDb, Rotten Tomatoes & Metacritic ratings
 OMDB_API_KEY=your_omdb_api_key
 
+# IntroDB — intro / recap skip windows (read access works unauthenticated)
+INTRO_DB_API_KEY=your_introdb_api_key
+
 # Trakt — watch scrobbling (device OAuth flow)
 TRAKT_CLIENT_ID=your_trakt_client_id
 TRAKT_CLIENT_SECRET=your_trakt_client_secret
 ```
+
+Every key is optional — Lume builds and runs fine with an empty `.env` or none at all.
 
 Trakt uses the **device OAuth flow** (no embedded web view), which works on tvOS as
 well as iOS/macOS. Tokens are stored securely in the Keychain.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability in Lume, please report it **privately** —
+do not open a public issue, pull request, or discussion, as that may put users at
+risk before a fix is available.
+
+Use one of the following:
+
+- **GitHub private advisory** (preferred): open a report at
+  <https://github.com/bilipp/Lume/security/advisories/new>
+- **Email**: p.bischoff@innoloft.com
+
+Please include, as far as you can:
+
+- A description of the issue and its impact
+- Steps to reproduce, or a proof of concept
+- The affected platform(s) and app/OS version
+- Any suggested remediation
+
+You can expect an initial acknowledgement within **5 business days**. We will keep
+you informed of progress toward a fix and will credit you in the release notes once
+the issue is resolved, unless you prefer to remain anonymous.
+
+## Scope
+
+Lume is a **client-side player** — it ships with no servers, no bundled streams,
+and no backend of its own. Relevant areas include:
+
+- Handling of user-supplied Xtream Codes credentials and M3U playlist URLs
+- Secure storage of credentials and OAuth tokens (Keychain)
+- The local SwiftData catalog and the CloudKit user-data mirror
+- Build tooling and the secret-injection script (`Scripts/inject-env.sh`)
+
+Out of scope: the security of third-party IPTV providers, playlists, or streams that
+a user chooses to connect to. See [`ANTI_PIRACY.md`](ANTI_PIRACY.md) for content policy.
+
+## Supported versions
+
+Lume is actively developed and security fixes target the **latest released version**.
+Please make sure you are on the most recent build before reporting.


### PR DESCRIPTION
## Summary

Closes the remaining gaps for open-sourcing the repo. The project was already in good shape (AGPL-3.0, README, CONTRIBUTING, ANTI_PIRACY, issue/PR templates, no leaked secrets in history). This fills the rest.

### 🐛 Fix: CI never injected the TMDB token
The sideload workflow wrote `TMDB_API_KEY` into `.env`, but `Scripts/inject-env.sh` reads **`TMDB_ACCESS_TOKEN`** — so every CI-built artifact silently shipped with TMDB disabled (no trending/artwork/trailers). Renamed the workflow env/secret to match, and added the optional `INTRO_DB_API_KEY` key while there.

> ⚠️ **Action needed:** rename the GitHub Actions repo secret `TMDB_API_KEY` → `TMDB_ACCESS_TOKEN` (and optionally add `INTRO_DB_API_KEY`) for the fix to take effect.

### ➕ Added community-health files
- **`.env.example`** — committed template for all *five* injected keys (the README previously omitted `INTRO_DB_API_KEY`); `cp .env.example .env` to get started.
- **`SECURITY.md`** — private vulnerability reporting (GitHub advisory + email).
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1.
- **`.github/FUNDING.yml`** — GitHub Sponsors button.

### 📝 README
- Document `INTRO_DB_API_KEY` in Requirements and the `.env` block.
- Switch the config section to the `cp .env.example .env` flow.
- Add a **Code signing** note so contributors set their own `DEVELOPMENT_TEAM` / bundle id (the maintainer's is committed; simulator builds work as-is).

## Notes
- No Swift touched — lefttook Swift gates skipped.
- No history rewrite / secret rotation needed: `.env` was never committed and no tokens exist anywhere in git history.
- AGPL-3.0 left as-is (assumed intentional — network copyleft).

## Test plan
- [x] Both edited/new YAML files validate (`ruby -ryaml`).
- [ ] Maintainer renames the `TMDB_ACCESS_TOKEN` Actions secret, then a release build confirms TMDB metadata is present.