### PR TITLE
feat(player): request an App Store review after finishing a movie or episode

### DIFF
--- a/Lume/Services/Review/AppStoreReviewTrigger.swift
+++ b/Lume/Services/Review/AppStoreReviewTrigger.swift
@@ -1,0 +1,56 @@
+//
+//  AppStoreReviewTrigger.swift
+//  Lume
+//
+//  Decides *when* to ask the user for an App Store rating. The prompt itself is
+//  surfaced by SwiftUI's `requestReview` action at the call site; this type owns
+//  only the throttling policy, so it stays a pure, testable scalar-flag store
+//  (UserDefaults) — the same shape as `RecommendationSettings`.
+//
+
+import Foundation
+
+/// Throttling policy for the StoreKit review prompt.
+///
+/// Apple's guidance is to ask only after a clearly positive experience and never
+/// from a button. We treat "finished watching a movie or episode" as that
+/// signal, and ask once the user has finished a few of them — at most once per
+/// app version, so a future update is the soonest we'd ever ask again. (StoreKit
+/// independently caps the system prompt to three appearances per year and may
+/// suppress it entirely, so this is best-effort on top of that.)
+nonisolated enum AppStoreReviewTrigger {
+    /// Finished playbacks required before the first prompt is considered.
+    static let completionThreshold = 3
+
+    /// Running count of finished movies/episodes since the last prompt.
+    static let completionCountKey = "appstore.review.completionCount.v1"
+    /// Marketing version the prompt was last shown for; blocks a second ask on
+    /// the same version.
+    static let lastPromptedVersionKey = "appstore.review.lastPromptedVersion.v1"
+
+    /// Record a finished playback and report whether it now makes sense to ask
+    /// for a review. Returns `true` at most once per app version — the caller
+    /// must follow a `true` with `markPromptShown()`.
+    static func registerSignificantEvent(
+        defaults: UserDefaults = .standard,
+        currentVersion: String = SupportInfo.appVersion
+    ) -> Bool {
+        let count = defaults.integer(forKey: completionCountKey) + 1
+        defaults.set(count, forKey: completionCountKey)
+
+        guard count >= completionThreshold else { return false }
+        // Already asked on this version → wait for the next update.
+        return defaults.string(forKey: lastPromptedVersionKey) != currentVersion
+    }
+
+    /// Mark that the prompt was shown for the current version and reset the
+    /// counter, so the next prompt can't fire until another `completionThreshold`
+    /// finishes accumulate on a later version.
+    static func markPromptShown(
+        defaults: UserDefaults = .standard,
+        currentVersion: String = SupportInfo.appVersion
+    ) {
+        defaults.set(currentVersion, forKey: lastPromptedVersionKey)
+        defaults.set(0, forKey: completionCountKey)
+    }
+}

--- a/Lume/Views/Player/FullScreenPlayerView.swift
+++ b/Lume/Views/Player/FullScreenPlayerView.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import OSLog
+import StoreKit
 import SwiftData
 import SwiftUI
 
@@ -18,6 +19,10 @@ struct FullScreenPlayerView: View {
     @Environment(\.scenePhase) private var scenePhase
     #if os(macOS)
         @Environment(\.dismissWindow) private var dismissWindow
+    #endif
+    #if !os(tvOS)
+        /// tvOS has no App Store rating prompt, so the action only exists elsewhere.
+        @Environment(\.requestReview) private var requestReview
     #endif
 
     /// The user's ordered engine fallback list, read once when the player opens.
@@ -339,8 +344,23 @@ struct FullScreenPlayerView: View {
                 ref: ref, progress: now, duration: total, force: force
             )
             WatchProgressBuffer.remove(ref: ref)
-            if let completion { syncTraktWatched(ref: completion.ref) }
+            if let completion {
+                syncTraktWatched(ref: completion.ref)
+                requestReviewIfAppropriate()
+            }
         }
+    }
+
+    /// Finishing a movie or episode is a clearly positive moment, so it's a good
+    /// time to (maybe) ask for an App Store rating — subject to
+    /// `AppStoreReviewTrigger`'s throttling. Only completions reach here (live
+    /// channels never produce one), and tvOS has no rating prompt at all.
+    private func requestReviewIfAppropriate() {
+        #if !os(tvOS)
+            guard AppStoreReviewTrigger.registerSignificantEvent() else { return }
+            requestReview()
+            AppStoreReviewTrigger.markPromptShown()
+        #endif
     }
 
     /// One-time "watched" sync on Trakt. Runs at most once per title (when it

--- a/LumeTests/Services/AppStoreReviewTriggerTests.swift
+++ b/LumeTests/Services/AppStoreReviewTriggerTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+@testable import Lume
+import Testing
+
+struct AppStoreReviewTriggerTests {
+    /// A throwaway, empty `UserDefaults` domain so the policy never reads or
+    /// mutates the shared standard suite.
+    private func makeDefaults() throws -> UserDefaults {
+        let suiteName = "AppStoreReviewTriggerTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    @Test func `does not ask before the completion threshold`() throws {
+        let defaults = try makeDefaults()
+        for _ in 1 ..< AppStoreReviewTrigger.completionThreshold {
+            #expect(AppStoreReviewTrigger.registerSignificantEvent(defaults: defaults, currentVersion: "1.0") == false)
+        }
+    }
+
+    @Test func `asks once the threshold is reached`() throws {
+        let defaults = try makeDefaults()
+        var eligible = false
+        for _ in 0 ..< AppStoreReviewTrigger.completionThreshold {
+            eligible = AppStoreReviewTrigger.registerSignificantEvent(defaults: defaults, currentVersion: "1.0")
+        }
+        #expect(eligible)
+    }
+
+    @Test func `does not ask twice on the same version`() throws {
+        let defaults = try makeDefaults()
+        for _ in 0 ..< AppStoreReviewTrigger.completionThreshold {
+            _ = AppStoreReviewTrigger.registerSignificantEvent(defaults: defaults, currentVersion: "1.0")
+        }
+        AppStoreReviewTrigger.markPromptShown(defaults: defaults, currentVersion: "1.0")
+
+        // After showing, the counter resets and the same version stays blocked.
+        for _ in 0 ..< AppStoreReviewTrigger.completionThreshold {
+            #expect(AppStoreReviewTrigger.registerSignificantEvent(defaults: defaults, currentVersion: "1.0") == false)
+        }
+    }
+
+    @Test func `asks again after an app update`() throws {
+        let defaults = try makeDefaults()
+        for _ in 0 ..< AppStoreReviewTrigger.completionThreshold {
+            _ = AppStoreReviewTrigger.registerSignificantEvent(defaults: defaults, currentVersion: "1.0")
+        }
+        AppStoreReviewTrigger.markPromptShown(defaults: defaults, currentVersion: "1.0")
+
+        // markPromptShown reset the counter, so a later version must accumulate
+        // its own completions before the prompt becomes eligible again.
+        var eligible = false
+        for _ in 0 ..< AppStoreReviewTrigger.completionThreshold {
+            eligible = AppStoreReviewTrigger.registerSignificantEvent(defaults: defaults, currentVersion: "1.1")
+        }
+        #expect(eligible)
+    }
+}


### PR DESCRIPTION
## Summary
Lume never prompts users for an App Store rating, even though happy, engaged viewers are the ones most likely to leave a positive review. This adds an automatic, throttled review request that fires at a genuinely positive moment — right after the viewer finishes watching a movie or episode — using SwiftUI's `requestReview` action.

## Implementation
- **`AppStoreReviewTrigger`** (`Lume/Services/Review/`) — a `nonisolated enum` scalar-flag store (same shape as `RecommendationSettings`) that owns the throttling policy: it counts finished playbacks and reports eligibility only once ≥ 3 completions accumulate, and at most once per app marketing version (a future update is the soonest it will ask again). StoreKit independently caps the system prompt to three appearances a year, so this is conservative on top of that.
- **`FullScreenPlayerView`** — hooks into the existing playback-completion seam in `persistProgressDetached`, right alongside the one-time Trakt "watched" sync. A `Completion` is only produced when a movie/episode crosses 90% (never for live channels), so the trigger naturally fires only on meaningful VOD finishes. The `requestReview` environment action is gated `#if !os(tvOS)` — tvOS has no App Store rating prompt.

No new user-facing strings (the prompt is system-provided), so no localization changes were needed. The existing manual "Rate Lume" link in Settings is unaffected and complements this automatic path.

## Testing
- [x] Acceptance criteria met (throttled prompt fires after meaningful engagement; once per version)
- [ ] Tests pass — see note below
- [x] SwiftLint clean (pre-commit hooks passed)
- [x] Tests added — `LumeTests/Services/AppStoreReviewTriggerTests.swift` covers the threshold, the per-version block, and re-eligibility after an update, using an isolated `UserDefaults` suite.

> **Note:** The app target **builds successfully** on the iOS Simulator with this change. The `LumeTests` target currently has a **pre-existing compile error** unrelated to this PR — `ModelTests`/`GenreDerivationTests` pass a `ModelContext` where a `ModelContainer` is expected (these files are unchanged from `main`). That breaks compilation of the whole test target, so the new `AppStoreReviewTriggerTests` could not be executed in-suite until that is fixed separately.

## Platforms
- [x] iOS / iPadOS
- [ ] tvOS (intentionally excluded — no rating prompt API)
- [x] macOS
- [x] visionOS

## Related