### PR TITLE
fix(player): cancel PiP observer task to stop KSPlayerLayer leak

### DIFF
--- a/Lume/Views/Player/KSPlayerEngineView+Playback.swift
+++ b/Lume/Views/Player/KSPlayerEngineView+Playback.swift
@@ -1,3 +1,4 @@
+import Combine
 import KSPlayer
 import OSLog
 import QuartzCore
@@ -344,3 +345,29 @@ extension KSPlayerEngineView {
         }
     }
 }
+
+// MARK: - PiP observation
+
+#if !os(tvOS)
+    @available(iOS 16.0, macOS 13.0, *)
+    extension KSPlayerEngineView {
+        /// Poll until playerLayer is available, then observe its published isPipActive.
+        /// The `for await` holds the layer strongly, so this task must be cancelled on
+        /// disappear or the KSPlayerLayer (and its decoder session) outlives playback.
+        func observePipState() {
+            pipObservationTask?.cancel()
+            pipObservationTask = Task { @MainActor in
+                var attempts = 0
+                while coordinator.playerLayer == nil, attempts < 50 {
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                    attempts += 1
+                }
+                guard !Task.isCancelled, let playerLayer = coordinator.playerLayer else { return }
+                for await active in playerLayer.$isPipActive.values {
+                    guard !Task.isCancelled else { return }
+                    isPipActive = active
+                }
+            }
+        }
+    }
+#endif

--- a/Lume/Views/Player/KSPlayerEngineView.swift
+++ b/Lume/Views/Player/KSPlayerEngineView.swift
@@ -92,9 +92,12 @@ struct KSPlayerEngineView: View {
     @State private var isControlsVisible = true
     @State var isSeeking = false
     @State private var seekPosition: TimeInterval = 0
-    @State private var isPipActive = false
+    /// PiP state and its observer task are `internal` (not `private`) so the
+    /// PiP observation in `KSPlayerEngineView+Playback.swift` can drive them.
+    @State var isPipActive = false
     @State var hideTask: Task<Void, Never>?
     @State private var hoverHideTask: Task<Void, Never>?
+    @State var pipObservationTask: Task<Void, Never>?
 
     #if os(tvOS)
         /// Republishes KSPlayer state to the shared overlay (`isPlaying`,
@@ -449,6 +452,7 @@ struct KSPlayerEngineView: View {
             .onDisappear {
                 hideTask?.cancel()
                 hoverHideTask?.cancel()
+                pipObservationTask?.cancel()
                 reconnector.cancel()
                 cancelStartupWatchdog()
                 cancelStallWatchdog()
@@ -513,22 +517,6 @@ struct KSPlayerEngineView: View {
             }
         }
 
-        // MARK: PiP
-
-        private func observePipState() {
-            // Poll until playerLayer is available, then observe its published isPipActive
-            Task { @MainActor in
-                var attempts = 0
-                while coordinator.playerLayer == nil, attempts < 50 {
-                    try? await Task.sleep(nanoseconds: 100_000_000)
-                    attempts += 1
-                }
-                guard let playerLayer = coordinator.playerLayer else { return }
-                for await active in playerLayer.$isPipActive.values {
-                    isPipActive = active
-                }
-            }
-        }
     #endif
 
     // MARK: - Actions (shared)


### PR DESCRIPTION
Part 1 of the July 2026 performance-audit backlog (Phase 0 — critical items).

## KSPlayerLayer leak via uncancelled PiP observer

`KSPlayerEngineView.observePipState()` started an unstored `Task` whose `for await playerLayer.$isPipActive.values` loop strongly retains the `KSPlayerLayer`. The loop only ends when the layer deallocates, and the layer can't deallocate while the loop retains it — a self-sustaining cycle that leaked one player layer (decoder session included) per iOS/macOS KSPlayer playback session. `.onDisappear` cancelled every other watchdog in the file but not this one.

**Fix:** the task is now stored in `@State pipObservationTask`, cancelled in `.onDisappear`, and checks `Task.isCancelled`. Combine's `.values` iterator is cancellation-aware, so the cancel ends the loop and releases the layer. The observer moved to `KSPlayerEngineView+Playback.swift` (with `isPipActive`/`pipObservationTask` made internal, per the existing cross-file-extension pattern) to stay under the type/file size caps.

Fixes #102 — the leaked layer is also why the server-side stream stayed open after backing out of the player. `coordinator.resetPlayer()` only nils the layer reference (its `didSet` merely pauses); the network/demuxer teardown (`playerItem.shutdown()`, which closes the FFmpeg format context and the HTTP connection) runs in `KSMEPlayer.deinit`, which the retain cycle prevented. One held connection accumulated per playback session until force-quit — exactly the reported symptom, and the leaky observer is present in v1.2.0 where it was reported.

**Suggested verification:** Instruments Allocations with Mark Generation — open/close a KSPlayer VOD session ~10 times; `KSPlayerLayer` instance count should return to baseline after each close (it grew by one per session before this fix).

> A second commit restoring the periodic watch-progress sampler (crash recovery) was originally part of this PR but has been dropped — the disable in f5992a7 stands.

## Testing
- iOS Simulator build ✅ (iPhone 17 Pro)
- tvOS Simulator build ✅ (Apple TV) — touched code is platform-conditional
- SwiftFormat/SwiftLint pre-commit gates ✅
