### PR TITLE
fix(epg): scope guide grid EPG fetch off the main thread

### DIFF
--- a/Lume/Views/LiveTV/ChannelEPGSnapshot.swift
+++ b/Lume/Views/LiveTV/ChannelEPGSnapshot.swift
@@ -65,3 +65,60 @@ enum ChannelEPGLoader {
         return result
     }
 }
+
+// MARK: - Guide window snapshot
+
+/// A single guide-window programme for a channel — plain values so the whole
+/// window can be fetched off the main thread and shaped into grid rows without
+/// keeping managed `EPGListing` objects alive on the view context.
+nonisolated struct EPGWindowListing: Equatable {
+    let id: String
+    let title: String
+    let detail: String
+    let start: Date
+    let end: Date
+}
+
+/// Loads the full guide window for a set of channels in one indexed, off-main
+/// fetch, grouped by channel id and sorted by start. This is the guide grid's
+/// counterpart to `ChannelEPGLoader`: it keeps *every* listing in the window
+/// (not just now/next) but, crucially, scopes the fetch to the channels on
+/// screen and returns `Sendable` snapshots. A view-context `@Query` here would
+/// instead materialize the *entire* guide window across every playlist on the
+/// main thread — and re-fire on every sync write — which froze the guide open
+/// and stuttered scrolling on large playlists.
+enum EPGGuideLoader {
+    nonisolated static func load(
+        container: ModelContainer,
+        channelIds: [String],
+        windowStart: Date,
+        windowEnd: Date
+    ) -> [String: [EPGWindowListing]] {
+        guard !channelIds.isEmpty else { return [:] }
+
+        let context = ModelContext(container)
+        // Channel-id scope is index-served; the time bounds trim it to the
+        // visible window. Sorted by start so the grid builder can tile in order.
+        let descriptor = FetchDescriptor<EPGListing>(
+            predicate: #Predicate {
+                channelIds.contains($0.channelId) && $0.end > windowStart && $0.start < windowEnd
+            },
+            sortBy: [SortDescriptor(\.channelId), SortDescriptor(\.start)]
+        )
+        guard let listings = try? context.fetch(descriptor) else { return [:] }
+
+        var grouped: [String: [EPGWindowListing]] = [:]
+        for listing in listings {
+            grouped[listing.channelId, default: []].append(
+                EPGWindowListing(
+                    id: listing.id,
+                    title: listing.title,
+                    detail: listing.listingDescription,
+                    start: listing.start,
+                    end: listing.end
+                )
+            )
+        }
+        return grouped
+    }
+}

--- a/Lume/Views/LiveTV/EPG/EPGGuideView.swift
+++ b/Lume/Views/LiveTV/EPG/EPGGuideView.swift
@@ -19,10 +19,19 @@ struct EPGGuideView: View {
     let playlistPrefix: String
     let onPlay: (LiveStream) -> Void
 
+    @Environment(\.modelContext) private var modelContext
     @Query private var streams: [LiveStream]
-    @Query private var listings: [EPGListing]
 
     private let timeline: EPGTimeline
+
+    /// The guide window's listings, grouped by channel and resolved in one
+    /// off-main fetch scoped to *this category's* channels (see `EPGGuideLoader`).
+    /// A view-context `@Query<EPGListing>` here instead pulled the entire guide
+    /// window across every playlist onto the main thread and re-fired on every
+    /// sync write — the freeze-on-open and stutter-while-scrolling this fixes.
+    @State private var listingsByChannel: [String: [EPGWindowListing]] = [:]
+    /// Observed so the guide refreshes once a guide import settles.
+    @State private var epgSync = EPGSyncService.shared
 
     init(scope: LiveChannelScope, playlistPrefix: String, sort: ContentSortOption, onPlay: @escaping (LiveStream) -> Void) {
         self.scope = scope
@@ -33,14 +42,6 @@ struct EPGGuideView: View {
         self.timeline = timeline
 
         _streams = Query(LiveChannelQuery.descriptor(for: scope, sort: sort))
-
-        // Fetch only listings overlapping the window, then group in memory.
-        let windowStart = timeline.start
-        let windowEnd = timeline.end
-        _listings = Query(
-            filter: #Predicate<EPGListing> { $0.end > windowStart && $0.start < windowEnd },
-            sort: [SortDescriptor(\.start)]
-        )
     }
 
     private var scopedStreams: [LiveStream] {
@@ -48,22 +49,49 @@ struct EPGGuideView: View {
     }
 
     var body: some View {
-        if scopedStreams.isEmpty {
-            ContentUnavailableView(
-                "No Channels",
-                systemImage: "antenna.radiowaves.left.and.right",
-                description: Text("This category has no channels")
-            )
-        } else {
-            EPGGridScroller(rows: buildRows(), timeline: timeline, onPlay: onPlay)
+        let channels = scopedStreams
+        Group {
+            if channels.isEmpty {
+                ContentUnavailableView(
+                    "No Channels",
+                    systemImage: "antenna.radiowaves.left.and.right",
+                    description: Text("This category has no channels")
+                )
+            } else {
+                EPGGridScroller(rows: buildRows(for: channels), timeline: timeline, onPlay: onPlay)
+            }
+        }
+        // Reload when the channel set changes or a guide import settles. Keyed on
+        // `isSyncing` (which flips twice per sync) rather than observing the store,
+        // so the grid rebuilds a handful of times — not on every batch write.
+        .task(id: "\(channels.count)-\(epgSync.isSyncing)") {
+            await loadListings(for: channels)
         }
     }
 
-    /// Groups the windowed listings by channel and tiles each stream into a row.
-    /// Runs only when the queries change — not on scroll.
-    private func buildRows() -> [EPGChannelRow] {
-        let grouped = Dictionary(grouping: listings, by: \.channelId)
-        return EPGGridBuilder.rows(streams: scopedStreams, listingsByChannel: grouped, timeline: timeline)
+    /// Tiles each scoped stream into a row from the pre-fetched window snapshots.
+    /// Runs only when the streams or loaded listings change — not on scroll.
+    private func buildRows(for channels: [LiveStream]) -> [EPGChannelRow] {
+        EPGGridBuilder.rows(streams: channels, listingsByChannel: listingsByChannel, timeline: timeline)
+    }
+
+    private func loadListings(for channels: [LiveStream]) async {
+        let channelIds = Array(Set(channels.compactMap(\.epgChannelId).filter { !$0.isEmpty }))
+        guard !channelIds.isEmpty else {
+            listingsByChannel = [:]
+            return
+        }
+        let container = modelContext.container
+        let windowStart = timeline.start
+        let windowEnd = timeline.end
+        listingsByChannel = await Task.detached(priority: .userInitiated) {
+            EPGGuideLoader.load(
+                container: container,
+                channelIds: channelIds,
+                windowStart: windowStart,
+                windowEnd: windowEnd
+            )
+        }.value
     }
 }
 

--- a/Lume/Views/LiveTV/EPG/EPGTimeline.swift
+++ b/Lume/Views/LiveTV/EPG/EPGTimeline.swift
@@ -132,7 +132,7 @@ enum EPGGridBuilder {
     @MainActor
     static func rows(
         streams: [LiveStream],
-        listingsByChannel: [String: [EPGListing]],
+        listingsByChannel: [String: [EPGWindowListing]],
         timeline: EPGTimeline
     ) -> [EPGChannelRow] {
         streams.map { stream in
@@ -147,7 +147,7 @@ enum EPGGridBuilder {
 
     /// Turns a channel's sorted listings into contiguous cells spanning the
     /// whole window, inserting gap fillers wherever data is missing.
-    static func cells(for listings: [EPGListing], timeline: EPGTimeline) -> [EPGProgramCell] {
+    static func cells(for listings: [EPGWindowListing], timeline: EPGTimeline) -> [EPGProgramCell] {
         var cells: [EPGProgramCell] = []
         var cursor = timeline.start
 
@@ -163,7 +163,7 @@ enum EPGGridBuilder {
             cells.append(EPGProgramCell(
                 id: listing.id,
                 title: listing.title,
-                detail: listing.listingDescription,
+                detail: listing.detail,
                 start: clampedStart,
                 end: clampedEnd,
                 listingID: listing.id,


### PR DESCRIPTION
## Problem

Customer report (Apple TV):

> When I select **Guide** in the upper left, the app slows down so much it appears to freeze. After a long time the guide appears, but scrolling makes it freeze again, and eventually I can scroll. If I select **List**, it works pretty well.

## Root cause

`EPGGuideView` (the guide grid) loaded EPG the one way the app had already learned to avoid:

```swift
@Query private var listings: [EPGListing]   // main-thread view context
_listings = Query(filter: #Predicate { $0.end > windowStart && $0.start < windowEnd })
```

- **Unscoped** — fetched *every* listing in the ~25h window across **all playlists/categories**, not just the opened category's channels. On a large guide (the `EPGListing` model comment notes *"hundreds of thousands of rows"*) this materializes tens of thousands of managed objects **on the main thread** → the multi-second freeze on opening Guide.
- **A live view-context `@Query`** → re-fires on every EPG batch write during a background sync, re-running `buildRows()` over the whole set → the repeated stutter while scrolling, which clears once the sync settles.

The **List** path (`ChannelEPGLoader`) was explicitly rewritten to avoid exactly this — scoped fetch, background `ModelContext`, `Sendable` value snapshots — which is why *"List works pretty well."* The guide grid was simply a straggler that never got that treatment.

## Fix

Make the Guide mirror the List:

- **`EPGGuideLoader` + `EPGWindowListing`** (`ChannelEPGSnapshot.swift`) — a scoped, off-main fetch returning value snapshots; the grid counterpart to `ChannelEPGLoader` (keeps the whole window, not just now/next).
- **`EPGGuideView`** keeps only `@Query streams`, drops the listings `@Query`, and loads listings scoped to the on-screen channels' `epgChannelId`s off-main in `.task(id: "\(count)-\(epgSync.isSyncing)")` — so it rebuilds a couple of times per sync instead of on every write.
- **`EPGGridBuilder.rows/cells`** now consume `[EPGWindowListing]` instead of managed `[EPGListing]` (the only caller was the guide).

## Testing

- ✅ `xcodebuild build` succeeds on the iOS Simulator; SwiftFormat + SwiftLint pre-commit hooks pass.
- ⚠️ Verified compilation only — the scroll-smoothness fix (removing the per-write `@Query` churn) should be confirmed on-device against a large real playlist on tvOS.