### PR TITLE
perf: cut re-render churn in series detail and download progress

### DIFF
--- a/Lume/Services/Downloads/DownloadManager.swift
+++ b/Lume/Services/Downloads/DownloadManager.swift
@@ -5,16 +5,31 @@ import SwiftData
 
 // MARK: - Data types
 
-/// Progress snapshot for a single active or queued download.
-struct ActiveDownload: Identifiable {
+/// Live progress for a single active or queued download.
+///
+/// A per-item `@Observable` box rather than a value in the `activeDownloads`
+/// dictionary: `@Observable` tracks access at stored-property granularity, so
+/// views that read a *value* out of the dictionary observe the whole
+/// dictionary — every progress tick for any download re-rendered every
+/// visible episode card. With a box, ticks mutate the box's own properties
+/// and only the card rendering that download re-renders; the dictionary
+/// itself changes only when a download starts, finishes, or fails.
+@Observable
+final class ActiveDownload: Identifiable {
     let id: String
     let title: String
-    var fractionCompleted: Double = 0
+    var fractionCompleted: Double
     var bytesWritten: Int64 = 0
     var totalBytes: Int64 = 0
     /// Ring-buffer of (timestamp, cumulative bytes) used for speed estimation.
     /// Capped at 5 seconds of history; populated at most every 500 ms.
     var samples: [(date: Date, bytes: Int64)] = []
+
+    init(id: String, title: String, fractionCompleted: Double = 0) {
+        self.id = id
+        self.title = title
+        self.fractionCompleted = fractionCompleted
+    }
 
     /// Bytes per second averaged over the sample window, or nil if too few samples.
     var speedBytesPerSec: Double? {
@@ -300,7 +315,7 @@ extension DownloadManager: URLSessionDownloadDelegate {
         }
         guard shouldPublish else { return }
         Task { @MainActor in
-            guard let id = self.taskMap[taskID], var download = self.activeDownloads[id] else { return }
+            guard let id = self.taskMap[taskID], let download = self.activeDownloads[id] else { return }
             download.fractionCompleted = fraction
             download.bytesWritten = totalBytesWritten
             download.totalBytes = totalBytesExpectedToWrite
@@ -310,7 +325,6 @@ extension DownloadManager: URLSessionDownloadDelegate {
                 download.samples.append((date: now, bytes: totalBytesWritten))
                 download.samples = download.samples.filter { $0.date >= now.addingTimeInterval(-5) }
             }
-            self.activeDownloads[id] = download
         }
     }
 

--- a/Lume/Views/Series/SeriesDetailView.swift
+++ b/Lume/Views/Series/SeriesDetailView.swift
@@ -382,7 +382,8 @@ struct SeriesDetailView: View {
         // Open on the season of the furthest point reached in the series, so
         // progress in a later season always wins over progress in an earlier
         // one — regardless of which was watched more recently.
-        let target = furthestInProgressEpisode ?? furthestProgressEpisode
+        let markers = SeriesEpisodeProgress.markers(in: series.episodes)
+        let target = markers.furthestInProgress ?? markers.furthestAnyProgress
         if let target, seasons.contains(target.seasonNum) {
             return target.seasonNum
         }
@@ -396,38 +397,10 @@ struct SeriesDetailView: View {
             .sorted { $0.episodeNum < $1.episodeNum }
     }
 
-    /// The furthest partially-watched (not completed) episode in the series,
-    /// ordered by season then episode.
-    private var furthestInProgressEpisode: Episode? {
-        series.episodes
-            .filter { $0.watchProgress > 1 && !$0.isWatched }
-            .max { ($0.seasonNum, $0.episodeNum) < ($1.seasonNum, $1.episodeNum) }
-    }
-
-    /// The furthest episode with any watch progress, including completed ones.
-    private var furthestProgressEpisode: Episode? {
-        series.episodes
-            .filter { $0.watchProgress > 0 || $0.isWatched }
-            .max { ($0.seasonNum, $0.episodeNum) < ($1.seasonNum, $1.episodeNum) }
-    }
-
-    /// The furthest fully-watched episode in the series.
-    private var furthestWatchedEpisode: Episode? {
-        series.episodes
-            .filter(\.isWatched)
-            .max { ($0.seasonNum, $0.episodeNum) < ($1.seasonNum, $1.episodeNum) }
-    }
-
-    /// Play button target: resume the furthest in-progress episode; else the
-    /// episode after the furthest watched one (overflowing seasons, wrapping to
-    /// the premiere after the finale); else the selected season's first episode.
+    /// Play button target — see `SeriesEpisodeProgress.nextEpisode`. Read on
+    /// every body evaluation, so it must stay O(episodes) with no sorting.
     private var nextEpisode: Episode? {
-        if let inProgress = furthestInProgressEpisode { return inProgress }
-        let ordered = series.episodes.sorted { ($0.seasonNum, $0.episodeNum) < ($1.seasonNum, $1.episodeNum) }
-        guard let watched = furthestWatchedEpisode,
-              let index = ordered.firstIndex(where: { $0 === watched })
-        else { return seasonEpisodes.first ?? ordered.first }
-        return index + 1 < ordered.count ? ordered[index + 1] : ordered.first
+        SeriesEpisodeProgress.nextEpisode(in: series.episodes, fallback: seasonEpisodes.first)
     }
 
     private var backgroundColor: Color {

--- a/Lume/Views/Series/SeriesEpisodeProgress.swift
+++ b/Lume/Views/Series/SeriesEpisodeProgress.swift
@@ -1,0 +1,86 @@
+//
+//  SeriesEpisodeProgress.swift
+//  Lume
+//
+//  Single-pass derivations over a series' episodes relationship, shared by
+//  `SeriesDetailView` and `TVSeriesDetailView`. Their bodies read the play
+//  target on every evaluation; deriving it with per-property computed vars
+//  re-filtered and re-sorted the full relationship several times per render,
+//  which visibly lagged watched-toggles and focus moves on long-running shows
+//  (hundreds to thousands of episodes). Everything here is O(episodes) scans
+//  with no sorting and no intermediate arrays.
+//
+
+enum SeriesEpisodeProgress {
+    /// The furthest episodes by watch state, in (season, episode) order.
+    struct Markers {
+        /// Furthest partially-watched (not completed) episode.
+        var furthestInProgress: Episode?
+        /// Furthest episode with any progress, including completed ones.
+        var furthestAnyProgress: Episode?
+        /// Furthest fully-watched episode.
+        var furthestWatched: Episode?
+    }
+
+    /// All three markers from one scan.
+    static func markers(in episodes: [Episode]) -> Markers {
+        var markers = Markers()
+        for episode in episodes {
+            if episode.watchProgress > 1, !episode.isWatched {
+                markers.furthestInProgress = later(markers.furthestInProgress, episode)
+            }
+            if episode.watchProgress > 0 || episode.isWatched {
+                markers.furthestAnyProgress = later(markers.furthestAnyProgress, episode)
+            }
+            if episode.isWatched {
+                markers.furthestWatched = later(markers.furthestWatched, episode)
+            }
+        }
+        return markers
+    }
+
+    /// Play button target: resume the furthest in-progress episode; else the
+    /// episode after the furthest watched one (overflowing seasons, wrapping to
+    /// the premiere after the finale); else `fallback` (the selected season's
+    /// first episode); else the series premiere.
+    static func nextEpisode(in episodes: [Episode], fallback: @autoclosure () -> Episode?) -> Episode? {
+        let markers = markers(in: episodes)
+        if let inProgress = markers.furthestInProgress { return inProgress }
+        guard let watched = markers.furthestWatched else {
+            return fallback() ?? earliest(in: episodes)
+        }
+        return successor(of: watched, in: episodes)
+    }
+
+    /// The episode after `watched` in (season, episode) order, wrapping to the
+    /// series premiere after the finale.
+    private static func successor(of watched: Episode, in episodes: [Episode]) -> Episode? {
+        var next: Episode?
+        var first: Episode?
+        for episode in episodes {
+            first = earlier(first, episode)
+            if (watched.seasonNum, watched.episodeNum) < (episode.seasonNum, episode.episodeNum) {
+                next = earlier(next, episode)
+            }
+        }
+        return next ?? first
+    }
+
+    private static func earliest(in episodes: [Episode]) -> Episode? {
+        episodes.reduce(nil) { earlier($0, $1) }
+    }
+
+    private static func later(_ current: Episode?, _ candidate: Episode) -> Episode {
+        guard let current else { return candidate }
+        return (current.seasonNum, current.episodeNum) < (candidate.seasonNum, candidate.episodeNum)
+            ? candidate
+            : current
+    }
+
+    private static func earlier(_ current: Episode?, _ candidate: Episode) -> Episode {
+        guard let current else { return candidate }
+        return (candidate.seasonNum, candidate.episodeNum) < (current.seasonNum, current.episodeNum)
+            ? candidate
+            : current
+    }
+}

--- a/Lume/Views/TV/TVSeriesDetailView.swift
+++ b/Lume/Views/TV/TVSeriesDetailView.swift
@@ -366,7 +366,8 @@
             // Open on the season of the furthest point reached in the series, so
             // progress in a later season always wins over progress in an earlier
             // one — regardless of which was watched more recently.
-            let target = furthestInProgressEpisode ?? furthestProgressEpisode
+            let markers = SeriesEpisodeProgress.markers(in: series.episodes)
+            let target = markers.furthestInProgress ?? markers.furthestAnyProgress
             if let target, seasons.contains(target.seasonNum) {
                 return target.seasonNum
             }
@@ -380,38 +381,11 @@
                 .sorted { $0.episodeNum < $1.episodeNum }
         }
 
-        /// The furthest partially-watched (not completed) episode in the
-        /// series, ordered by season then episode.
-        private var furthestInProgressEpisode: Episode? {
-            series.episodes
-                .filter { $0.watchProgress > 1 && !$0.isWatched }
-                .max { ($0.seasonNum, $0.episodeNum) < ($1.seasonNum, $1.episodeNum) }
-        }
-
-        /// The furthest episode with any watch progress, including completed.
-        private var furthestProgressEpisode: Episode? {
-            series.episodes
-                .filter { $0.watchProgress > 0 || $0.isWatched }
-                .max { ($0.seasonNum, $0.episodeNum) < ($1.seasonNum, $1.episodeNum) }
-        }
-
-        /// The furthest fully-watched episode in the series.
-        private var furthestWatchedEpisode: Episode? {
-            series.episodes
-                .filter(\.isWatched)
-                .max { ($0.seasonNum, $0.episodeNum) < ($1.seasonNum, $1.episodeNum) }
-        }
-
-        /// Play button target: resume the furthest in-progress episode; else the
-        /// episode after the furthest watched one (overflowing seasons, wrapping
-        /// to the premiere after the finale); else the selected season's first.
+        /// Play button target — see `SeriesEpisodeProgress.nextEpisode`. Read
+        /// more than once per body evaluation (play button + `playTitle`), so
+        /// it must stay O(episodes) with no sorting.
         private var nextEpisode: Episode? {
-            if let inProgress = furthestInProgressEpisode { return inProgress }
-            let ordered = series.episodes.sorted { ($0.seasonNum, $0.episodeNum) < ($1.seasonNum, $1.episodeNum) }
-            guard let watched = furthestWatchedEpisode,
-                  let index = ordered.firstIndex(where: { $0 === watched })
-            else { return seasonEpisodes.first ?? ordered.first }
-            return index + 1 < ordered.count ? ordered[index + 1] : ordered.first
+            SeriesEpisodeProgress.nextEpisode(in: series.episodes, fallback: seasonEpisodes.first)
         }
 
         private var playTitle: LocalizedStringKey {

--- a/LumeTests/Models/SeriesEpisodeProgressTests.swift
+++ b/LumeTests/Models/SeriesEpisodeProgressTests.swift
@@ -1,0 +1,120 @@
+//
+//  SeriesEpisodeProgressTests.swift
+//  LumeTests
+//
+//  Verifies the single-pass episode derivations behind the series detail
+//  screens' Play button: the furthest-progress markers and the next-episode
+//  resolution (resume in-progress → successor of furthest watched, wrapping
+//  to the premiere after the finale → fallback).
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+@MainActor
+struct SeriesEpisodeProgressTests {
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([Series.self, Episode.self])
+        // `cloudKitDatabase: .none`: the catalog uses `@Attribute(.unique)`,
+        // which CloudKit forbids and fails the load on a signed test host.
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true, cloudKitDatabase: .none)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    /// Two seasons × three episodes, unwatched, inserted out of order to prove
+    /// the scans don't depend on relationship order.
+    private func seedEpisodes(in context: ModelContext) -> [Episode] {
+        var episodes: [Episode] = []
+        for (season, number) in [(2, 2), (1, 1), (2, 3), (1, 3), (2, 1), (1, 2)] {
+            let episode = Episode(
+                id: "s\(season)e\(number)", episodeId: "\(season)-\(number)", title: "S\(season)E\(number)",
+                containerExtension: "mkv", seasonNum: season, episodeNum: number
+            )
+            context.insert(episode)
+            episodes.append(episode)
+        }
+        return episodes
+    }
+
+    private func episode(_ episodes: [Episode], _ season: Int, _ number: Int) -> Episode {
+        episodes.first { $0.seasonNum == season && $0.episodeNum == number }!
+    }
+
+    @Test func `markers are nil for an unwatched series`() throws {
+        let container = try makeContainer()
+        let episodes = seedEpisodes(in: container.mainContext)
+
+        let markers = SeriesEpisodeProgress.markers(in: episodes)
+        #expect(markers.furthestInProgress == nil)
+        #expect(markers.furthestAnyProgress == nil)
+        #expect(markers.furthestWatched == nil)
+    }
+
+    @Test func `markers pick the furthest episode by season then number`() throws {
+        let container = try makeContainer()
+        let episodes = seedEpisodes(in: container.mainContext)
+        episode(episodes, 1, 3).isWatched = true
+        episode(episodes, 2, 1).isWatched = true
+        episode(episodes, 1, 2).watchProgress = 300 // in-progress, earlier than the watched ones
+        episode(episodes, 2, 2).watchProgress = 120 // in-progress, furthest overall
+
+        let markers = SeriesEpisodeProgress.markers(in: episodes)
+        #expect(markers.furthestInProgress === episode(episodes, 2, 2))
+        #expect(markers.furthestAnyProgress === episode(episodes, 2, 2))
+        #expect(markers.furthestWatched === episode(episodes, 2, 1))
+    }
+
+    @Test func `next episode resumes the furthest in-progress episode`() throws {
+        let container = try makeContainer()
+        let episodes = seedEpisodes(in: container.mainContext)
+        episode(episodes, 2, 1).isWatched = true
+        episode(episodes, 1, 2).watchProgress = 300
+
+        let next = SeriesEpisodeProgress.nextEpisode(in: episodes, fallback: nil)
+        #expect(next === episode(episodes, 1, 2))
+    }
+
+    @Test func `next episode follows the furthest watched one across seasons`() throws {
+        let container = try makeContainer()
+        let episodes = seedEpisodes(in: container.mainContext)
+        episode(episodes, 1, 3).isWatched = true // season finale → next is S2E1
+
+        let next = SeriesEpisodeProgress.nextEpisode(in: episodes, fallback: nil)
+        #expect(next === episode(episodes, 2, 1))
+    }
+
+    @Test func `next episode wraps to the premiere after the series finale`() throws {
+        let container = try makeContainer()
+        let episodes = seedEpisodes(in: container.mainContext)
+        episode(episodes, 2, 3).isWatched = true
+
+        let next = SeriesEpisodeProgress.nextEpisode(in: episodes, fallback: nil)
+        #expect(next === episode(episodes, 1, 1))
+    }
+
+    @Test func `next episode falls back to the given episode, then the premiere`() throws {
+        let container = try makeContainer()
+        let episodes = seedEpisodes(in: container.mainContext)
+
+        let fallback = episode(episodes, 2, 1)
+        #expect(SeriesEpisodeProgress.nextEpisode(in: episodes, fallback: fallback) === fallback)
+        #expect(SeriesEpisodeProgress.nextEpisode(in: episodes, fallback: nil) === episode(episodes, 1, 1))
+        #expect(SeriesEpisodeProgress.nextEpisode(in: [], fallback: nil) == nil)
+    }
+
+    @Test func `a fully watched episode does not count as in-progress`() throws {
+        let container = try makeContainer()
+        let episodes = seedEpisodes(in: container.mainContext)
+        let watched = episode(episodes, 1, 2)
+        watched.watchProgress = 2400
+        watched.isWatched = true
+
+        let markers = SeriesEpisodeProgress.markers(in: episodes)
+        #expect(markers.furthestInProgress == nil)
+        #expect(markers.furthestWatched === watched)
+        // Resume target is the episode after it, not the watched one itself.
+        #expect(SeriesEpisodeProgress.nextEpisode(in: episodes, fallback: nil) === episode(episodes, 1, 3))
+    }
+}


### PR DESCRIPTION
Part 3 of the July 2026 performance-audit backlog (Phase 2 — SwiftUI re-render churn).

## 1. Series detail: one O(n) scan instead of repeated sorts per render

`SeriesDetailView` and `TVSeriesDetailView` derived the Play target through per-property computed vars — `furthestInProgressEpisode`, `furthestProgressEpisode`, `furthestWatchedEpisode`, each a filtered `.max` scan, plus a **full sort of the episodes relationship** inside `nextEpisode` — recomputed on every body evaluation. The tvOS body is worse than the audit estimated: it evaluates `nextEpisode` twice per render (play button `isEnabled` + `playTitle`). On long-running shows (hundreds to 1000+ episodes) toggling watched or moving focus re-ran several O(n log n) passes and visibly lagged.

The shared logic now lives in `SeriesEpisodeProgress`: all three markers from one O(n) scan, and the successor of the furthest watched episode from another single scan — no sorting, no intermediate arrays. The properties stay computed (not `@State`-cached), so the views keep observing episode watch-state exactly as before — no stale-Play-button risk from background Trakt/iCloud updates.

Semantics preserved (resume in-progress → successor across seasons → wrap to premiere after finale → season-first fallback) and now covered by 7 new unit tests (`SeriesEpisodeProgressTests`) — this logic had no coverage before.

## 2. Downloads: per-item observable progress boxes

`@Observable` tracks access at stored-property granularity, so views reading `activeDownloads[id]` (episode cards, download rows, detail buttons) observed the **whole dictionary** — every 250 ms progress tick for any download re-rendered every visible episode card. `ActiveDownload` is now a per-item `@Observable` class: ticks mutate the box's own properties and only the view rendering that download re-renders. The dictionary itself changes only on start/finish/fail. No call-site changes needed — consumers already read properties through the optional lookup.

## Deliberately deferred

The audit's third Phase-2 item — migrating `AVPlayerCoordinator`/`VLCPlayerCoordinator` from `ObservableObject` to `@Observable` — turned out to be a much larger surface than estimated: the shared tvOS overlay consumes engines through a `TVPlaybackEngine: ObservableObject` protocol, so the migration spans the protocol, three conformers (`KSTVPlaybackEngine` included), the generic overlay, and every `$coordinator` binding across three engines. That deserves its own PR with manual playback verification on each platform rather than riding along here.

## Testing
- iOS + tvOS Simulator builds ✅
- New `SeriesEpisodeProgressTests` (7 tests) ✅
- SwiftFormat/SwiftLint pre-commit gates ✅