### PR TITLE
perf: move Settings clears off-main, batch Stalker saves, constrain indexer network, gate hero auto-advance

### DIFF
--- a/Lume/Services/Indexing/ContentIndexer.swift
+++ b/Lume/Services/Indexing/ContentIndexer.swift
@@ -37,9 +37,24 @@ actor ContentIndexer {
     private let assetRetryPause: Duration = .seconds(15)
     private let assetRetryMaxPause: Duration = .seconds(300)
 
-    init(modelContainer: ModelContainer, tmdbClient: TMDBClient = .shared) {
+    init(modelContainer: ModelContainer, tmdbClient: TMDBClient? = nil) {
         self.modelContainer = modelContainer
-        self.tmdbClient = tmdbClient
+        self.tmdbClient = tmdbClient ?? TMDBClient(session: Self.makeIndexingSession())
+    }
+
+    /// Session for the indexer's TMDB traffic: skips expensive (cellular /
+    /// hotspot) and constrained (Low Data Mode) networks. A full-library pass
+    /// issues one request per unindexed title over a long stretch, and nobody
+    /// is waiting on it — so it shouldn't burn metered data or hold the radio.
+    /// On a cellular-only connection requests fail immediately (no
+    /// `waitsForConnectivity`), the run throws, and the next kick retries —
+    /// the same recovery path as any transient network failure. User-initiated
+    /// detail-screen enrichment stays on `.shared`, unconstrained.
+    private static func makeIndexingSession() -> URLSession {
+        let config = URLSessionConfiguration.default
+        config.allowsExpensiveNetworkAccess = false
+        config.allowsConstrainedNetworkAccess = false
+        return URLSession(configuration: config)
     }
 
     // MARK: - Run loop

--- a/Lume/Services/Storage/StorageManager.swift
+++ b/Lume/Services/Storage/StorageManager.swift
@@ -69,63 +69,83 @@ enum StorageManager {
         }.value
     }
 
+    /// Rows mutated between intermediate saves during the clear operations, so
+    /// one clear doesn't build a single giant transaction in memory.
+    private static let clearBatchSize = 1000
+
     /// Drops cached TMDB/OMDb enrichment (artwork paths, cast, trailers, ratings
     /// and collection info) from every enriched movie and series so it re-fetches
-    /// lazily on the next detail-screen visit. Runs on the passed-in (main)
-    /// context — like `TMDBLanguageWatcher` — so browse views reflect the cleared
-    /// artwork immediately rather than after a relaunch.
-    static func clearMetadataEnrichment(in context: ModelContext) {
-        do {
-            // Filter in SQLite so only already-enriched rows are hydrated.
-            let movies = try context.fetch(FetchDescriptor<Movie>(
-                predicate: #Predicate { $0.tmdbEnrichedAt != nil || $0.ratingsEnrichedAt != nil }
-            ))
-            for movie in movies {
-                // Clearing the relationship array only disassociates the rows;
-                // delete them explicitly so the orphaned cast doesn't linger and
-                // keep occupying the store.
-                for cast in movie.castMembers {
-                    context.delete(cast)
+    /// lazily on the next detail-screen visit. Runs on a private background
+    /// context — hydrating and mutating every enriched title (plus cascade-
+    /// deleting its cast) on the main context froze the UI for seconds on a
+    /// large library. The saves merge back into the main context, so browse
+    /// views still reflect the cleared artwork as soon as they land.
+    static func clearMetadataEnrichment(container: ModelContainer) async {
+        await Task.detached(priority: .userInitiated) {
+            let context = ModelContext(container)
+            context.autosaveEnabled = false
+            do {
+                // Filter in SQLite so only already-enriched rows are hydrated.
+                let movies = try context.fetch(FetchDescriptor<Movie>(
+                    predicate: #Predicate { $0.tmdbEnrichedAt != nil || $0.ratingsEnrichedAt != nil }
+                ))
+                for (index, movie) in movies.enumerated() {
+                    clearEnrichment(of: movie, in: context)
+                    if (index + 1).isMultiple(of: clearBatchSize) { try context.save() }
                 }
-                movie.backdropPath = nil
-                movie.logoPath = nil
-                movie.tagline = nil
-                movie.contentRating = nil
-                movie.tmdbEnrichedAt = nil
-                movie.similarTMDBIds = []
-                movie.trailersData = nil
-                movie.imdbId = nil
-                movie.externalRatingsData = nil
-                movie.ratingsEnrichedAt = nil
-                movie.collectionId = nil
-                movie.collectionName = nil
-                movie.collectionPosterPath = nil
-                movie.collectionBackdropPath = nil
-            }
+                try context.save()
 
-            let series = try context.fetch(FetchDescriptor<Series>(
-                predicate: #Predicate { $0.tmdbEnrichedAt != nil || $0.ratingsEnrichedAt != nil }
-            ))
-            for show in series {
-                for cast in show.castMembers {
-                    context.delete(cast)
+                let series = try context.fetch(FetchDescriptor<Series>(
+                    predicate: #Predicate { $0.tmdbEnrichedAt != nil || $0.ratingsEnrichedAt != nil }
+                ))
+                for (index, show) in series.enumerated() {
+                    clearEnrichment(of: show, in: context)
+                    if (index + 1).isMultiple(of: clearBatchSize) { try context.save() }
                 }
-                show.backdropPath = nil
-                show.logoPath = nil
-                show.tagline = nil
-                show.contentRating = nil
-                show.tmdbEnrichedAt = nil
-                show.similarTMDBIds = []
-                show.trailersData = nil
-                show.imdbId = nil
-                show.externalRatingsData = nil
-                show.ratingsEnrichedAt = nil
+                try context.save()
+            } catch {
+                logger.error("Failed to clear metadata enrichment: \(error.localizedDescription)")
             }
+        }.value
+    }
 
-            try context.save()
-        } catch {
-            logger.error("Failed to clear metadata enrichment: \(error.localizedDescription)")
+    private nonisolated static func clearEnrichment(of movie: Movie, in context: ModelContext) {
+        // Clearing the relationship array only disassociates the rows; delete
+        // them explicitly so the orphaned cast doesn't linger and keep
+        // occupying the store.
+        for cast in movie.castMembers {
+            context.delete(cast)
         }
+        movie.backdropPath = nil
+        movie.logoPath = nil
+        movie.tagline = nil
+        movie.contentRating = nil
+        movie.tmdbEnrichedAt = nil
+        movie.similarTMDBIds = []
+        movie.trailersData = nil
+        movie.imdbId = nil
+        movie.externalRatingsData = nil
+        movie.ratingsEnrichedAt = nil
+        movie.collectionId = nil
+        movie.collectionName = nil
+        movie.collectionPosterPath = nil
+        movie.collectionBackdropPath = nil
+    }
+
+    private nonisolated static func clearEnrichment(of show: Series, in context: ModelContext) {
+        for cast in show.castMembers {
+            context.delete(cast)
+        }
+        show.backdropPath = nil
+        show.logoPath = nil
+        show.tagline = nil
+        show.contentRating = nil
+        show.tmdbEnrichedAt = nil
+        show.similarTMDBIds = []
+        show.trailersData = nil
+        show.imdbId = nil
+        show.externalRatingsData = nil
+        show.ratingsEnrichedAt = nil
     }
 
     /// Wipes the active profile's watch history: resets `watchProgress`,
@@ -133,51 +153,60 @@ enum StorageManager {
     /// `lastWatchedDate` on every series and channel. Favorites, watchlist and
     /// recommendation votes are left untouched.
     ///
-    /// Runs on the passed-in (main) context — like `clearMetadataEnrichment` —
-    /// so the Continue Watching / Recently Watched rows update immediately. The
-    /// iCloud reconciler picks up the cleared local state on its next pass and
+    /// Runs on a private background context — like `clearMetadataEnrichment` —
+    /// whose saves merge back into the main context, so the Continue Watching /
+    /// Recently Watched rows still update as soon as they land. The iCloud
+    /// reconciler picks up the cleared local state on its next pass and
     /// mirrors the reset to CloudKit (and thus the user's other devices), the
     /// same way an individual "remove from recently watched" does. The
     /// `#Predicate` filters keep only rows that actually carry watch state out of
     /// the fetch, so an untouched catalog isn't hydrated wholesale.
-    static func clearWatchHistory(in context: ModelContext) {
-        do {
-            let movies = try context.fetch(FetchDescriptor<Movie>(
-                predicate: #Predicate { $0.watchProgress != 0 || $0.isWatched || $0.lastWatchedDate != nil }
-            ))
-            for movie in movies {
-                movie.watchProgress = 0
-                movie.isWatched = false
-                movie.lastWatchedDate = nil
-            }
+    static func clearWatchHistory(container: ModelContainer) async {
+        await Task.detached(priority: .userInitiated) {
+            let context = ModelContext(container)
+            context.autosaveEnabled = false
+            do {
+                let movies = try context.fetch(FetchDescriptor<Movie>(
+                    predicate: #Predicate { $0.watchProgress != 0 || $0.isWatched || $0.lastWatchedDate != nil }
+                ))
+                for (index, movie) in movies.enumerated() {
+                    movie.watchProgress = 0
+                    movie.isWatched = false
+                    movie.lastWatchedDate = nil
+                    if (index + 1).isMultiple(of: clearBatchSize) { try context.save() }
+                }
+                try context.save()
 
-            let episodes = try context.fetch(FetchDescriptor<Episode>(
-                predicate: #Predicate { $0.watchProgress != 0 || $0.isWatched || $0.lastWatchedDate != nil }
-            ))
-            for episode in episodes {
-                episode.watchProgress = 0
-                episode.isWatched = false
-                episode.lastWatchedDate = nil
-            }
+                let episodes = try context.fetch(FetchDescriptor<Episode>(
+                    predicate: #Predicate { $0.watchProgress != 0 || $0.isWatched || $0.lastWatchedDate != nil }
+                ))
+                for (index, episode) in episodes.enumerated() {
+                    episode.watchProgress = 0
+                    episode.isWatched = false
+                    episode.lastWatchedDate = nil
+                    if (index + 1).isMultiple(of: clearBatchSize) { try context.save() }
+                }
+                try context.save()
 
-            let series = try context.fetch(FetchDescriptor<Series>(
-                predicate: #Predicate { $0.lastWatchedDate != nil }
-            ))
-            for show in series {
-                show.lastWatchedDate = nil
-            }
+                let series = try context.fetch(FetchDescriptor<Series>(
+                    predicate: #Predicate { $0.lastWatchedDate != nil }
+                ))
+                for show in series {
+                    show.lastWatchedDate = nil
+                }
 
-            let channels = try context.fetch(FetchDescriptor<LiveStream>(
-                predicate: #Predicate { $0.lastWatchedDate != nil }
-            ))
-            for channel in channels {
-                channel.lastWatchedDate = nil
-            }
+                let channels = try context.fetch(FetchDescriptor<LiveStream>(
+                    predicate: #Predicate { $0.lastWatchedDate != nil }
+                ))
+                for channel in channels {
+                    channel.lastWatchedDate = nil
+                }
 
-            try context.save()
-        } catch {
-            logger.error("Failed to clear watch history: \(error.localizedDescription)")
-        }
+                try context.save()
+            } catch {
+                logger.error("Failed to clear watch history: \(error.localizedDescription)")
+            }
+        }.value
     }
 
     #if DEBUG
@@ -186,31 +215,35 @@ enum StorageManager {
         /// resolved `tmdbId` links and each title's `indexedAt` stamp — so the
         /// next indexing pass rebuilds everything from scratch. Used to exercise
         /// the indexer during development.
-        static func clearIndex(in context: ModelContext) {
-            clearMetadataEnrichment(in: context)
-            do {
-                let movies = try context.fetch(FetchDescriptor<Movie>(
-                    predicate: #Predicate { $0.indexedAt != nil || $0.embeddingData != nil || $0.tmdbId != nil }
-                ))
-                for movie in movies {
-                    movie.tmdbId = nil
-                    movie.embeddingData = nil
-                    movie.indexedAt = nil
-                }
+        static func clearIndex(container: ModelContainer) async {
+            await clearMetadataEnrichment(container: container)
+            await Task.detached(priority: .userInitiated) {
+                let context = ModelContext(container)
+                context.autosaveEnabled = false
+                do {
+                    let movies = try context.fetch(FetchDescriptor<Movie>(
+                        predicate: #Predicate { $0.indexedAt != nil || $0.embeddingData != nil || $0.tmdbId != nil }
+                    ))
+                    for movie in movies {
+                        movie.tmdbId = nil
+                        movie.embeddingData = nil
+                        movie.indexedAt = nil
+                    }
 
-                let series = try context.fetch(FetchDescriptor<Series>(
-                    predicate: #Predicate { $0.indexedAt != nil || $0.embeddingData != nil || $0.tmdbId != nil }
-                ))
-                for show in series {
-                    show.tmdbId = nil
-                    show.embeddingData = nil
-                    show.indexedAt = nil
-                }
+                    let series = try context.fetch(FetchDescriptor<Series>(
+                        predicate: #Predicate { $0.indexedAt != nil || $0.embeddingData != nil || $0.tmdbId != nil }
+                    ))
+                    for show in series {
+                        show.tmdbId = nil
+                        show.embeddingData = nil
+                        show.indexedAt = nil
+                    }
 
-                try context.save()
-            } catch {
-                logger.error("Failed to clear index: \(error.localizedDescription)")
-            }
+                    try context.save()
+                } catch {
+                    logger.error("Failed to clear index: \(error.localizedDescription)")
+                }
+            }.value
         }
     #endif
 

--- a/Lume/Services/Sync/ContentSyncManager+Stalker.swift
+++ b/Lume/Services/Sync/ContentSyncManager+Stalker.swift
@@ -106,18 +106,39 @@ extension ContentSyncManager {
         var seenIds = Set<String>()
         var imported = 0
 
+        // Accumulate items across categories and save in fixed-size batches
+        // (mirroring `syncStalkerChannels` and the Xtream/m3u pipelines).
+        // Saving once per category produced one main-context merge — and the
+        // browse-view `@Query` re-evaluation it triggers — per category, which
+        // adds up on portals with many small categories.
+        let batchSize = 2000
+        var pending: [(item: StalkerVODItem, categoryId: String)] = []
+
         for category in categories where !category.id.isEmpty {
             try Task.checkCancellation()
             let items = await (try? client.getAllOrderedItems(type: "vod", categoryId: category.id)) ?? []
             guard !items.isEmpty else { continue }
 
+            pending.append(contentsOf: items.map { (item: $0, categoryId: category.id) })
+            while pending.count >= batchSize {
+                let batch = Array(pending.prefix(batchSize))
+                pending.removeFirst(batchSize)
+                autoreleasepool {
+                    imported += upsertStalkerMovies(
+                        batch, playlistPrefix: playlistPrefix,
+                        playlistId: playlistId, seenIds: &seenIds
+                    )
+                }
+            }
+            await progress?.update(detail: "\(imported + pending.count) items")
+        }
+        if !pending.isEmpty {
             autoreleasepool {
                 imported += upsertStalkerMovies(
-                    items, categoryId: category.id, playlistPrefix: playlistPrefix,
+                    pending, playlistPrefix: playlistPrefix,
                     playlistId: playlistId, seenIds: &seenIds
                 )
             }
-            await progress?.update(detail: "\(imported) items")
         }
 
         if !seenIds.isEmpty {
@@ -127,19 +148,18 @@ extension ContentSyncManager {
         await progress?.complete(.movies)
     }
 
-    /// Upserts one category's worth of VOD items on a fresh context and returns
-    /// how many were imported.
+    /// Upserts one batch of VOD items (each carrying its category) on a fresh
+    /// context and returns how many were imported.
     private func upsertStalkerMovies(
-        _ items: [StalkerVODItem],
-        categoryId: String,
+        _ items: [(item: StalkerVODItem, categoryId: String)],
         playlistPrefix: String,
         playlistId: UUID,
         seenIds: inout Set<String>
     ) -> Int {
         let context = ModelContext(modelContainer)
         context.autosaveEnabled = false
-        let ids = items.compactMap { item -> String? in
-            guard let stalkerId = item.id else { return nil }
+        let ids = items.compactMap { entry -> String? in
+            guard let stalkerId = entry.item.id else { return nil }
             return "\(playlistId.uuidString)-movie-\(Self.streamId(for: stalkerId))"
         }
         var existing: [String: Movie] = [:]
@@ -151,7 +171,7 @@ extension ContentSyncManager {
         }
 
         var imported = 0
-        for item in items {
+        for (item, categoryId) in items {
             guard let stalkerId = item.id, let cmd = item.cmd else { continue }
             let streamId = Self.streamId(for: stalkerId)
             let movieId = "\(playlistId.uuidString)-movie-\(streamId)"
@@ -190,49 +210,37 @@ extension ContentSyncManager {
         var seenIds = Set<String>()
         var imported = 0
 
+        // Same cross-category batching as `syncStalkerMovies`, for the same
+        // reason: one save (and main-context merge) per fixed-size batch
+        // instead of one per category.
+        let batchSize = 2000
+        var pending: [(item: StalkerVODItem, categoryId: String)] = []
+
         for category in categories where !category.id.isEmpty {
             try Task.checkCancellation()
             let items = await (try? client.getAllOrderedItems(type: "series", categoryId: category.id)) ?? []
             guard !items.isEmpty else { continue }
 
-            try autoreleasepool {
-                let context = ModelContext(modelContainer)
-                context.autosaveEnabled = false
-                let ids = items.compactMap { item -> String? in
-                    guard let stalkerId = item.id else { return nil }
-                    return "\(playlistId.uuidString)-series-\(Self.streamId(for: stalkerId))"
+            pending.append(contentsOf: items.map { (item: $0, categoryId: category.id) })
+            while pending.count >= batchSize {
+                let batch = Array(pending.prefix(batchSize))
+                pending.removeFirst(batchSize)
+                autoreleasepool {
+                    imported += upsertStalkerSeries(
+                        batch, playlistPrefix: playlistPrefix,
+                        playlistId: playlistId, seenIds: &seenIds
+                    )
                 }
-                var existing: [String: Series] = [:]
-                let fetched = (try? context.fetch(
-                    FetchDescriptor<Series>(predicate: #Predicate { ids.contains($0.id) })
-                )) ?? []
-                for series in fetched {
-                    existing[series.id] = series
-                }
-
-                for item in items {
-                    guard let stalkerId = item.id else { continue }
-                    let seriesId = Self.streamId(for: stalkerId)
-                    let id = "\(playlistId.uuidString)-series-\(seriesId)"
-                    seenIds.insert(id)
-
-                    let series: Series
-                    if let found = existing[id] {
-                        series = found
-                    } else {
-                        series = Series(id: id, seriesId: seriesId, name: "")
-                        context.insert(series)
-                    }
-                    series.name = item.name ?? ""
-                    series.cover = item.screenshot
-                    series.plot = item.description
-                    series.releaseDate = item.year
-                    series.categoryId = playlistPrefix + category.id
-                    imported += 1
-                }
-                try context.save()
             }
-            await progress?.update(detail: "\(imported) items")
+            await progress?.update(detail: "\(imported + pending.count) items")
+        }
+        if !pending.isEmpty {
+            autoreleasepool {
+                imported += upsertStalkerSeries(
+                    pending, playlistPrefix: playlistPrefix,
+                    playlistId: playlistId, seenIds: &seenIds
+                )
+            }
         }
 
         if !seenIds.isEmpty {
@@ -240,6 +248,53 @@ extension ContentSyncManager {
         }
         Logger.database.info("Stalker: synced \(imported) series")
         await progress?.complete(.series)
+    }
+
+    /// Upserts one batch of series items (each carrying its category) on a
+    /// fresh context and returns how many were imported.
+    private func upsertStalkerSeries(
+        _ items: [(item: StalkerVODItem, categoryId: String)],
+        playlistPrefix: String,
+        playlistId: UUID,
+        seenIds: inout Set<String>
+    ) -> Int {
+        let context = ModelContext(modelContainer)
+        context.autosaveEnabled = false
+        let ids = items.compactMap { entry -> String? in
+            guard let stalkerId = entry.item.id else { return nil }
+            return "\(playlistId.uuidString)-series-\(Self.streamId(for: stalkerId))"
+        }
+        var existing: [String: Series] = [:]
+        let fetched = (try? context.fetch(
+            FetchDescriptor<Series>(predicate: #Predicate { ids.contains($0.id) })
+        )) ?? []
+        for series in fetched {
+            existing[series.id] = series
+        }
+
+        var imported = 0
+        for (item, categoryId) in items {
+            guard let stalkerId = item.id else { continue }
+            let seriesId = Self.streamId(for: stalkerId)
+            let id = "\(playlistId.uuidString)-series-\(seriesId)"
+            seenIds.insert(id)
+
+            let series: Series
+            if let found = existing[id] {
+                series = found
+            } else {
+                series = Series(id: id, seriesId: seriesId, name: "")
+                context.insert(series)
+            }
+            series.name = item.name ?? ""
+            series.cover = item.screenshot
+            series.plot = item.description
+            series.releaseDate = item.year
+            series.categoryId = playlistPrefix + categoryId
+            imported += 1
+        }
+        try? context.save()
+        return imported
     }
 
     /// Fetches a Stalker series' episodes on demand (the series detail screen

--- a/Lume/Views/Home/HomeHeroCarousel.swift
+++ b/Lume/Views/Home/HomeHeroCarousel.swift
@@ -20,6 +20,9 @@ struct HomeHeroCarousel: View {
 
     @State private var currentID: String?
     @State private var isInteracting = false
+    /// False while the hero is scrolled out of view, so the carousel doesn't
+    /// page (and animate the crossfade + loading bar) where nobody can see it.
+    @State private var isVisible = true
 
     /// Fill of the active page indicator (0…1). Driven by `autoAdvance()` and
     /// reset on every page change, it doubles as the auto-advance clock so the
@@ -133,6 +136,9 @@ struct HomeHeroCarousel: View {
         .task(id: items.count) {
             await autoAdvance()
         }
+        .onScrollVisibilityChange { visible in
+            isVisible = visible
+        }
     }
 
     /// Warms the cache for the slides on either side so they appear instantly.
@@ -238,7 +244,10 @@ struct HomeHeroCarousel: View {
             // let go fired `advance()` immediately — off a still-settling
             // `currentID` — which read as random forward/backward jumps. Keeping
             // it at zero guarantees a full dwell on the slide they land on.
-            if isInteracting {
+            // Same hold while scrolled off-screen (mirroring tvOS's fold pause):
+            // no paging, prefetching or crossfades where nobody can see them,
+            // and a full dwell once the hero scrolls back into view.
+            if isInteracting || !isVisible {
                 progress = 0
                 continue
             }

--- a/Lume/Views/Player/VLCPlayerCoordinator+Diagnostics.swift
+++ b/Lume/Views/Player/VLCPlayerCoordinator+Diagnostics.swift
@@ -32,6 +32,9 @@ extension VLCPlayerCoordinator {
             let timer = Timer(timeInterval: 2, repeats: true) { [weak self] _ in
                 self?.logStreamHealth()
             }
+            // Diagnostic sampling doesn't need exact firing; a tolerance lets
+            // the system coalesce the wake-up with other timers.
+            timer.tolerance = 0.2
             // Common mode so sampling continues during scrolling / tracking
             // runloop activity in the player UI.
             RunLoop.main.add(timer, forMode: .common)

--- a/Lume/Views/Settings/StorageManagementView.swift
+++ b/Lume/Views/Settings/StorageManagementView.swift
@@ -51,13 +51,13 @@ struct StorageManagementView: View {
         case .imageCache:
             await StorageManager.clearImageCache()
         case .metadata:
-            StorageManager.clearMetadataEnrichment(in: modelContext)
+            await StorageManager.clearMetadataEnrichment(container: modelContext.container)
         case .watchHistory:
-            StorageManager.clearWatchHistory(in: modelContext)
+            await StorageManager.clearWatchHistory(container: modelContext.container)
         #if DEBUG
             case .index:
                 indexing.reset()
-                StorageManager.clearIndex(in: modelContext)
+                await StorageManager.clearIndex(container: modelContext.container)
                 indexing.kick()
         #endif
         }

--- a/LumeTests/Services/StorageManagerTests.swift
+++ b/LumeTests/Services/StorageManagerTests.swift
@@ -28,7 +28,7 @@ struct StorageManagerTests {
         #expect(stats.channelCount == 1)
     }
 
-    @Test func `clearMetadataEnrichment resets enrichment but keeps the title`() throws {
+    @Test func `clearMetadataEnrichment resets enrichment but keeps the title`() async throws {
         let container = try makeTestContainer()
         let context = container.mainContext
 
@@ -51,10 +51,14 @@ struct StorageManagerTests {
         context.insert(CastMember(id: "m1-cast-0", tmdbPersonId: 5, name: "Actor", order: 0, movie: movie))
         try context.save()
 
-        StorageManager.clearMetadataEnrichment(in: context)
+        await StorageManager.clearMetadataEnrichment(container: container)
 
+        // Verify against a fresh context: the clear ran on its own background
+        // context, and the main context's registered objects may not have
+        // merged the change yet.
+        let verifyContext = ModelContext(container)
         let refetched = try #require(
-            try context.fetch(FetchDescriptor<Movie>(predicate: #Predicate { $0.id == "m1" })).first
+            try verifyContext.fetch(FetchDescriptor<Movie>(predicate: #Predicate { $0.id == "m1" })).first
         )
         // Title and user data survive.
         #expect(refetched.name == "Keep Me")
@@ -75,7 +79,7 @@ struct StorageManagerTests {
         #expect(refetched.collectionName == nil)
         #expect(refetched.castMembers.isEmpty)
 
-        let remainingCast = try context.fetch(FetchDescriptor<CastMember>())
+        let remainingCast = try verifyContext.fetch(FetchDescriptor<CastMember>())
         #expect(remainingCast.isEmpty)
     }
 }


### PR DESCRIPTION
Part 4 of the July 2026 performance-audit backlog (Phase 3 — background work & energy). Four independent fixes, one commit each.

## 1. Settings clear operations off the main context

`clearMetadataEnrichment` hydrated and mutated every enriched title — cascade-deleting cast rows one by one — synchronously on the main context; `clearWatchHistory` did the same for every row carrying watch state. On a large library, tapping either Settings button froze the UI for seconds. Both (plus the DEBUG `clearIndex`) now run on a private background context with saves chunked every 1000 rows; the merges propagate back to the main context so browse views still update. The existing `StorageManagerTests` were adapted to the async signatures and pass.

## 2. Stalker VOD/series batch saves

The Stalker movie and series pipelines saved once per category, unlike the Xtream/m3u pipelines and Stalker's own channels path (2000-item batches). Each save forces a main-context merge plus the browse-view `@Query` re-evaluation it triggers — costly on portals with many small categories. Items now accumulate across categories and flush in strict 2000-item batches (each item carries its category id).

## 3. Content indexer stays off expensive networks

A full-library indexing pass issues one TMDB request per unindexed title and nobody waits on it. The indexer's client now uses a session with `allowsExpensiveNetworkAccess`/`allowsConstrainedNetworkAccess` disabled — no metered data burned on cellular/hotspot or Low Data Mode. On cellular-only, requests fail fast and the run retries on the next kick (deliberately no `waitsForConnectivity`, which would wedge the run loop). Detail-screen enrichment keeps the unconstrained shared session. (The audit also named OMDb here, but the indexer never touches OMDb — only TMDB.)

## 4. iOS hero auto-advance pauses off-screen

The carousel's 50 ms tick loop kept paging, crossfading and prefetching artwork while scrolled out of view. Now gated on `onScrollVisibilityChange`, holding the progress bar at zero exactly like the existing user-interaction pause — mirroring the fold pause the tvOS hero already has.

## Audit findings rejected during implementation

- **`remote-notification` background mode is NOT vestigial** — the energy audit flagged it as dead (no `registerForRemoteNotifications` in app code), but CloudKit delivers sync change notifications as silent pushes that the SwiftData/NSPersistentCloudKitContainer stack registers for internally. Removing the mode would degrade iCloud sync wake-ups. Kept.
- **tvOS hero auto-advance was already gated** — `TVHomeScreen` wires `model.isPaused = zone != .expanded` and the tick holds at zero below the fold. No change needed.

Plus a drive-by: the DEBUG-only VLC stats timer gets a `.tolerance` so Debug-build sampling can coalesce wake-ups.

## Testing
- iOS + tvOS Simulator builds ✅
- `StorageManagerTests` (updated for async) + `ContentSyncManagerLogicTests` ✅ (15 passes)
- SwiftFormat/SwiftLint pre-commit gates ✅ (the clear-enrichment field reset moved into helpers to satisfy the function-body cap)