### PR TITLE
fix(sync): stop the launch EPG refresh from racing the playlist sync

### DIFF
--- a/Lume/LumeApp.swift
+++ b/Lume/LumeApp.swift
@@ -231,8 +231,10 @@ struct LumeApp: App {
                     ContentIndexingService.shared.configure(container: catalogContainer)
                     ContentIndexingService.shared.kick()
 
-                    // Refresh the TV guide on its own schedule, independent of
-                    // the content sync. No-ops when no guide is due yet.
+                    // Refresh the TV guide on its own schedule. No-ops when no
+                    // guide is due yet, and stands aside when a playlist sync
+                    // is running or about to start — the post-sync hook kicks
+                    // the refresh instead once the sync queue drains.
                     EPGSyncService.shared.configure(container: catalogContainer)
                     EPGSyncService.shared.syncIfDue()
                 }

--- a/Lume/Services/Network/M3UClient.swift
+++ b/Lume/Services/Network/M3UClient.swift
@@ -41,6 +41,30 @@ nonisolated enum M3UError: LocalizedError {
             "The playlist file could not be found."
         }
     }
+
+    /// Credential-free summary for diagnostic logs. Interpolated with
+    /// `privacy: .public`, so it must never contain a URL — playlist and EPG
+    /// URLs can carry account credentials as query items, and underlying
+    /// `NSError` descriptions can embed the failing URL.
+    var logDescription: String {
+        switch self {
+        case .invalidURL:
+            return "invalid URL"
+        case let .networkError(error):
+            let nsError = error as NSError
+            return "network error (\(nsError.domain) \(nsError.code))"
+        case let .serverError(code):
+            return "HTTP \(code)"
+        case .invalidResponse:
+            return "non-HTTP response"
+        case .notAPlaylist:
+            return "not an m3u playlist"
+        case .enigma2Bouquet:
+            return "Enigma2 bouquet URL"
+        case .fileNotFound:
+            return "file not found"
+        }
+    }
 }
 
 nonisolated class M3UClient {

--- a/Lume/Services/Network/XtreamClient.swift
+++ b/Lume/Services/Network/XtreamClient.swift
@@ -8,54 +8,6 @@
 import Foundation
 import OSLog
 
-enum XtreamError: LocalizedError {
-    case invalidURL
-    case authenticationFailed
-    case networkError(Error)
-    case decodingError(Error)
-    case invalidResponse
-    case serverError(Int)
-
-    var errorDescription: String? {
-        switch self {
-        case .invalidURL:
-            "The server URL is invalid."
-        case .authenticationFailed:
-            "Authentication failed. The provider rejected the request (this can also happen when the account's connection limit is reached)."
-        case let .networkError(error):
-            "Network error: \(error.localizedDescription)"
-        case let .decodingError(error):
-            "Failed to read the server response: \(error.localizedDescription)"
-        case .invalidResponse:
-            "Received an invalid response from the server."
-        case let .serverError(code):
-            "Server error (HTTP \(code))."
-        }
-    }
-
-    /// Whether the failure is likely transient and worth retrying.
-    /// Note: `authenticationFailed` (HTTP 401/403) is *not* retriable by
-    /// default — for login it means bad credentials. During an
-    /// already-authenticated sync it's usually the provider's connection /
-    /// rate limit, so those call sites opt in via `retryAuthFailure`.
-    var isRetriable: Bool {
-        switch self {
-        case .networkError:
-            // Timeouts, connection reset (RST), lost connection — transient.
-            true
-        case let .serverError(code):
-            code >= 500
-        case .invalidURL, .authenticationFailed, .decodingError, .invalidResponse:
-            false
-        }
-    }
-
-    var isAuthFailure: Bool {
-        if case .authenticationFailed = self { return true }
-        return false
-    }
-}
-
 // MARK: - XtreamClient
 
 class XtreamClient: APIClient {
@@ -164,13 +116,18 @@ class XtreamClient: APIClient {
                 return try await performRequest(url)
             } catch let error as XtreamError {
                 let retriable = error.isRetriable || (retryAuthFailure && error.isAuthFailure)
-                guard retriable, attempt < Self.maxAttempts else { throw error }
+                guard retriable, attempt < Self.maxAttempts else {
+                    Logger.network.error(
+                        "Xtream request failed permanently (\(error.logDescription, privacy: .public)) after \(attempt) attempt(s)"
+                    )
+                    throw error
+                }
 
                 // Exponential backoff: 2s, then 4s. Gives the provider time to
                 // release the connection slot / clear the rate-limit window.
                 let delay = pow(2.0, Double(attempt))
                 Logger.network.warning(
-                    "Xtream request failed (\(error.localizedDescription)); retry \(attempt)/\(Self.maxAttempts - 1) in \(delay)s"
+                    "Xtream request failed (\(error.logDescription, privacy: .public)); retry \(attempt)/\(Self.maxAttempts - 1) in \(delay)s"
                 )
                 try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             }

--- a/Lume/Services/Network/XtreamError.swift
+++ b/Lume/Services/Network/XtreamError.swift
@@ -1,0 +1,86 @@
+//
+//  XtreamError.swift
+//  Lume
+//
+//  Errors surfaced by XtreamClient, plus the retry / logging policy attached
+//  to each case.
+//
+
+import Foundation
+
+enum XtreamError: LocalizedError {
+    case invalidURL
+    case authenticationFailed
+    case networkError(Error)
+    case decodingError(Error)
+    case invalidResponse
+    case serverError(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            "The server URL is invalid."
+        case .authenticationFailed:
+            "Authentication failed. The provider rejected the request (this can also happen when the account's connection limit is reached)."
+        case let .networkError(error):
+            "Network error: \(error.localizedDescription)"
+        case let .decodingError(error):
+            "Failed to read the server response: \(error.localizedDescription)"
+        case .invalidResponse:
+            "Received an invalid response from the server."
+        case let .serverError(code):
+            "Server error (HTTP \(code))."
+        }
+    }
+
+    /// Whether the failure is likely transient and worth retrying.
+    /// Note: `authenticationFailed` (HTTP 401/403) is *not* retriable by
+    /// default — for login it means bad credentials. During an
+    /// already-authenticated sync it's usually the provider's connection /
+    /// rate limit, so those call sites opt in via `retryAuthFailure`.
+    var isRetriable: Bool {
+        switch self {
+        case .networkError:
+            // Timeouts, connection reset (RST), lost connection — transient.
+            true
+        case let .serverError(code):
+            code >= 500
+        case .invalidURL, .authenticationFailed, .decodingError, .invalidResponse:
+            false
+        }
+    }
+
+    var isAuthFailure: Bool {
+        if case .authenticationFailed = self { return true }
+        return false
+    }
+
+    /// Credential-free summary for diagnostic logs. Interpolated with
+    /// `privacy: .public` so user-exported logs stay actionable — which means
+    /// it must never contain a URL: Xtream URLs carry the account username and
+    /// password as query items, and underlying `NSError` descriptions can
+    /// embed the failing URL.
+    var logDescription: String {
+        switch self {
+        case .invalidURL:
+            return "invalid server URL"
+        case .authenticationFailed:
+            return "HTTP 401/403 (bad credentials or connection limit)"
+        case let .networkError(error):
+            let nsError = error as NSError
+            return "network error (\(nsError.domain) \(nsError.code))"
+        case let .decodingError(error):
+            switch error as? DecodingError {
+            case .dataCorrupted: return "undecodable response (not valid JSON)"
+            case .keyNotFound: return "undecodable response (missing key)"
+            case .typeMismatch: return "undecodable response (type mismatch)"
+            case .valueNotFound: return "undecodable response (missing value)"
+            default: return "undecodable response"
+            }
+        case .invalidResponse:
+            return "non-HTTP response"
+        case let .serverError(code):
+            return "HTTP \(code)"
+        }
+    }
+}

--- a/Lume/Services/Sync/EPGSyncManager.swift
+++ b/Lume/Services/Sync/EPGSyncManager.swift
@@ -70,7 +70,11 @@ actor EPGSyncManager {
             markSynced(sourceID)
             return true
         } catch {
-            Logger.database.warning("EPG source \(sourceID) sync failed: \(error.localizedDescription)")
+            // Credential-free detail (never a URL) so it can be public in
+            // user-exported diagnostic logs.
+            let nsError = error as NSError
+            let detail = (error as? M3UError)?.logDescription ?? "\(nsError.domain) \(nsError.code)"
+            Logger.database.warning("EPG source \(sourceID, privacy: .public) sync failed: \(detail, privacy: .public)")
             markStatus(sourceID, .error)
             return false
         }

--- a/Lume/Services/Sync/EPGSyncService.swift
+++ b/Lume/Services/Sync/EPGSyncService.swift
@@ -29,16 +29,50 @@ final class EPGSyncService {
     }
 
     /// Manual trigger (settings "Sync Now"): refreshes now regardless of the
-    /// schedule.
+    /// schedule or any in-flight content sync.
     func syncNow() {
         kick()
     }
 
-    /// Background trigger (launch / after a content sync): refreshes only if the
-    /// guide is stale per the EPG frequency setting.
+    /// Background trigger (launch): refreshes only if the guide is stale per
+    /// the EPG frequency setting — and never alongside a running or imminent
+    /// playlist sync. The guide download would open a second connection to the
+    /// provider, tripping the one-connection account cap many Xtream panels
+    /// enforce and failing both the guide and the sync's content requests.
+    /// `syncAfterContentSync` re-kicks the refresh once the sync queue drains.
     func syncIfDue() {
-        guard isDue else { return }
+        guard isDue, !isContentSyncPending else { return }
         kick()
+    }
+
+    /// Background trigger after a playlist sync finishes: refreshes regardless
+    /// of the schedule — a freshly synced playlist's channels shouldn't wait
+    /// for the next scheduled run — but still stands aside while another
+    /// playlist sync is due (this hook fires again when that one completes).
+    func syncAfterContentSync() {
+        guard !isContentSyncPending else { return }
+        kick()
+    }
+
+    /// Whether any playlist's content sync is running or due to start, meaning
+    /// a background guide refresh would compete with it for the provider's
+    /// connection allowance.
+    private var isContentSyncPending: Bool {
+        guard let container else { return false }
+        let frequency = SyncFrequency.resolve(
+            UserDefaults.standard.string(forKey: SyncFrequency.storageKey) ?? ""
+        )
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+        let playlists = (try? context.fetch(FetchDescriptor<Playlist>())) ?? []
+        return playlists.contains { playlist in
+            AutoSync.blocksEPGRefresh(
+                syncEnabled: playlist.syncEnabled,
+                status: playlist.syncStatus,
+                lastSyncDate: playlist.lastSyncDate,
+                frequency: frequency
+            )
+        }
     }
 
     private var isDue: Bool {

--- a/Lume/Services/Sync/SyncFrequency.swift
+++ b/Lume/Services/Sync/SyncFrequency.swift
@@ -130,4 +130,30 @@ enum AutoSync {
             && !alreadyStarted
             && frequency.isDue(lastSyncDate: lastSyncDate, now: now)
     }
+
+    /// Whether a background EPG refresh must stand aside for this playlist:
+    /// its content sync is either running right now or due to start.
+    ///
+    /// Both downloads hit the same provider account, and Xtream panels
+    /// commonly cap an account at one concurrent connection — a guide
+    /// download racing the catalog sync gets one of the two rejected (and can
+    /// leave the account briefly blocked, failing the sync's next requests
+    /// too). Deferring costs nothing: the post-sync hook re-kicks the refresh
+    /// as soon as the content sync queue drains.
+    static func blocksEPGRefresh(
+        syncEnabled: Bool,
+        status: SyncStatus,
+        lastSyncDate: Date?,
+        frequency: SyncFrequency,
+        now: Date = Date()
+    ) -> Bool {
+        status == .syncing || shouldSync(
+            syncEnabled: syncEnabled,
+            status: status,
+            lastSyncDate: lastSyncDate,
+            frequency: frequency,
+            alreadyStarted: false,
+            now: now
+        )
+    }
 }

--- a/Lume/Views/Sync/SyncProgressView.swift
+++ b/Lume/Views/Sync/SyncProgressView.swift
@@ -104,7 +104,10 @@ struct SyncProgressView: View {
                     ContentIndexingService.shared.kick(after: .seconds(3))
                     // Refresh the guide so a freshly synced playlist's channels
                     // get EPG data without waiting for the next scheduled run.
-                    EPGSyncService.shared.syncNow()
+                    // Gated: defers while another queued playlist sync is due,
+                    // so the guide download never races a content sync for the
+                    // provider's connection allowance.
+                    EPGSyncService.shared.syncAfterContentSync()
                     phase = .finished
                     // Auto-sync gets out of the way as soon as it succeeds so the
                     // user can start browsing; the manual flow waits for Done.

--- a/LumeTests/Services/SyncFrequencyTests.swift
+++ b/LumeTests/Services/SyncFrequencyTests.swift
@@ -186,8 +186,68 @@ struct SyncFrequencyTests {
         ))
     }
 
-    // MARK: - EPGSyncSchedule
+    // MARK: - blocksEPGRefresh
 
+    @Test func `epg refresh blocked while a sync is running`() {
+        // A manual sync in flight blocks even when the playlist isn't due.
+        #expect(AutoSync.blocksEPGRefresh(
+            syncEnabled: true,
+            status: .syncing,
+            lastSyncDate: Date(),
+            frequency: .daily
+        ))
+    }
+
+    @Test func `epg refresh blocked while a sync is due`() {
+        #expect(AutoSync.blocksEPGRefresh(
+            syncEnabled: true,
+            status: .idle,
+            lastSyncDate: nil,
+            frequency: .daily
+        ))
+    }
+
+    @Test func `epg refresh blocked while a failed sync is still due`() {
+        #expect(AutoSync.blocksEPGRefresh(
+            syncEnabled: true,
+            status: .error,
+            lastSyncDate: Date().addingTimeInterval(-48 * 60 * 60),
+            frequency: .daily
+        ))
+    }
+
+    @Test func `epg refresh not blocked by a recently synced playlist`() {
+        #expect(!AutoSync.blocksEPGRefresh(
+            syncEnabled: true,
+            status: .idle,
+            lastSyncDate: Date().addingTimeInterval(-60),
+            frequency: .daily
+        ))
+    }
+
+    @Test func `epg refresh not blocked by a sync-disabled playlist`() {
+        // Auto-sync will never run for it, so there is nothing to defer for.
+        #expect(!AutoSync.blocksEPGRefresh(
+            syncEnabled: false,
+            status: .idle,
+            lastSyncDate: nil,
+            frequency: .daily
+        ))
+    }
+
+    // MARK: - label
+
+    @Test func `sync frequency has labels`() {
+        for frequency in SyncFrequency.allCases {
+            #expect(!frequency.label.key.isEmpty)
+        }
+    }
+}
+
+/// Serialized: both tests mutate the same `UserDefaults.standard` key, so
+/// running them in parallel races the shared value.
+@Suite(.serialized)
+struct EPGSyncScheduleTests {
     @Test func `epg sync schedule stores and retrieves date`() {
         let date = Date(timeIntervalSince1970: 1_700_000_000)
         EPGSyncSchedule.lastSyncDate = date
@@ -197,13 +257,5 @@ struct SyncFrequencyTests {
     @Test func `epg sync schedule nil when never set`() {
         EPGSyncSchedule.lastSyncDate = nil
         #expect(EPGSyncSchedule.lastSyncDate == nil)
-    }
-
-    // MARK: - label
-
-    @Test func `sync frequency has labels`() {
-        for frequency in SyncFrequency.allCases {
-            #expect(!frequency.label.key.isEmpty)
-        }
     }
 }


### PR DESCRIPTION
## Problem

A user reported movies not syncing; their diagnostic log shows categories fetched fine (77 VOD / 59 Series / 233 Live), then two redacted `Xtream request failed` retries and nothing more — no "Fetched N movies" line, no error.

What actually happens:

1. At launch, the auto playlist sync and the EPG refresh (`LumeApp` → `EPGSyncService.syncIfDue()`) run **concurrently**.
2. For an Xtream playlist the EPG source is the same provider's `xmltv.php`, downloaded through `M3UClient`'s **own URLSession** — a second connection to a panel that caps the account at one (the exact limit `XtreamClient` serializes its own session around).
3. The panel rejects one side: the EPG download fails mid-category-sync (visible in the log), and the next heavy call, `get_vod_streams`, is rejected through all three attempts (~3 s each — a server rejection, not a timeout; the 2 s + 4 s backoff can't outlast the block window).
4. `syncMovies` throws, aborting series and live streams too. Categories were already saved → the user sees the category structure but no/stale movies.
5. **Self-sustaining:** neither the playlist nor the EPG schedule records a success, so both are due again next launch and the collision repeats every time.

## Fix

- **`AutoSync.blocksEPGRefresh(...)`** (pure, unit-tested): a playlist blocks a background guide refresh while its content sync is running or due to start.
- **`EPGSyncService.syncIfDue()`** (launch trigger) defers behind that gate; the post-sync hook now calls the new **`syncAfterContentSync()`**, which ignores EPG dueness (a freshly synced playlist shouldn't wait a day for guide data) but still defers while another queued playlist sync is pending. The manual "Sync Now" buttons in EPG settings stay ungated — explicit user intent.
- **Diagnostic logs become actionable:** the user's log only showed `<private>`. `XtreamError`/`M3UError` gain a credential-free `logDescription` (never a URL — Xtream/EPG URLs carry the account credentials as query items) interpolated with `privacy: .public`, and the Xtream retry loop now logs an `error`-level line when attempts exhaust — the final failure used to be completely silent.
- `XtreamError` moved to its own file; the additions pushed `XtreamClient.swift` over the 600-line lint cap.

## Tests

- 5 new cases for `blocksEPGRefresh` (syncing blocks; due blocks; failed-but-due blocks; recently-synced and sync-disabled don't).
- The two pre-existing `EPGSyncSchedule` tests now run in a `@Suite(.serialized)` — they mutate the same `UserDefaults.standard` key and raced under parallel execution (surfaced while running the suite; confirmed by an isolated-run pass).
- `xcodebuild test -only-testing:LumeTests/SyncFrequencyTests -only-testing:LumeTests/EPGSyncScheduleTests` → **TEST SUCCEEDED** (iPhone 17 Pro sim).

## Known trade-off

If a playlist is stuck permanently failing, its auto-sync stays "due" and the background EPG refresh keeps deferring — a user whose EPG source lives on a *different* host sees a stale guide until they fix/disable the playlist or tap Sync Now in EPG settings. Accepted: today's behavior breaks both the sync *and* the guide in that scenario.

## Follow-ups (not in this PR)

- Widen the Xtream retry budget (2 s + 4 s can't outlast a provider block window caused by another device/app on the account).
- Sync movies/series/live independently so one failing endpoint doesn't abort the others.