### PR TITLE
feat(ui): add Home Screen widgets and tvOS Top Shelf

### DIFF
--- a/Lume.xcodeproj/project.pbxproj
+++ b/Lume.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		C6AA10012FDD00010000AA01 /* LumeEngine in Frameworks */ = {isa = PBXBuildFile; productRef = C6AA10022FDD00010000AA02 /* LumeEngine */; };
 		C6AA10042FDD00010000AA04 /* LumeEngine in Embed Frameworks */ = {isa = PBXBuildFile; productRef = C6AA10022FDD00010000AA02 /* LumeEngine */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C6FF000A2FC5A59D00484601 /* VLCKitSPM in Frameworks */ = {isa = PBXBuildFile; productRef = C6FF000B2FC5A59D00484602 /* VLCKitSPM */; };
+		C6BD5701000000000000F002 /* LumeWidgets.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = C6BD5701000000000000A001 /* LumeWidgets.appex */; platformFilters = (ios, macos, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		C6BD5701000000000000F003 /* LumeTopShelf.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = C6BD5701000000000000A002 /* LumeTopShelf.appex */; platformFilters = (tvos, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -28,6 +30,20 @@
 			remoteGlobalIDString = C67C02BF2F880F2200842DBA;
 			remoteInfo = Lume;
 		};
+		C6BD5701000000000000F004 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C67C02B82F880F2200842DBA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C6BD5701000000000000D001;
+			remoteInfo = LumeWidgets;
+		};
+		C6BD5701000000000000F005 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C67C02B82F880F2200842DBA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C6BD5701000000000000E001;
+			remoteInfo = LumeTopShelf;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -35,6 +51,8 @@
 		C67C02C02F880F2200842DBA /* Lume.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lume.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C67C02D12F880F2400842DBA /* LumeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LumeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C67C02DB2F880F2400842DBA /* LumeUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LumeUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6BD5701000000000000A001 /* LumeWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LumeWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6BD5701000000000000A002 /* LumeTopShelf.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LumeTopShelf.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -44,6 +62,20 @@
 				Info.plist,
 			);
 			target = C67C02BF2F880F2200842DBA /* Lume */;
+		};
+		C6BD5701000000000000C001 /* Exceptions for "LumeWidgets" folder in "LumeWidgets" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = C6BD5701000000000000D001 /* LumeWidgets */;
+		};
+		C6BD5701000000000000C002 /* Exceptions for "LumeTopShelf" folder in "LumeTopShelf" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = C6BD5701000000000000E001 /* LumeTopShelf */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -64,6 +96,27 @@
 		C67C02DE2F880F2400842DBA /* LumeUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = LumeUITests;
+			sourceTree = "<group>";
+		};
+		C6BD5701000000000000B001 /* LumeShared */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = LumeShared;
+			sourceTree = "<group>";
+		};
+		C6BD5701000000000000B002 /* LumeWidgets */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				C6BD5701000000000000C001 /* Exceptions for "LumeWidgets" folder in "LumeWidgets" target */,
+			);
+			path = LumeWidgets;
+			sourceTree = "<group>";
+		};
+		C6BD5701000000000000B003 /* LumeTopShelf */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				C6BD5701000000000000C002 /* Exceptions for "LumeTopShelf" folder in "LumeTopShelf" target */,
+			);
+			path = LumeTopShelf;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -93,6 +146,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C6BD5701000000000000D004 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6BD5701000000000000E004 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -103,6 +170,9 @@
 				C67C02C22F880F2200842DBA /* Lume */,
 				C67C02D42F880F2400842DBA /* LumeTests */,
 				C67C02DE2F880F2400842DBA /* LumeUITests */,
+				C6BD5701000000000000B001 /* LumeShared */,
+				C6BD5701000000000000B002 /* LumeWidgets */,
+				C6BD5701000000000000B003 /* LumeTopShelf */,
 				C67C02C12F880F2200842DBA /* Products */,
 			);
 			sourceTree = "<group>";
@@ -113,6 +183,8 @@
 				C67C02C02F880F2200842DBA /* Lume.app */,
 				C67C02D12F880F2400842DBA /* LumeTests.xctest */,
 				C67C02DB2F880F2400842DBA /* LumeUITests.xctest */,
+				C6BD5701000000000000A001 /* LumeWidgets.appex */,
+				C6BD5701000000000000A002 /* LumeTopShelf.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -129,14 +201,18 @@
 				C67C02BD2F880F2200842DBA /* Frameworks */,
 				C67C02BE2F880F2200842DBA /* Resources */,
 				C6AA10052FDD00010000AA05 /* Embed Frameworks */,
+				C6BD5701000000000000F001 /* Embed Foundation Extensions */,
 				C6FEED020000000000000002 /* Inject .env secrets */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				C6BD5701000000000000F006 /* PBXTargetDependency */,
+				C6BD5701000000000000F007 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				C67C02C22F880F2200842DBA /* Lume */,
+				C6BD5701000000000000B001 /* LumeShared */,
 			);
 			name = Lume;
 			packageProductDependencies = (
@@ -194,6 +270,52 @@
 			productReference = C67C02DB2F880F2400842DBA /* LumeUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		C6BD5701000000000000D001 /* LumeWidgets */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C6BD5701000000000000D002 /* Build configuration list for PBXNativeTarget "LumeWidgets" */;
+			buildPhases = (
+				C6BD5701000000000000D003 /* Sources */,
+				C6BD5701000000000000D004 /* Frameworks */,
+				C6BD5701000000000000D005 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				C6BD5701000000000000B002 /* LumeWidgets */,
+				C6BD5701000000000000B001 /* LumeShared */,
+			);
+			name = LumeWidgets;
+			packageProductDependencies = (
+			);
+			productName = LumeWidgets;
+			productReference = C6BD5701000000000000A001 /* LumeWidgets.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		C6BD5701000000000000E001 /* LumeTopShelf */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C6BD5701000000000000E002 /* Build configuration list for PBXNativeTarget "LumeTopShelf" */;
+			buildPhases = (
+				C6BD5701000000000000E003 /* Sources */,
+				C6BD5701000000000000E004 /* Frameworks */,
+				C6BD5701000000000000E005 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				C6BD5701000000000000B003 /* LumeTopShelf */,
+				C6BD5701000000000000B001 /* LumeShared */,
+			);
+			name = LumeTopShelf;
+			packageProductDependencies = (
+			);
+			productName = LumeTopShelf;
+			productReference = C6BD5701000000000000A002 /* LumeTopShelf.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -214,6 +336,12 @@
 					C67C02DA2F880F2400842DBA = {
 						CreatedOnToolsVersion = 26.4;
 						TestTargetID = C67C02BF2F880F2200842DBA;
+					};
+					C6BD5701000000000000D001 = {
+						CreatedOnToolsVersion = 26.4;
+					};
+					C6BD5701000000000000E001 = {
+						CreatedOnToolsVersion = 26.4;
 					};
 				};
 			};
@@ -247,6 +375,8 @@
 				C67C02BF2F880F2200842DBA /* Lume */,
 				C67C02D02F880F2400842DBA /* LumeTests */,
 				C67C02DA2F880F2400842DBA /* LumeUITests */,
+				C6BD5701000000000000D001 /* LumeWidgets */,
+				C6BD5701000000000000E001 /* LumeTopShelf */,
 			);
 		};
 /* End PBXProject section */
@@ -273,6 +403,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C6BD5701000000000000D005 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6BD5701000000000000E005 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -285,6 +429,18 @@
 				C6AA10042FDD00010000AA04 /* LumeEngine in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6BD5701000000000000F001 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				C6BD5701000000000000F002 /* LumeWidgets.appex in Embed Foundation Extensions */,
+				C6BD5701000000000000F003 /* LumeTopShelf.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -354,6 +510,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C6BD5701000000000000D003 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6BD5701000000000000E003 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -366,6 +536,23 @@
 			isa = PBXTargetDependency;
 			target = C67C02BF2F880F2200842DBA /* Lume */;
 			targetProxy = C67C02DC2F880F2400842DBA /* PBXContainerItemProxy */;
+		};
+		C6BD5701000000000000F006 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+			);
+			target = C6BD5701000000000000D001 /* LumeWidgets */;
+			targetProxy = C6BD5701000000000000F004 /* PBXContainerItemProxy */;
+		};
+		C6BD5701000000000000F007 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilters = (
+				tvos,
+			);
+			target = C6BD5701000000000000E001 /* LumeTopShelf */;
+			targetProxy = C6BD5701000000000000F005 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -844,6 +1031,204 @@
 			};
 			name = Sideload;
 		};
+		C6BD5701000000000000D006 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = LumeWidgets/LumeWidgets.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 12;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				ENABLE_APP_SANDBOX = YES;
+				"ENABLE_APP_SANDBOX[sdk=macosx*]" = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LumeWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Lume;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.4.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bilipp.lume.widgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C6BD5701000000000000D007 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = LumeWidgets/LumeWidgets.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 12;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				ENABLE_APP_SANDBOX = YES;
+				"ENABLE_APP_SANDBOX[sdk=macosx*]" = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LumeWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Lume;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.4.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bilipp.lume.widgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		C6BD5701000000000000D008 /* Sideload */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = LumeWidgets/LumeWidgets.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 12;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				ENABLE_APP_SANDBOX = YES;
+				"ENABLE_APP_SANDBOX[sdk=macosx*]" = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LumeWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Lume;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.4.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bilipp.lume.widgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Sideload;
+		};
+		C6BD5701000000000000E006 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = LumeTopShelf/LumeTopShelf.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 12;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LumeTopShelf/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Lume;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.4.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bilipp.lume.topshelf;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 18.0;
+			};
+			name = Debug;
+		};
+		C6BD5701000000000000E007 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = LumeTopShelf/LumeTopShelf.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 12;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LumeTopShelf/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Lume;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.4.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bilipp.lume.topshelf;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 18.0;
+			};
+			name = Release;
+		};
+		C6BD5701000000000000E008 /* Sideload */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = LumeTopShelf/LumeTopShelf.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 12;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LumeTopShelf/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Lume;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.4.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bilipp.lume.topshelf;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 18.0;
+			};
+			name = Sideload;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -883,6 +1268,26 @@
 				C67C02ED2F880F2400842DBA /* Debug */,
 				C67C02EE2F880F2400842DBA /* Release */,
 				C67C02F42F880F2400842DBA /* Sideload */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C6BD5701000000000000D002 /* Build configuration list for PBXNativeTarget "LumeWidgets" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C6BD5701000000000000D006 /* Debug */,
+				C6BD5701000000000000D007 /* Release */,
+				C6BD5701000000000000D008 /* Sideload */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C6BD5701000000000000E002 /* Build configuration list for PBXNativeTarget "LumeTopShelf" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C6BD5701000000000000E006 /* Debug */,
+				C6BD5701000000000000E007 /* Release */,
+				C6BD5701000000000000E008 /* Sideload */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Lume/Lume.entitlements
+++ b/Lume/Lume.entitlements
@@ -16,6 +16,10 @@
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.bilipp.lume</string>
+	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>

--- a/Lume/LumeApp.swift
+++ b/Lume/LumeApp.swift
@@ -173,6 +173,16 @@ struct LumeApp: App {
 
     @Environment(\.scenePhase) private var scenePhase
 
+    /// Rebuilds the shared widget snapshot off the main actor. Cheap enough to
+    /// run on every launch and backgrounding: a handful of bounded fetches.
+    private func exportWidgetSnapshot() {
+        let container = catalogContainer
+        let isChild = profileManager.activeProfileIsChild
+        Task.detached(priority: .utility) {
+            WidgetSnapshotExporter.export(container: container, isChildProfile: isChild)
+        }
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -228,6 +238,10 @@ struct LumeApp: App {
                     // the content sync. No-ops when no guide is due yet.
                     EPGSyncService.shared.configure(container: catalogContainer)
                     EPGSyncService.shared.syncIfDue()
+
+                    // Seed the widget / Top Shelf snapshot once services are up
+                    // (after profile bootstrap, so the catalog is profile-scoped).
+                    exportWidgetSnapshot()
                 }
                 .onChange(of: scenePhase) { _, phase in
                     cloudSync.handleScenePhaseChange(to: phase)
@@ -242,6 +256,11 @@ struct LumeApp: App {
                             ImageMemoryCache.shared.purge(reason: "app backgrounded")
                         }
                     #endif
+                    // Leaving the foreground is the natural refresh point for
+                    // widgets: progress/favorites changed while the app was open.
+                    if phase == .background {
+                        exportWidgetSnapshot()
+                    }
                 }
         }
         .modelContainer(catalogContainer)

--- a/Lume/Services/DeepLink/DeepLink.swift
+++ b/Lume/Services/DeepLink/DeepLink.swift
@@ -3,7 +3,10 @@
 //  Lume
 //
 //  Custom URL-scheme deep links. `lume://movie/{tmdbId}` and
-//  `lume://series/{tmdbId}` open a title's detail screen directly.
+//  `lume://series/{tmdbId}` open a title's detail screen directly;
+//  `lume://play/{movie|episode|live}/{catalogId}` and
+//  `lume://open/series/{catalogId}` are emitted by the widgets / Top Shelf
+//  (built in `WidgetDeepLink`) and launch playback or a detail screen.
 //
 
 import Foundation
@@ -14,23 +17,48 @@ import Foundation
 nonisolated enum DeepLink: Equatable {
     case movie(tmdbId: Int)
     case series(tmdbId: Int)
+    case playMovie(id: String)
+    case playEpisode(id: String)
+    case playLive(id: String)
+    case openSeries(id: String)
 
     /// The app's registered URL scheme (see `CFBundleURLTypes` in Info.plist).
     static let scheme = "lume"
 
-    /// Parses `lume://movie/{tmdbId}` and `lume://series/{tmdbId}`. Returns nil
-    /// for any other scheme, an unknown kind, or a non-numeric id.
+    /// Parses every supported `lume://` form. Returns nil for any other scheme,
+    /// an unknown kind, or a malformed id.
     init?(url: URL) {
         guard url.scheme?.lowercased() == Self.scheme else { return nil }
         // For `lume://movie/123` the kind is the host and the id is the first
-        // path component; `pathComponents` includes the leading "/".
-        guard let idComponent = url.pathComponents.first(where: { $0 != "/" }),
-              let tmdbId = Int(idComponent)
-        else { return nil }
+        // path component; `pathComponents` includes the leading "/" and returns
+        // components percent-decoded (widget links encode their catalog ids).
+        let components = url.pathComponents.filter { $0 != "/" }
         switch url.host()?.lowercased() {
-        case "movie": self = .movie(tmdbId: tmdbId)
-        case "series": self = .series(tmdbId: tmdbId)
-        default: return nil
+        case "movie":
+            guard let tmdbId = components.first.flatMap(Int.init) else { return nil }
+            self = .movie(tmdbId: tmdbId)
+        case "series":
+            guard let tmdbId = components.first.flatMap(Int.init) else { return nil }
+            self = .series(tmdbId: tmdbId)
+        case "play":
+            guard let link = Self.play(components) else { return nil }
+            self = link
+        case "open":
+            guard components.count == 2, components[0].lowercased() == "series" else { return nil }
+            self = .openSeries(id: components[1])
+        default:
+            return nil
+        }
+    }
+
+    /// `play/{movie|episode|live}/{catalogId}` — built by `WidgetDeepLink.play`.
+    private static func play(_ components: [String]) -> DeepLink? {
+        guard components.count == 2 else { return nil }
+        return switch components[0].lowercased() {
+        case "movie": .playMovie(id: components[1])
+        case "episode": .playEpisode(id: components[1])
+        case "live": .playLive(id: components[1])
+        default: nil
         }
     }
 }

--- a/Lume/Services/Widgets/WidgetSnapshotExporter.swift
+++ b/Lume/Services/Widgets/WidgetSnapshotExporter.swift
@@ -1,0 +1,266 @@
+//
+//  WidgetSnapshotExporter.swift
+//  Lume
+//
+//  Builds the `WidgetSnapshot` the widgets and the tvOS Top Shelf render, and
+//  writes it to the shared App Group container. Extensions never query the
+//  catalog themselves — SwiftData stays app-only and the extension reads a
+//  small precomputed file instead (the reliable pattern for widget data).
+//
+//  Runs off the main actor on its own `ModelContext`, mirroring the Home
+//  screen's rails: Recently Watched (resumable movies + series), Favorites
+//  (unified `favoriteOrder`), and now/next EPG for favorite channels.
+//
+
+import Foundation
+import SwiftData
+#if os(iOS) || os(macOS)
+    import WidgetKit
+#endif
+
+enum WidgetSnapshotExporter {
+    private static let continueWatchingLimit = 10
+    private static let favoritesLimit = 12
+    private static let onNowLimit = 8
+
+    /// Exports a fresh snapshot for the active playlist/profile and reloads the
+    /// widget timelines.
+    nonisolated static func export(container: ModelContainer, isChildProfile: Bool, now: Date = Date()) {
+        let storedID = UserDefaults.standard.string(forKey: PlaylistSelectionStore.key) ?? ""
+        let snapshot = makeSnapshot(
+            container: container,
+            storedPlaylistID: storedID,
+            isChildProfile: isChildProfile,
+            now: now
+        )
+        try? WidgetDataStore.save(snapshot)
+        #if os(iOS) || os(macOS)
+            WidgetCenter.shared.reloadAllTimelines()
+        #endif
+    }
+
+    /// Builds the snapshot for the active playlist. Restricted categories stay
+    /// out of the snapshot while a child profile is active — a widget must not
+    /// leak hidden content. Internal (not private) so tests can build snapshots
+    /// without touching the App Group container.
+    nonisolated static func makeSnapshot(
+        container: ModelContainer,
+        storedPlaylistID: String,
+        isChildProfile: Bool,
+        now: Date = Date()
+    ) -> WidgetSnapshot {
+        let context = ModelContext(container)
+        let playlists = (try? context.fetch(FetchDescriptor<Playlist>())) ?? []
+        guard let playlist = playlists.active(for: storedPlaylistID) else {
+            var empty = WidgetSnapshot.empty
+            empty.generatedAt = now
+            return empty
+        }
+
+        let playlistPrefix = "\(playlist.id.uuidString)-"
+        let restriction = ContentRestriction(
+            isActive: isChildProfile,
+            restrictedCategoryIDs: isChildProfile ? restrictedCategoryIDs(in: context) : []
+        )
+
+        return WidgetSnapshot(
+            generatedAt: now,
+            continueWatching: continueWatching(in: context, prefix: playlistPrefix, restriction: restriction),
+            favorites: favorites(in: context, prefix: playlistPrefix, restriction: restriction),
+            onNow: onNow(in: context, container: container, prefix: playlistPrefix, restriction: restriction, now: now)
+        )
+    }
+
+    private nonisolated static func restrictedCategoryIDs(in context: ModelContext) -> Set<String> {
+        let descriptor = FetchDescriptor<Category>(predicate: #Predicate { $0.isRestricted })
+        let categories = (try? context.fetch(descriptor)) ?? []
+        return Set(categories.map(\.id))
+    }
+
+    // MARK: - Continue Watching
+
+    /// Resumable titles, most recently watched first: partially-watched movies
+    /// plus the in-progress episode of recently-watched series (the same resume
+    /// resolution as the Home rail, see `HomeMediaItem.progress`).
+    private nonisolated static func continueWatching(
+        in context: ModelContext,
+        prefix: String,
+        restriction: ContentRestriction
+    ) -> [WidgetMediaItem] {
+        let entries = resumableMovies(in: context, prefix: prefix, restriction: restriction)
+            + resumableEpisodes(in: context, prefix: prefix, restriction: restriction)
+        return entries
+            .sorted { $0.lastWatched > $1.lastWatched }
+            .prefix(continueWatchingLimit)
+            .map(\.item)
+    }
+
+    private nonisolated static func resumableMovies(
+        in context: ModelContext,
+        prefix: String,
+        restriction: ContentRestriction
+    ) -> [(lastWatched: Date, item: WidgetMediaItem)] {
+        var entries: [(lastWatched: Date, item: WidgetMediaItem)] = []
+
+        var movieDescriptor = FetchDescriptor<Movie>(
+            predicate: #Predicate { $0.lastWatchedDate != nil && !$0.isWatched && $0.watchProgress > 0 },
+            sortBy: [SortDescriptor(\.lastWatchedDate, order: .reverse)]
+        )
+        movieDescriptor.fetchLimit = 30
+        let movies = (try? context.fetch(movieDescriptor)) ?? []
+        for movie in movies where movie.id.hasPrefix(prefix) && !restriction.hides(categoryID: movie.categoryId) {
+            guard let lastWatched = movie.lastWatchedDate,
+                  let deepLink = WidgetDeepLink.play(kind: .movie, id: movie.id) else { continue }
+            var progress: Double?
+            if let duration = movie.durationSecs, duration > 0 {
+                progress = min(movie.watchProgress / Double(duration), 1)
+            }
+            entries.append((lastWatched, WidgetMediaItem(
+                id: "movie-\(movie.id)",
+                kind: .movie,
+                title: movie.name,
+                subtitle: movie.releaseDate,
+                imageURL: URL(string: movie.streamIcon ?? ""),
+                progress: progress,
+                deepLink: deepLink
+            )))
+        }
+        return entries
+    }
+
+    private nonisolated static func resumableEpisodes(
+        in context: ModelContext,
+        prefix: String,
+        restriction: ContentRestriction
+    ) -> [(lastWatched: Date, item: WidgetMediaItem)] {
+        var entries: [(lastWatched: Date, item: WidgetMediaItem)] = []
+
+        var seriesDescriptor = FetchDescriptor<Series>(
+            predicate: #Predicate { $0.lastWatchedDate != nil },
+            sortBy: [SortDescriptor(\.lastWatchedDate, order: .reverse)]
+        )
+        seriesDescriptor.fetchLimit = 30
+        let series = (try? context.fetch(seriesDescriptor)) ?? []
+        for show in series where show.id.hasPrefix(prefix) && !restriction.hides(categoryID: show.categoryId) {
+            let inProgress = show.episodes
+                .filter { $0.watchProgress > 0 && !$0.isWatched }
+                .sorted { ($0.lastWatchedDate ?? .distantPast) > ($1.lastWatchedDate ?? .distantPast) }
+            guard let episode = inProgress.first,
+                  let lastWatched = show.lastWatchedDate,
+                  let deepLink = WidgetDeepLink.play(kind: .episode, id: episode.id) else { continue }
+            var progress: Double?
+            if let duration = episode.durationSecs, duration > 0 {
+                progress = min(episode.watchProgress / Double(duration), 1)
+            }
+            entries.append((lastWatched, WidgetMediaItem(
+                id: "episode-\(episode.id)",
+                kind: .episode,
+                title: show.name,
+                subtitle: "S\(episode.seasonNum) E\(episode.episodeNum) · \(episode.title)",
+                imageURL: URL(string: show.cover ?? episode.movieImage ?? ""),
+                progress: progress,
+                deepLink: deepLink
+            )))
+        }
+        return entries
+    }
+
+    // MARK: - Favorites
+
+    /// Favorite movies, series and channels interleaved by the user's unified
+    /// `favoriteOrder` (nil orders last, then alphabetical — same as Home).
+    private nonisolated static func favorites(
+        in context: ModelContext,
+        prefix: String,
+        restriction: ContentRestriction
+    ) -> [WidgetMediaItem] {
+        var entries: [(order: Int, item: WidgetMediaItem)] = []
+
+        let movies = (try? context.fetch(FetchDescriptor<Movie>(predicate: #Predicate { $0.isFavorite }))) ?? []
+        for movie in movies where movie.id.hasPrefix(prefix) && !restriction.hides(categoryID: movie.categoryId) {
+            guard let deepLink = WidgetDeepLink.play(kind: .movie, id: movie.id) else { continue }
+            entries.append((movie.favoriteOrder ?? Int.max, WidgetMediaItem(
+                id: "movie-\(movie.id)",
+                kind: .movie,
+                title: movie.name,
+                subtitle: nil,
+                imageURL: URL(string: movie.streamIcon ?? ""),
+                progress: nil,
+                deepLink: deepLink
+            )))
+        }
+
+        let series = (try? context.fetch(FetchDescriptor<Series>(predicate: #Predicate { $0.isFavorite }))) ?? []
+        for show in series where show.id.hasPrefix(prefix) && !restriction.hides(categoryID: show.categoryId) {
+            guard let deepLink = WidgetDeepLink.openSeries(id: show.id) else { continue }
+            entries.append((show.favoriteOrder ?? Int.max, WidgetMediaItem(
+                id: "series-\(show.id)",
+                kind: .series,
+                title: show.name,
+                subtitle: nil,
+                imageURL: URL(string: show.cover ?? ""),
+                progress: nil,
+                deepLink: deepLink
+            )))
+        }
+
+        let streams = (try? context.fetch(FetchDescriptor<LiveStream>(predicate: #Predicate { $0.isFavorite }))) ?? []
+        for stream in streams where stream.id.hasPrefix(prefix) && !restriction.hides(categoryID: stream.categoryId) {
+            guard let deepLink = WidgetDeepLink.play(kind: .live, id: stream.id) else { continue }
+            entries.append((stream.favoriteOrder ?? Int.max, WidgetMediaItem(
+                id: "live-\(stream.id)",
+                kind: .live,
+                title: stream.name,
+                subtitle: nil,
+                imageURL: URL(string: stream.streamIcon ?? ""),
+                progress: nil,
+                deepLink: deepLink
+            )))
+        }
+
+        return entries
+            .sorted { ($0.order, $0.item.title) < ($1.order, $1.item.title) }
+            .prefix(favoritesLimit)
+            .map(\.item)
+    }
+
+    // MARK: - On Now
+
+    /// Now/next programmes for favorite channels, resolved through the same
+    /// indexed EPG fetch the channel list uses (`ChannelEPGLoader`). Channels
+    /// without guide data still appear — the widget shows them logo-only.
+    private nonisolated static func onNow(
+        in context: ModelContext,
+        container: ModelContainer,
+        prefix: String,
+        restriction: ContentRestriction,
+        now: Date
+    ) -> [WidgetChannelNow] {
+        let descriptor = FetchDescriptor<LiveStream>(
+            predicate: #Predicate { $0.isFavorite },
+            sortBy: [SortDescriptor(\.favoriteOrder), SortDescriptor(\.name)]
+        )
+        let streams = ((try? context.fetch(descriptor)) ?? [])
+            .filter { $0.id.hasPrefix(prefix) && !restriction.hides(categoryID: $0.categoryId) }
+            .prefix(onNowLimit)
+
+        let channelIds = streams.compactMap(\.epgChannelId)
+        let guide = ChannelEPGLoader.load(container: container, channelIds: channelIds, now: now)
+
+        return streams.compactMap { stream in
+            guard let deepLink = WidgetDeepLink.play(kind: .live, id: stream.id) else { return nil }
+            let epg = stream.epgChannelId.flatMap { guide[$0] }
+            return WidgetChannelNow(
+                id: stream.id,
+                channelName: stream.name,
+                logoURL: URL(string: stream.streamIcon ?? ""),
+                nowTitle: epg?.current?.title,
+                nowStart: epg?.current?.start,
+                nowEnd: epg?.current?.end,
+                nextTitle: epg?.next?.title,
+                nextStart: epg?.next?.start,
+                deepLink: deepLink
+            )
+        }
+    }
+}

--- a/Lume/Views/MainTabView.swift
+++ b/Lume/Views/MainTabView.swift
@@ -11,6 +11,9 @@ import SwiftUI
 struct MainTabView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.scenePhase) private var scenePhase
+    #if os(macOS)
+        @Environment(\.openWindow) private var openWindow
+    #endif
     // Optional so previews (which don't inject it) don't crash.
     @Environment(PlaylistSwitchModel.self) private var playlistSwitch: PlaylistSwitchModel?
     @Environment(ProfileManager.self) private var profileManager: ProfileManager?
@@ -25,6 +28,10 @@ struct MainTabView: View {
     /// Selected tab and the Movies/Series navigation stacks, shared so an
     /// `onOpenURL` deep link can switch tabs and push a detail screen.
     @State private var router = DeepLinkRouter()
+
+    /// Playback launched from a `lume://play/...` deep link (widgets, Top Shelf).
+    /// Presented here — not in HomeView — because the link can arrive on any tab.
+    @State private var playingMedia: PlayableMedia?
 
     /// Playlists waiting to be auto-synced, and the one currently shown in the
     /// blocking progress cover. Auto-sync is presented (not silent) so the user
@@ -86,6 +93,11 @@ struct MainTabView: View {
                     enqueueDueSyncs(playlists)
                 }
             }
+        #if os(iOS) || os(tvOS)
+            .fullScreenCover(item: $playingMedia) { media in
+                FullScreenPlayerView(media: media)
+            }
+        #endif
             .syncCover(item: $activeSyncPlaylist, onDismiss: promoteNextIfIdle)
             .overlay {
                 if playlistSwitch?.isSwitching == true {
@@ -183,8 +195,9 @@ struct MainTabView: View {
 
     /// Resolves a `lume://movie/{tmdbId}` / `lume://series/{tmdbId}` link to a
     /// catalog item, switches to the matching tab and pushes its detail screen.
-    /// Silently ignores unknown links and titles not present in the catalog
-    /// (e.g. a tmdbId that was never synced or enriched).
+    /// `play`/`open` links (from widgets and the Top Shelf) launch playback or
+    /// a detail screen by catalog id. Silently ignores unknown links and titles
+    /// not present in the catalog (e.g. a tmdbId that was never synced).
     private func handleDeepLink(_ url: URL) {
         guard let link = DeepLink(url: url) else { return }
         switch link {
@@ -195,10 +208,70 @@ struct MainTabView: View {
             router.moviesPath.append(movie)
         case let .series(tmdbId):
             guard let series = resolveSeries(tmdbId: tmdbId) else { return }
-            router.selectedTab = .series
-            router.seriesPath = NavigationPath()
-            router.seriesPath.append(series)
+            openSeriesDetail(series)
+        case .playMovie, .playEpisode, .playLive:
+            present(resolvePlayable(link))
+        case let .openSeries(id):
+            guard let series = fetchFirst(FetchDescriptor<Series>(predicate: #Predicate { $0.id == id })),
+                  !contentRestriction.hides(categoryID: series.categoryId) else { return }
+            openSeriesDetail(series)
         }
+    }
+
+    private func openSeriesDetail(_ series: Series) {
+        router.selectedTab = .series
+        router.seriesPath = NavigationPath()
+        router.seriesPath.append(series)
+    }
+
+    /// Resolves a `play` deep link to playable media: fetch the catalog item by
+    /// id, hide restricted categories from child profiles, find the owning
+    /// playlist and build the stream URL.
+    private func resolvePlayable(_ link: DeepLink) -> PlayableMedia? {
+        switch link {
+        case let .playMovie(id):
+            guard let movie = fetchFirst(FetchDescriptor<Movie>(predicate: #Predicate { $0.id == id })),
+                  !contentRestriction.hides(categoryID: movie.categoryId),
+                  let playlist = owningPlaylist(of: id) else { return nil }
+            return PlayableMedia.from(movie: movie, playlist: playlist)
+        case let .playEpisode(id):
+            guard let episode = fetchFirst(FetchDescriptor<Episode>(predicate: #Predicate { $0.id == id })),
+                  let playlist = owningPlaylist(of: id) else { return nil }
+            return PlayableMedia.from(episode: episode, playlist: playlist)
+        case let .playLive(id):
+            guard let stream = fetchFirst(FetchDescriptor<LiveStream>(predicate: #Predicate { $0.id == id })),
+                  !contentRestriction.hides(categoryID: stream.categoryId),
+                  let playlist = owningPlaylist(of: id) else { return nil }
+            return PlayableMedia.from(stream: stream, playlist: playlist)
+        default:
+            return nil
+        }
+    }
+
+    /// Starts playback of deep-linked media, mirroring the in-app play paths:
+    /// external player hand-off first, then a player window (macOS) or a
+    /// full-screen cover (iOS/tvOS).
+    private func present(_ media: PlayableMedia?) {
+        guard let media else { return }
+        if ExternalPlayback.open(media) { return }
+        #if os(macOS)
+            openWindow(id: "player", value: media)
+        #else
+            playingMedia = media
+        #endif
+    }
+
+    /// Fetches the first match of a catalog-id lookup.
+    private func fetchFirst<Model: PersistentModel>(_ descriptor: FetchDescriptor<Model>) -> Model? {
+        var descriptor = descriptor
+        descriptor.fetchLimit = 1
+        return try? modelContext.fetch(descriptor).first
+    }
+
+    /// The playlist that owns a catalog item — ids are prefixed with the owning
+    /// playlist's UUID (same convention as `NextEpisodeResolver.playlist(for:)`).
+    private func owningPlaylist(of id: String) -> Playlist? {
+        playlists.first { id.hasPrefix("\($0.id.uuidString)-") } ?? playlists.first
     }
 
     /// Finds a movie by `tmdbId`, preferring the active playlist but falling back

--- a/Lume/Views/Player/LumeEngineCoordinator.swift
+++ b/Lume/Views/Player/LumeEngineCoordinator.swift
@@ -293,7 +293,11 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
                 onRecovered?()
             }
             if state == .failed {
-                Logger.player.error("LumeEngine failed (hasStartedPlayback: \(hasStartedPlayback))")
+                // Local copy: the Logger interpolation is an autoclosure, and the
+                // `self.` it would need gets re-stripped by swiftformat's
+                // redundantSelf rule (same failure as f1432f8).
+                let hadStartedPlayback = hasStartedPlayback
+                Logger.player.error("LumeEngine failed (hasStartedPlayback: \(hadStartedPlayback))")
                 if hasStartedPlayback {
                     onStalled?()
                 } else {

--- a/LumeShared/WidgetDataStore.swift
+++ b/LumeShared/WidgetDataStore.swift
@@ -1,0 +1,66 @@
+//
+//  WidgetDataStore.swift
+//  LumeShared
+//
+//  Reads/writes the widget snapshot in the shared App Group container, and
+//  builds the `lume://` deep links widget taps launch the app with. Shared by
+//  the app (writer) and both extensions (readers).
+//
+
+import Foundation
+
+/// The snapshot file in the App Group container. The app is the only writer;
+/// the WidgetKit and Top Shelf extensions only read.
+nonisolated enum WidgetDataStore {
+    /// Must match `com.apple.security.application-groups` in every target's
+    /// entitlements (app, LumeWidgets, LumeTopShelf).
+    static let appGroupID = "group.com.bilipp.lume"
+
+    private static let snapshotFilename = "widget-snapshot.json"
+
+    static var snapshotURL: URL? {
+        FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: appGroupID)?
+            .appendingPathComponent(snapshotFilename)
+    }
+
+    static func load() -> WidgetSnapshot? {
+        guard let url = snapshotURL, let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(WidgetSnapshot.self, from: data)
+    }
+
+    static func save(_ snapshot: WidgetSnapshot) throws {
+        guard let url = snapshotURL else { return }
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(snapshot)
+        try data.write(to: url, options: .atomic)
+    }
+}
+
+/// Builds the widget-facing `lume://` URLs. The app-side parser lives in
+/// `DeepLink` (app target); `DeepLinkWidgetRoundTripTests` keeps the two in sync.
+nonisolated enum WidgetDeepLink {
+    static let scheme = "lume"
+
+    /// `lume://play/{movie|episode|live}/{catalogId}` — launches straight into
+    /// playback with resume. The catalog id is percent-encoded: provider-derived
+    /// ids can contain characters that are invalid in a URL path.
+    static func play(kind: WidgetMediaItem.Kind, id: String) -> URL? {
+        guard kind != .series else { return nil }
+        return build(host: "play", kindSegment: kind.rawValue, id: id)
+    }
+
+    /// `lume://open/series/{catalogId}` — a series has no single playable URL,
+    /// so favorites open its detail screen instead.
+    static func openSeries(id: String) -> URL? {
+        build(host: "open", kindSegment: "series", id: id)
+    }
+
+    private static func build(host: String, kindSegment: String, id: String) -> URL? {
+        guard let escaped = id.addingPercentEncoding(withAllowedCharacters: .alphanumerics) else { return nil }
+        return URL(string: "\(scheme)://\(host)/\(kindSegment)/\(escaped)")
+    }
+}

--- a/LumeShared/WidgetSnapshot.swift
+++ b/LumeShared/WidgetSnapshot.swift
@@ -1,0 +1,63 @@
+//
+//  WidgetSnapshot.swift
+//  LumeShared
+//
+//  The value-type snapshot the app exports for its widgets. Compiled into the
+//  app, the WidgetKit extension and the tvOS Top Shelf extension, so it must
+//  stay a plain Codable surface with no SwiftData / app dependencies.
+//  Everything is `nonisolated`: the app target builds with default MainActor
+//  isolation while the extensions don't, and these values cross actors freely.
+//
+
+import Foundation
+
+/// Everything the widgets and the Top Shelf can render, precomputed by the app
+/// (see `WidgetSnapshotExporter`) and written to the shared App Group container.
+/// Extensions never query the catalog — they read this file only.
+nonisolated struct WidgetSnapshot: Codable, Equatable {
+    var generatedAt: Date
+    var continueWatching: [WidgetMediaItem]
+    var favorites: [WidgetMediaItem]
+    var onNow: [WidgetChannelNow]
+
+    static let empty = WidgetSnapshot(
+        generatedAt: .distantPast,
+        continueWatching: [],
+        favorites: [],
+        onNow: []
+    )
+}
+
+/// One resumable or favorite title. `deepLink` carries the full launch intent so
+/// renderers never rebuild routing logic.
+nonisolated struct WidgetMediaItem: Codable, Equatable, Identifiable {
+    nonisolated enum Kind: String, Codable {
+        case movie
+        case episode
+        case series
+        case live
+    }
+
+    var id: String
+    var kind: Kind
+    var title: String
+    var subtitle: String?
+    var imageURL: URL?
+    /// Resume fraction (0...1) for partially-watched items, nil otherwise.
+    var progress: Double?
+    var deepLink: URL
+}
+
+/// The now/next programme pair for one favorite channel, resolved from the EPG
+/// at export time. Widgets re-render at programme boundaries from these dates.
+nonisolated struct WidgetChannelNow: Codable, Equatable, Identifiable {
+    var id: String
+    var channelName: String
+    var logoURL: URL?
+    var nowTitle: String?
+    var nowStart: Date?
+    var nowEnd: Date?
+    var nextTitle: String?
+    var nextStart: Date?
+    var deepLink: URL
+}

--- a/LumeTests/Services/WidgetSnapshotTests.swift
+++ b/LumeTests/Services/WidgetSnapshotTests.swift
@@ -1,0 +1,226 @@
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+// MARK: - Deep-link round trip
+
+/// `WidgetDeepLink` (LumeShared) builds the URLs the widgets emit; `DeepLink`
+/// (app) parses them. These tests are the contract keeping the two in sync.
+struct DeepLinkWidgetRoundTripTests {
+    @Test func `play movie link round-trips`() throws {
+        let url = try #require(WidgetDeepLink.play(kind: .movie, id: "ABC-123"))
+        #expect(DeepLink(url: url) == .playMovie(id: "ABC-123"))
+    }
+
+    @Test func `play episode link round-trips`() throws {
+        let url = try #require(WidgetDeepLink.play(kind: .episode, id: "ABC-9-1-2"))
+        #expect(DeepLink(url: url) == .playEpisode(id: "ABC-9-1-2"))
+    }
+
+    @Test func `play live link round-trips`() throws {
+        let url = try #require(WidgetDeepLink.play(kind: .live, id: "ABC-55"))
+        #expect(DeepLink(url: url) == .playLive(id: "ABC-55"))
+    }
+
+    @Test func `open series link round-trips`() throws {
+        let url = try #require(WidgetDeepLink.openSeries(id: "ABC-77"))
+        #expect(DeepLink(url: url) == .openSeries(id: "ABC-77"))
+    }
+
+    @Test func `provider ids with reserved URL characters survive the round trip`() throws {
+        let hostileID = "ABC-my show/№1 ?ep=2&x=ä"
+        let url = try #require(WidgetDeepLink.play(kind: .live, id: hostileID))
+        #expect(DeepLink(url: url) == .playLive(id: hostileID))
+    }
+
+    @Test func `a series cannot be a play target`() {
+        #expect(WidgetDeepLink.play(kind: .series, id: "ABC-1") == nil)
+    }
+
+    @Test func `builder and parser agree on the scheme`() {
+        #expect(WidgetDeepLink.scheme == DeepLink.scheme)
+    }
+}
+
+// MARK: - Snapshot codability
+
+struct WidgetSnapshotCodingTests {
+    @Test func `snapshot survives an encode-decode round trip`() throws {
+        let deepLink = try #require(WidgetDeepLink.play(kind: .movie, id: "p-1"))
+        let snapshot = WidgetSnapshot(
+            generatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            continueWatching: [WidgetMediaItem(
+                id: "movie-p-1", kind: .movie, title: "A", subtitle: "2024",
+                imageURL: URL(string: "https://example.com/a.jpg"), progress: 0.5, deepLink: deepLink
+            )],
+            favorites: [],
+            onNow: [WidgetChannelNow(
+                id: "p-2", channelName: "News", logoURL: nil,
+                nowTitle: "Now", nowStart: Date(timeIntervalSince1970: 1_700_000_000),
+                nowEnd: Date(timeIntervalSince1970: 1_700_003_600),
+                nextTitle: "Next", nextStart: Date(timeIntervalSince1970: 1_700_003_600),
+                deepLink: deepLink
+            )]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(WidgetSnapshot.self, from: encoder.encode(snapshot))
+        #expect(decoded == snapshot)
+    }
+}
+
+// MARK: - Exporter
+
+@MainActor
+struct WidgetSnapshotExporterTests {
+    /// One playlist with resumable, watched, favorite and EPG-backed content.
+    private func seedContainer() throws -> (ModelContainer, Playlist) {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let playlist = Playlist(name: "Test", serverURL: "http://example.com", username: "u", password: "p")
+        context.insert(playlist)
+        let prefix = playlist.id.uuidString
+
+        let resumable = Movie(id: "\(prefix)-m1", streamId: 1, name: "Resumable", streamIcon: "https://img/m1.jpg")
+        resumable.durationSecs = 3600
+        resumable.watchProgress = 900
+        resumable.lastWatchedDate = Date(timeIntervalSinceNow: -3600)
+        context.insert(resumable)
+
+        let watched = Movie(id: "\(prefix)-m2", streamId: 2, name: "Watched")
+        watched.isWatched = true
+        watched.watchProgress = 3600
+        watched.lastWatchedDate = Date(timeIntervalSinceNow: -7200)
+        context.insert(watched)
+
+        let favoriteMovie = Movie(id: "\(prefix)-m3", streamId: 3, name: "Favorite Movie")
+        favoriteMovie.isFavorite = true
+        favoriteMovie.favoriteOrder = 1
+        context.insert(favoriteMovie)
+
+        let series = Series(id: "\(prefix)-s1", seriesId: 10, name: "Show")
+        series.lastWatchedDate = Date(timeIntervalSinceNow: -60)
+        series.isFavorite = true
+        series.favoriteOrder = 0
+        context.insert(series)
+        let episodeDone = Episode(id: "\(prefix)-s1-1-1", episodeId: "e1", title: "Pilot", containerExtension: "mp4", seasonNum: 1, episodeNum: 1, series: series)
+        episodeDone.setWatched(true)
+        context.insert(episodeDone)
+        let episodeInProgress = Episode(id: "\(prefix)-s1-1-2", episodeId: "e2", title: "Second", containerExtension: "mp4", seasonNum: 1, episodeNum: 2, series: series)
+        episodeInProgress.durationSecs = 1200
+        episodeInProgress.watchProgress = 600
+        episodeInProgress.lastWatchedDate = Date(timeIntervalSinceNow: -60)
+        context.insert(episodeInProgress)
+
+        let channel = LiveStream(id: "\(prefix)-l1", streamId: 100, name: "News 24", streamIcon: "https://img/l1.png", epgChannelId: "news24.example")
+        channel.isFavorite = true
+        channel.favoriteOrder = 2
+        context.insert(channel)
+
+        let now = Date()
+        context.insert(EPGListing(id: "epg-1", channelId: "news24.example", title: "Evening News", listingDescription: "", start: now.addingTimeInterval(-600), end: now.addingTimeInterval(1200)))
+        context.insert(EPGListing(id: "epg-2", channelId: "news24.example", title: "Weather", listingDescription: "", start: now.addingTimeInterval(1200), end: now.addingTimeInterval(2400)))
+
+        try context.save()
+        return (container, playlist)
+    }
+
+    @Test func `continue watching resumes movies and the series' in-progress episode`() throws {
+        let (container, playlist) = try seedContainer()
+        let snapshot = WidgetSnapshotExporter.makeSnapshot(
+            container: container, storedPlaylistID: playlist.id.uuidString, isChildProfile: false
+        )
+
+        // The series was watched more recently than the movie.
+        #expect(snapshot.continueWatching.map(\.kind) == [.episode, .movie])
+        let episode = try #require(snapshot.continueWatching.first)
+        #expect(episode.title == "Show")
+        #expect(episode.subtitle == "S1 E2 · Second")
+        #expect(episode.progress == 0.5)
+        let movie = try #require(snapshot.continueWatching.last)
+        #expect(movie.title == "Resumable")
+        #expect(movie.progress == 0.25)
+        // The fully-watched movie must not resurface.
+        #expect(!snapshot.continueWatching.contains { $0.title == "Watched" })
+    }
+
+    @Test func `favorites interleave kinds in unified order`() throws {
+        let (container, playlist) = try seedContainer()
+        let snapshot = WidgetSnapshotExporter.makeSnapshot(
+            container: container, storedPlaylistID: playlist.id.uuidString, isChildProfile: false
+        )
+
+        #expect(snapshot.favorites.map(\.title) == ["Show", "Favorite Movie", "News 24"])
+        #expect(snapshot.favorites.map(\.kind) == [.series, .movie, .live])
+    }
+
+    @Test func `on now carries the current and next programme`() throws {
+        let (container, playlist) = try seedContainer()
+        let snapshot = WidgetSnapshotExporter.makeSnapshot(
+            container: container, storedPlaylistID: playlist.id.uuidString, isChildProfile: false
+        )
+
+        let channel = try #require(snapshot.onNow.first)
+        #expect(channel.channelName == "News 24")
+        #expect(channel.nowTitle == "Evening News")
+        #expect(channel.nextTitle == "Weather")
+    }
+
+    @Test func `a child profile keeps restricted categories out of the snapshot`() throws {
+        let (container, playlist) = try seedContainer()
+        let context = container.mainContext
+        let restricted = Lume.Category(apiId: "9", name: "Adults", parentId: 0, type: .vod, playlist: playlist)
+        restricted.isRestricted = true
+        context.insert(restricted)
+        let hidden = Movie(id: "\(playlist.id.uuidString)-m9", streamId: 9, name: "Hidden", categoryId: restricted.id)
+        hidden.isFavorite = true
+        hidden.durationSecs = 3600
+        hidden.watchProgress = 600
+        hidden.lastWatchedDate = Date()
+        context.insert(hidden)
+        try context.save()
+
+        let adult = WidgetSnapshotExporter.makeSnapshot(
+            container: container, storedPlaylistID: playlist.id.uuidString, isChildProfile: false
+        )
+        #expect(adult.favorites.contains { $0.title == "Hidden" })
+
+        let child = WidgetSnapshotExporter.makeSnapshot(
+            container: container, storedPlaylistID: playlist.id.uuidString, isChildProfile: true
+        )
+        #expect(!child.favorites.contains { $0.title == "Hidden" })
+        #expect(!child.continueWatching.contains { $0.title == "Hidden" })
+    }
+
+    @Test func `content from other playlists is excluded`() throws {
+        let (container, playlist) = try seedContainer()
+        let context = container.mainContext
+        let foreign = Movie(id: "\(UUID().uuidString)-x1", streamId: 50, name: "Foreign")
+        foreign.isFavorite = true
+        foreign.durationSecs = 3600
+        foreign.watchProgress = 60
+        foreign.lastWatchedDate = Date()
+        context.insert(foreign)
+        try context.save()
+
+        let snapshot = WidgetSnapshotExporter.makeSnapshot(
+            container: container, storedPlaylistID: playlist.id.uuidString, isChildProfile: false
+        )
+        #expect(!snapshot.favorites.contains { $0.title == "Foreign" })
+        #expect(!snapshot.continueWatching.contains { $0.title == "Foreign" })
+    }
+
+    @Test func `no playlists produces an empty snapshot`() throws {
+        let container = try makeTestContainer()
+        let snapshot = WidgetSnapshotExporter.makeSnapshot(
+            container: container, storedPlaylistID: "", isChildProfile: false
+        )
+        #expect(snapshot.continueWatching.isEmpty)
+        #expect(snapshot.favorites.isEmpty)
+        #expect(snapshot.onNow.isEmpty)
+    }
+}

--- a/LumeTopShelf/ContentProvider.swift
+++ b/LumeTopShelf/ContentProvider.swift
@@ -1,0 +1,78 @@
+//
+//  ContentProvider.swift
+//  LumeTopShelf
+//
+//  The tvOS Top Shelf — the marquee row above the app icon on the Apple TV
+//  home screen. Mirrors the widgets: Continue Watching, Favorites and On Now
+//  sections from the shared snapshot the app exports. Selecting an item
+//  deep-links into the app via `lume://`; the system fetches artwork itself
+//  from the URLs we hand it.
+//
+
+import Foundation
+import TVServices
+
+final class ContentProvider: TVTopShelfContentProvider {
+    override func loadTopShelfContent(completionHandler: @escaping (TVTopShelfContent?) -> Void) {
+        guard let snapshot = WidgetDataStore.load() else {
+            completionHandler(nil)
+            return
+        }
+
+        var sections: [TVTopShelfItemCollection<TVTopShelfSectionedItem>] = []
+
+        let continueWatching = snapshot.continueWatching.prefix(10).compactMap(mediaItem)
+        if !continueWatching.isEmpty {
+            let section = TVTopShelfItemCollection(items: continueWatching)
+            section.title = String(localized: "Continue Watching", comment: "Top Shelf section")
+            sections.append(section)
+        }
+
+        let onNow = snapshot.onNow.prefix(10).compactMap(channelItem)
+        if !onNow.isEmpty {
+            let section = TVTopShelfItemCollection(items: onNow)
+            section.title = String(localized: "On Now", comment: "Top Shelf section")
+            sections.append(section)
+        }
+
+        let favorites = snapshot.favorites.prefix(10).compactMap(mediaItem)
+        if !favorites.isEmpty {
+            let section = TVTopShelfItemCollection(items: favorites)
+            section.title = String(localized: "Favorites", comment: "Top Shelf section")
+            sections.append(section)
+        }
+
+        completionHandler(sections.isEmpty ? nil : TVTopShelfSectionedContent(sections: sections))
+    }
+
+    private func mediaItem(_ media: WidgetMediaItem) -> TVTopShelfSectionedItem? {
+        let item = TVTopShelfSectionedItem(identifier: media.id)
+        item.title = media.title
+        item.imageShape = media.kind == .live ? .square : .poster
+        if let imageURL = media.imageURL {
+            item.setImageURL(imageURL, for: [.screenScale1x, .screenScale2x])
+        }
+        if let progress = media.progress {
+            item.playbackProgress = progress
+        }
+        item.displayAction = TVTopShelfAction(url: media.deepLink)
+        item.playAction = TVTopShelfAction(url: media.deepLink)
+        return item
+    }
+
+    private func channelItem(_ channel: WidgetChannelNow) -> TVTopShelfSectionedItem? {
+        let item = TVTopShelfSectionedItem(identifier: channel.id)
+        if let nowTitle = channel.nowTitle {
+            item.title = "\(channel.channelName) — \(nowTitle)"
+        } else {
+            item.title = channel.channelName
+        }
+        item.imageShape = .square
+        if let logoURL = channel.logoURL {
+            item.setImageURL(logoURL, for: [.screenScale1x, .screenScale2x])
+        }
+        item.displayAction = TVTopShelfAction(url: channel.deepLink)
+        item.playAction = TVTopShelfAction(url: channel.deepLink)
+        return item
+    }
+}

--- a/LumeTopShelf/Info.plist
+++ b/LumeTopShelf/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.tv-top-shelf</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ContentProvider</string>
+	</dict>
+</dict>
+</plist>

--- a/LumeTopShelf/Localizable.xcstrings
+++ b/LumeTopShelf/Localizable.xcstrings
@@ -1,0 +1,168 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Continue Watching" : {
+      "comment" : "Top Shelf section",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weiterschauen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar viendo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprendre la lecture"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continua a guardare"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視聴を再開"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계속 시청하기"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar a Assistir"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继续观看"
+          }
+        }
+      }
+    },
+    "Favorites" : {
+      "comment" : "Top Shelf section",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoriten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoritos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoris"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preferiti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お気に入り"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "즐겨찾기"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoritos"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "收藏"
+          }
+        }
+      }
+    },
+    "On Now" : {
+      "comment" : "Top Shelf section",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ahora"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En ce moment"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In onda ora"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "放送中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 방송 중"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Ar Agora"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在播放"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/LumeTopShelf/LumeTopShelf.entitlements
+++ b/LumeTopShelf/LumeTopShelf.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.bilipp.lume</string>
+	</array>
+</dict>
+</plist>

--- a/LumeWidgets/ContinueWatchingWidget.swift
+++ b/LumeWidgets/ContinueWatchingWidget.swift
@@ -1,0 +1,106 @@
+//
+//  ContinueWatchingWidget.swift
+//  LumeWidgets
+//
+//  Resume in-progress movies and episodes straight from the Home Screen /
+//  Desktop. Every tile deep-links into playback via `lume://play/...`.
+//
+
+import SwiftUI
+import WidgetKit
+
+struct ContinueWatchingWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "ContinueWatching", provider: ContinueWatchingProvider()) { entry in
+            ContinueWatchingView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName(Text("Continue Watching", comment: "Widget name"))
+        .description(Text("Pick up where you left off.", comment: "Widget description"))
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+struct ContinueWatchingView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: MediaEntry
+
+    var body: some View {
+        if entry.items.isEmpty {
+            WidgetEmptyView(symbol: "play.circle", message: "Nothing in progress. Open Lume and start watching.")
+        } else {
+            switch family {
+            case .systemSmall:
+                if let item = entry.items.first {
+                    smallCard(item)
+                        .widgetURL(item.deepLink)
+                }
+            case .systemLarge:
+                rowList(maxRows: 4)
+            default:
+                posterRow(maxItems: 3)
+            }
+        }
+    }
+
+    private func smallCard(_ item: WidgetMediaItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ArtworkView(image: entry.images[item.imageURL], kind: item.kind)
+            if let progress = item.progress {
+                ResumeBar(progress: progress)
+            }
+            Text(item.title)
+                .font(.caption.bold())
+                .lineLimit(1)
+        }
+    }
+
+    private func posterRow(maxItems: Int) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            ForEach(entry.items.prefix(maxItems)) { item in
+                Link(destination: item.deepLink) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ArtworkView(image: entry.images[item.imageURL], kind: item.kind)
+                            .aspectRatio(2 / 3, contentMode: .fit)
+                        if let progress = item.progress {
+                            ResumeBar(progress: progress)
+                        }
+                        Text(item.title)
+                            .font(.caption2.bold())
+                            .lineLimit(1)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    private func rowList(maxRows: Int) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(entry.items.prefix(maxRows)) { item in
+                Link(destination: item.deepLink) {
+                    HStack(spacing: 10) {
+                        ArtworkView(image: entry.images[item.imageURL], kind: item.kind, cornerRadius: 6)
+                            .frame(width: 42, height: 63)
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(item.title)
+                                .font(.footnote.bold())
+                                .lineLimit(1)
+                            if let subtitle = item.subtitle {
+                                Text(subtitle)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                            if let progress = item.progress {
+                                ResumeBar(progress: progress)
+                            }
+                        }
+                    }
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+    }
+}

--- a/LumeWidgets/FavoritesWidget.swift
+++ b/LumeWidgets/FavoritesWidget.swift
@@ -1,0 +1,95 @@
+//
+//  FavoritesWidget.swift
+//  LumeWidgets
+//
+//  Quick-launch tiles for favorite channels and titles, in the user's unified
+//  favorites order. Channels and movies deep-link straight into playback;
+//  series open their detail screen.
+//
+
+import SwiftUI
+import WidgetKit
+
+struct FavoritesWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "Favorites", provider: FavoritesProvider()) { entry in
+            FavoritesView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName(Text("Favorites", comment: "Widget name"))
+        .description(Text("Jump straight into your favorite titles and channels.", comment: "Widget description"))
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+struct FavoritesView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: MediaEntry
+
+    var body: some View {
+        if entry.items.isEmpty {
+            WidgetEmptyView(symbol: "star", message: "No favorites yet. Mark titles and channels as favorites in Lume.")
+        } else {
+            switch family {
+            case .systemSmall:
+                if let item = entry.items.first {
+                    tile(item)
+                        .widgetURL(item.deepLink)
+                }
+            case .systemLarge:
+                grid(rows: 2, columns: 4)
+            default:
+                grid(rows: 1, columns: 4)
+            }
+        }
+    }
+
+    private func tile(_ item: WidgetMediaItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            artwork(item)
+            Text(item.title)
+                .font(.caption.bold())
+                .lineLimit(1)
+        }
+    }
+
+    private func grid(rows: Int, columns: Int) -> some View {
+        VStack(spacing: 12) {
+            ForEach(0 ..< rows, id: \.self) { row in
+                HStack(alignment: .top, spacing: 10) {
+                    ForEach(entry.items.dropFirst(row * columns).prefix(columns)) { item in
+                        Link(destination: item.deepLink) {
+                            VStack(spacing: 4) {
+                                artwork(item)
+                                Text(item.title)
+                                    .font(.caption2)
+                                    .lineLimit(1)
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    // Keep an incomplete last row left-aligned with even cells.
+                    ForEach(0 ..< missingCells(row: row, columns: columns), id: \.self) { _ in
+                        Color.clear.frame(maxWidth: .infinity)
+                    }
+                }
+            }
+        }
+    }
+
+    private func missingCells(row: Int, columns: Int) -> Int {
+        let shown = entry.items.dropFirst(row * columns).prefix(columns).count
+        return columns - shown
+    }
+
+    @ViewBuilder
+    private func artwork(_ item: WidgetMediaItem) -> some View {
+        if item.kind == .live {
+            ChannelLogoView(image: entry.images[item.imageURL])
+                .aspectRatio(1, contentMode: .fit)
+        } else {
+            ArtworkView(image: entry.images[item.imageURL], kind: item.kind)
+                .aspectRatio(2 / 3, contentMode: .fit)
+        }
+    }
+}

--- a/LumeWidgets/Info.plist
+++ b/LumeWidgets/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/LumeWidgets/Localizable.xcstrings
+++ b/LumeWidgets/Localizable.xcstrings
@@ -1,0 +1,600 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Continue Watching" : {
+      "comment" : "Widget name",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weiterschauen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar viendo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprendre la lecture"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continua a guardare"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視聴を再開"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계속 시청하기"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar a Assistir"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继续观看"
+          }
+        }
+      }
+    },
+    "Favorites" : {
+      "comment" : "Widget name",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoriten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoritos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoris"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preferiti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お気に入り"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "즐겨찾기"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoritos"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "收藏"
+          }
+        }
+      }
+    },
+    "Jump straight into your favorite titles and channels." : {
+      "comment" : "Widget description",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starte direkt deine Lieblingstitel und -sender."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accede directamente a tus títulos y canales favoritos."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accédez directement à vos titres et chaînes favoris."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vai direttamente ai tuoi titoli e canali preferiti."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お気に入りの作品やチャンネルにすばやくアクセス。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "즐겨찾는 콘텐츠와 채널로 바로 이동하세요."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aceda diretamente aos seus títulos e canais favoritos."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速打开您收藏的内容和频道。"
+          }
+        }
+      }
+    },
+    "Next: %@" : {
+      "comment" : "Upcoming programme on a channel",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Danach: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A continuación: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ensuite : %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A seguire: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음: %@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A seguir: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接下来：%@"
+          }
+        }
+      }
+    },
+    "No favorite channels. Favorite channels in Lume to see their guide here." : {
+      "comment" : "Empty on-now widget",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Favoritensender. Füge in Lume Sender zu deinen Favoriten hinzu, um hier ihr Programm zu sehen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay canales favoritos. Añade canales a favoritos en Lume para ver aquí su guía."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune chaîne favorite. Ajoutez des chaînes aux favoris dans Lume pour voir leur guide ici."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun canale preferito. Aggiungi canali ai preferiti in Lume per vedere qui la loro guida."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お気に入りのチャンネルがありません。Lumeでチャンネルをお気に入りに追加すると、ここに番組表が表示されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "즐겨찾는 채널이 없습니다. Lume에서 채널을 즐겨찾기에 추가하면 여기에 편성표가 표시됩니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sem canais favoritos. Adicione canais aos favoritos no Lume para ver aqui o guia."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有收藏的频道。在 Lume 中收藏频道即可在此查看节目单。"
+          }
+        }
+      }
+    },
+    "No favorites yet. Mark titles and channels as favorites in Lume." : {
+      "comment" : "Empty favorites widget",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch keine Favoriten. Markiere Titel und Sender in Lume als Favoriten."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no hay favoritos. Marca títulos y canales como favoritos en Lume."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun favori pour l'instant. Ajoutez des titres et des chaînes aux favoris dans Lume."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ancora nessun preferito. Aggiungi titoli e canali ai preferiti in Lume."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お気に入りはまだありません。Lumeで作品やチャンネルをお気に入りに追加しましょう。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아직 즐겨찾기가 없습니다. Lume에서 콘텐츠와 채널을 즐겨찾기에 추가하세요."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ainda sem favoritos. Marque títulos e canais como favoritos no Lume."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还没有收藏。在 Lume 中将内容和频道加入收藏。"
+          }
+        }
+      }
+    },
+    "No guide data" : {
+      "comment" : "Shown when a channel has no EPG information",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Programmdaten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin datos de guía"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune donnée de guide"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun dato della guida"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "番組情報なし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "편성표 정보 없음"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sem dados do guia"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无节目信息"
+          }
+        }
+      }
+    },
+    "Nothing in progress. Open Lume and start watching." : {
+      "comment" : "Empty continue-watching widget",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nichts angefangen. Öffne Lume und starte die Wiedergabe."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nada en curso. Abre Lume y empieza a ver algo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rien en cours. Ouvrez Lume et lancez une lecture."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun contenuto in corso. Apri Lume e inizia a guardare."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視聴中の作品はありません。Lumeを開いて視聴を始めましょう。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시청 중인 콘텐츠가 없습니다. Lume을 열고 시청을 시작하세요."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nada em curso. Abra o Lume e comece a assistir."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有观看中的内容。打开 Lume 开始观看。"
+          }
+        }
+      }
+    },
+    "On Now" : {
+      "comment" : "Widget name",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ahora"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En ce moment"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In onda ora"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "放送中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 방송 중"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Ar Agora"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在播放"
+          }
+        }
+      }
+    },
+    "Pick up where you left off." : {
+      "comment" : "Widget description",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mach da weiter, wo du aufgehört hast."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retoma donde lo dejaste."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprenez là où vous vous êtes arrêté."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riprendi da dove avevi interrotto."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "続きから視聴できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중단한 부분부터 이어서 시청하세요."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retome de onde parou."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从上次中断的地方继续观看。"
+          }
+        }
+      }
+    },
+    "What's playing on your favorite channels." : {
+      "comment" : "Widget description",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Was auf deinen Lieblingssendern läuft."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lo que se emite en tus canales favoritos."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce qui passe sur vos chaînes favorites."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cosa c'è in onda sui tuoi canali preferiti."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お気に入りのチャンネルで放送中の番組。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "즐겨찾는 채널에서 방송 중인 프로그램."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O que está a dar nos seus canais favoritos."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您收藏的频道正在播放的节目。"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/LumeWidgets/LumeWidgets.entitlements
+++ b/LumeWidgets/LumeWidgets.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.bilipp.lume</string>
+	</array>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>

--- a/LumeWidgets/LumeWidgetsBundle.swift
+++ b/LumeWidgets/LumeWidgetsBundle.swift
@@ -1,0 +1,20 @@
+//
+//  LumeWidgetsBundle.swift
+//  LumeWidgets
+//
+//  Home Screen / Desktop widgets (iOS, iPadOS, macOS). All three widgets render
+//  the snapshot the app exports to the App Group container — the extension
+//  never touches SwiftData or the network beyond fetching artwork.
+//
+
+import SwiftUI
+import WidgetKit
+
+@main
+struct LumeWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        ContinueWatchingWidget()
+        FavoritesWidget()
+        OnNowWidget()
+    }
+}

--- a/LumeWidgets/OnNowWidget.swift
+++ b/LumeWidgets/OnNowWidget.swift
@@ -1,0 +1,112 @@
+//
+//  OnNowWidget.swift
+//  LumeWidgets
+//
+//  The current programme on favorite channels, driven by the EPG data in the
+//  shared snapshot. Progress bars tick live via `ProgressView(timerInterval:)`;
+//  the timeline only reloads at programme boundaries.
+//
+
+import SwiftUI
+import WidgetKit
+
+struct OnNowWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "OnNow", provider: OnNowProvider()) { entry in
+            OnNowView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName(Text("On Now", comment: "Widget name"))
+        .description(Text("What's playing on your favorite channels.", comment: "Widget description"))
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+struct OnNowView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: OnNowEntry
+
+    var body: some View {
+        if entry.channels.isEmpty {
+            WidgetEmptyView(symbol: "antenna.radiowaves.left.and.right", message: "No favorite channels. Favorite channels in Lume to see their guide here.")
+        } else {
+            switch family {
+            case .systemSmall:
+                if let channel = entry.channels.first {
+                    ChannelNowRow(channel: channel, logo: entry.images[channel.logoURL], compact: true)
+                        .widgetURL(channel.deepLink)
+                }
+            case .systemLarge:
+                rows(max: 5)
+            default:
+                rows(max: 2)
+            }
+        }
+    }
+
+    private func rows(max maxRows: Int) -> some View {
+        VStack(spacing: 10) {
+            ForEach(entry.channels.prefix(maxRows)) { channel in
+                Link(destination: channel.deepLink) {
+                    ChannelNowRow(channel: channel, logo: entry.images[channel.logoURL], compact: false)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+    }
+}
+
+struct ChannelNowRow: View {
+    let channel: WidgetChannelNow
+    let logo: Image?
+    let compact: Bool
+
+    var body: some View {
+        if compact {
+            VStack(alignment: .leading, spacing: 6) {
+                ChannelLogoView(image: logo)
+                    .frame(width: 36, height: 36)
+                details
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        } else {
+            HStack(spacing: 10) {
+                ChannelLogoView(image: logo)
+                    .frame(width: 36, height: 36)
+                details
+            }
+        }
+    }
+
+    private var details: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(channel.channelName)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            if let title = channel.nowTitle {
+                Text(title)
+                    .font(.footnote.bold())
+                    .lineLimit(1)
+            } else {
+                Text("No guide data", comment: "Shown when a channel has no EPG information")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            if let start = channel.nowStart, let end = channel.nowEnd, start <= end {
+                ProgressView(timerInterval: start ... end, countsDown: false)
+                    .labelsHidden()
+                    .tint(.accentColor)
+                    .scaleEffect(x: 1, y: 0.6, anchor: .center)
+            }
+            if !compact, let next = channel.nextTitle {
+                Text("Next: \(next)", comment: "Upcoming programme on a channel")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/LumeWidgets/WidgetComponents.swift
+++ b/LumeWidgets/WidgetComponents.swift
@@ -1,0 +1,110 @@
+//
+//  WidgetComponents.swift
+//  LumeWidgets
+//
+//  Small building blocks shared by the three widgets.
+//
+
+import SwiftUI
+import WidgetKit
+
+/// Poster (2:3) artwork with a graceful monochrome fallback when the provider
+/// has no image (or it hasn't been fetched yet).
+struct ArtworkView: View {
+    let image: Image?
+    let kind: WidgetMediaItem.Kind
+    var cornerRadius: CGFloat = 8
+
+    var body: some View {
+        ZStack {
+            if let image {
+                Color.clear.overlay(
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                )
+            } else {
+                Rectangle()
+                    .fill(.quaternary)
+                Image(systemName: fallbackSymbol)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+    }
+
+    private var fallbackSymbol: String {
+        switch kind {
+        case .movie: "film"
+        case .episode, .series: "tv"
+        case .live: "antenna.radiowaves.left.and.right"
+        }
+    }
+}
+
+/// Channel logos are mostly transparent PNGs — give them padding on a subtle
+/// tile so they read on any widget background.
+struct ChannelLogoView: View {
+    let image: Image?
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(.quaternary)
+            if let image {
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .padding(4)
+            } else {
+                Image(systemName: "antenna.radiowaves.left.and.right")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+/// Thin resume bar under continue-watching artwork.
+struct ResumeBar: View {
+    let progress: Double
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule().fill(.quaternary)
+                Capsule()
+                    .fill(.tint)
+                    .frame(width: max(proxy.size.width * progress, 4))
+            }
+        }
+        .frame(height: 4)
+    }
+}
+
+/// Entry image lookup with an optional key, so views can index straight with
+/// `item.imageURL`.
+extension [URL: Image] {
+    subscript(url: URL?) -> Image? {
+        guard let url else { return nil }
+        return self[url]
+    }
+}
+
+/// Shown when the snapshot has no content for a widget yet.
+struct WidgetEmptyView: View {
+    let symbol: String
+    let message: LocalizedStringKey
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Image(systemName: symbol)
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text(message)
+                .font(.caption)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/LumeWidgets/WidgetProviders.swift
+++ b/LumeWidgets/WidgetProviders.swift
@@ -1,0 +1,195 @@
+//
+//  WidgetProviders.swift
+//  LumeWidgets
+//
+//  Timeline providers for the three widgets. Data comes from the shared
+//  snapshot; artwork is fetched (downsampled) inside the provider — never in
+//  the views, which are rendered and archived by the system.
+//
+
+import CoreGraphics
+import Foundation
+import ImageIO
+import SwiftUI
+import WidgetKit
+
+// MARK: - Entries
+
+struct MediaEntry: TimelineEntry {
+    let date: Date
+    let items: [WidgetMediaItem]
+    let images: [URL: Image]
+}
+
+struct OnNowEntry: TimelineEntry {
+    let date: Date
+    let channels: [WidgetChannelNow]
+    let images: [URL: Image]
+}
+
+// MARK: - Providers
+
+struct ContinueWatchingProvider: TimelineProvider {
+    func placeholder(in _: Context) -> MediaEntry {
+        MediaEntry(date: Date(), items: WidgetSampleData.continueWatching, images: [:])
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (MediaEntry) -> Void) {
+        if context.isPreview {
+            completion(placeholder(in: context))
+            return
+        }
+        Task { await completion(Self.entry()) }
+    }
+
+    func getTimeline(in _: Context, completion: @escaping (Timeline<MediaEntry>) -> Void) {
+        Task {
+            // The app reloads timelines whenever it writes a fresh snapshot, so
+            // there is nothing to poll for — `.never` preserves reload budget.
+            await completion(Timeline(entries: [Self.entry()], policy: .never))
+        }
+    }
+
+    private static func entry() async -> MediaEntry {
+        let items = WidgetDataStore.load()?.continueWatching ?? []
+        let images = await WidgetImageLoader.load(urls: items.prefix(6).compactMap(\.imageURL))
+        return MediaEntry(date: Date(), items: items, images: images)
+    }
+}
+
+struct FavoritesProvider: TimelineProvider {
+    func placeholder(in _: Context) -> MediaEntry {
+        MediaEntry(date: Date(), items: WidgetSampleData.favorites, images: [:])
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (MediaEntry) -> Void) {
+        if context.isPreview {
+            completion(placeholder(in: context))
+            return
+        }
+        Task { await completion(Self.entry()) }
+    }
+
+    func getTimeline(in _: Context, completion: @escaping (Timeline<MediaEntry>) -> Void) {
+        Task {
+            await completion(Timeline(entries: [Self.entry()], policy: .never))
+        }
+    }
+
+    private static func entry() async -> MediaEntry {
+        let items = WidgetDataStore.load()?.favorites ?? []
+        let images = await WidgetImageLoader.load(urls: items.prefix(8).compactMap(\.imageURL))
+        return MediaEntry(date: Date(), items: items, images: images)
+    }
+}
+
+struct OnNowProvider: TimelineProvider {
+    func placeholder(in _: Context) -> OnNowEntry {
+        OnNowEntry(date: Date(), channels: WidgetSampleData.onNow, images: [:])
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (OnNowEntry) -> Void) {
+        if context.isPreview {
+            completion(placeholder(in: context))
+            return
+        }
+        Task { await completion(Self.entry(now: Date())) }
+    }
+
+    func getTimeline(in _: Context, completion: @escaping (Timeline<OnNowEntry>) -> Void) {
+        Task {
+            let now = Date()
+            let entry = await Self.entry(now: now)
+            // Refresh when the earliest programme ends so "on now" rolls over,
+            // clamped to [5 min, 60 min] to stay inside the reload budget.
+            // Progress bars advance live via ProgressView(timerInterval:).
+            let boundaries = entry.channels
+                .flatMap { [$0.nowEnd, $0.nextStart] }
+                .compactMap(\.self)
+                .filter { $0 > now }
+            let refresh = min(
+                max(boundaries.min() ?? now.addingTimeInterval(3600), now.addingTimeInterval(300)),
+                now.addingTimeInterval(3600)
+            )
+            completion(Timeline(entries: [entry], policy: .after(refresh)))
+        }
+    }
+
+    private static func entry(now: Date) async -> OnNowEntry {
+        let channels = WidgetDataStore.load()?.onNow ?? []
+        let images = await WidgetImageLoader.load(urls: channels.prefix(8).compactMap(\.logoURL), maxPixel: 160)
+        return OnNowEntry(date: now, channels: channels, images: images)
+    }
+}
+
+// MARK: - Artwork
+
+/// Fetches artwork for timeline entries. Widget extensions run in a ~30 MB
+/// memory budget, so every image is decoded through an ImageIO thumbnail —
+/// never a full-size decode of a provider poster.
+enum WidgetImageLoader {
+    static func load(urls: some Collection<URL>, maxPixel: Int = 480) async -> [URL: Image] {
+        await withTaskGroup(of: (URL, Image?).self) { group in
+            for url in Set(urls) {
+                group.addTask { await (url, fetch(url: url, maxPixel: maxPixel)) }
+            }
+            var result: [URL: Image] = [:]
+            for await (url, image) in group {
+                if let image { result[url] = image }
+            }
+            return result
+        }
+    }
+
+    private static func fetch(url: URL, maxPixel: Int) async -> Image? {
+        guard let (data, _) = try? await URLSession.shared.data(from: url) else { return nil }
+        return downsampled(data: data, maxPixel: maxPixel)
+    }
+
+    private static func downsampled(data: Data, maxPixel: Int) -> Image? {
+        let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else { return nil }
+        let thumbnailOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixel
+        ] as CFDictionary
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions) else { return nil }
+        return Image(decorative: cgImage, scale: 1)
+    }
+}
+
+// MARK: - Gallery samples
+
+/// Fabricated content for the widget gallery (`placeholder` / preview
+/// snapshots). Deep links are never followed there, so a bare scheme URL is fine.
+enum WidgetSampleData {
+    private static let sampleLink = URL(string: "lume://open/series/sample") ?? URL(fileURLWithPath: "/")
+
+    static let continueWatching: [WidgetMediaItem] = [
+        WidgetMediaItem(id: "1", kind: .movie, title: "The Long Voyage", subtitle: "2024", imageURL: nil, progress: 0.4, deepLink: sampleLink),
+        WidgetMediaItem(id: "2", kind: .episode, title: "Northern Lights", subtitle: "S1 E4 · Aurora", imageURL: nil, progress: 0.7, deepLink: sampleLink),
+        WidgetMediaItem(id: "3", kind: .movie, title: "Riverbend", subtitle: "2023", imageURL: nil, progress: 0.2, deepLink: sampleLink)
+    ]
+
+    static let favorites: [WidgetMediaItem] = [
+        WidgetMediaItem(id: "1", kind: .live, title: "News 24", subtitle: nil, imageURL: nil, progress: nil, deepLink: sampleLink),
+        WidgetMediaItem(id: "2", kind: .movie, title: "The Long Voyage", subtitle: nil, imageURL: nil, progress: nil, deepLink: sampleLink),
+        WidgetMediaItem(id: "3", kind: .series, title: "Northern Lights", subtitle: nil, imageURL: nil, progress: nil, deepLink: sampleLink),
+        WidgetMediaItem(id: "4", kind: .live, title: "Sports One", subtitle: nil, imageURL: nil, progress: nil, deepLink: sampleLink)
+    ]
+
+    static let onNow: [WidgetChannelNow] = [
+        WidgetChannelNow(
+            id: "1", channelName: "News 24", logoURL: nil,
+            nowTitle: "Evening News", nowStart: Date().addingTimeInterval(-900), nowEnd: Date().addingTimeInterval(1800),
+            nextTitle: "Weather", nextStart: Date().addingTimeInterval(1800), deepLink: sampleLink
+        ),
+        WidgetChannelNow(
+            id: "2", channelName: "Sports One", logoURL: nil,
+            nowTitle: "Match Day Live", nowStart: Date().addingTimeInterval(-2700), nowEnd: Date().addingTimeInterval(2700),
+            nextTitle: "Highlights", nextStart: Date().addingTimeInterval(2700), deepLink: sampleLink
+        )
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Metacritic, Trakt, Letterboxd), and your viewing activity can be scrobbled to **
 - **Immersive full-screen tvOS home** with TMDB backdrop, crossfading hero, and fold-based scroll snapping
 - Continue Watching, Favorites, Recently Watched, and Trending rails
 - **For You** rail — on-device recommendations from your watch history and favorites; thumbs-up / thumbs-down a suggestion to tune what you see next, with your votes syncing across devices via iCloud (can be turned off in Settings)
+- **Home Screen widgets** (iOS/iPadOS/macOS) — Continue Watching, Favorites, and On Now (EPG for favorite channels), each deep-linking straight into playback
+- **tvOS Top Shelf** — Continue Watching, On Now, and Favorites in the marquee row above the app icon
 
 #### 🔎 Discovery & organization
 - Global search across Movies, Series, and Live channels with type filtering


### PR DESCRIPTION
## Summary
Adds the WidgetKit surface from #127: **Continue Watching**, **Favorites** and **On Now** Home Screen/Desktop widgets on iOS/iPadOS/macOS, plus a sectioned **tvOS Top Shelf** with the same three groups. Every tile deep-links straight into playback (or a series' detail screen) so users can resume a title or tune a favorite channel without navigating the app.

## Implementation
- **Two new extension targets** hand-wired into the pbxproj: `LumeWidgets` (WidgetKit, iOS+macOS) and `LumeTopShelf` (TVServices, tvOS), embedded with `platformFilters` from the single multiplatform app target.
- **App Group snapshot, not shared SwiftData**: a new `group.com.bilipp.lume` App Group carries a small `widget-snapshot.json`. The app's new `WidgetSnapshotExporter` rebuilds it off-main on launch and on backgrounding (bounded fetches mirroring the Home rails + `ChannelEPGLoader` for now/next EPG), then reloads widget timelines. Extensions never open the catalog store. Snapshots are scoped to the active playlist/profile and honor child-profile category restrictions.
- **Shared code** lives in a new `LumeShared/` synchronized folder compiled into the app and both extensions (`WidgetSnapshot` DTOs, `WidgetDataStore`, `WidgetDeepLink`).
- **Deep links**: new `lume://play/{movie|episode|live}/{id}` and `lume://open/series/{id}` routes (ids percent-encoded); `MainTabView` resolves them to `PlayableMedia` (external-player hand-off respected, macOS opens the player window) — round-trip covered by tests. #125's App Intents entity layer isn't built yet, so plain URL routes as the issue allows ("ideally" App Intents — can migrate later).
- **Timelines**: Continue Watching/Favorites use `.never` + app-driven reloads; On Now re-renders at programme boundaries (clamped 5–60 min) with `ProgressView(timerInterval:)` ticking live; artwork is fetched provider-side through ImageIO thumbnails to respect the ~30 MB extension budget.
- Also fixes a pre-existing compile break on the branch base in `LumeEngineCoordinator.swift` (os_log autoclosure self-capture — same class as f1432f8).

## Testing
- [x] Acceptance criteria met (widgets on iOS/macOS, Top Shelf on tvOS, App Group data, playback deep links)
- [x] Tests pass — full `LumeTests` on iPhone 17 Pro sim (only failure was one sim-clone launch crash under parallel load; all affected suites re-verified green with `-parallel-testing-enabled NO`, incl. the known `RecommendationEngineTests` flake)
- [x] SwiftLint clean (`--strict`) + SwiftFormat + xcstrings normalized
- [x] Tests added — deep-link round trip, snapshot codability, exporter behavior (resume/favorites/EPG/child-profile/playlist scoping)

## Platforms
Builds verified via CLI for all three; not yet manually exercised on device/sim — see notes.
- [ ] iOS / iPadOS (build ✅)
- [ ] tvOS (build ✅, `LumeTopShelf.appex` embedded)
- [ ] macOS (compile ✅ with `CODE_SIGNING_ALLOWED=NO`)

## Notes for verification
- First signed build must regenerate provisioning: the new App Group + the two new bundle ids (`com.bilipp.lume.widgets` / `.topshelf`) need Xcode automatic signing with an account session (the ASC API key on this machine lacks provisioning permission, so CLI `-allowProvisioningUpdates` couldn't do it).
- Widget gallery names/descriptions and empty states are localized in all 9 locales (extension-local String Catalogs, marked `manual` so `xcstringstool sync` won't prune them).

## Related
Closes #127