### PR TITLE
fix(tvos): pin the UI dark regardless of the device appearance

### DIFF
--- a/Lume.xcodeproj/project.pbxproj
+++ b/Lume.xcodeproj/project.pbxproj
@@ -397,6 +397,8 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				"INFOPLIST_KEY_UIUserInterfaceStyle[sdk=appletvos*]" = Dark;
+				"INFOPLIST_KEY_UIUserInterfaceStyle[sdk=appletvsimulator*]" = Dark;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
@@ -447,6 +449,8 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				"INFOPLIST_KEY_UIUserInterfaceStyle[sdk=appletvos*]" = Dark;
+				"INFOPLIST_KEY_UIUserInterfaceStyle[sdk=appletvsimulator*]" = Dark;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
@@ -770,6 +774,8 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				"INFOPLIST_KEY_UIUserInterfaceStyle[sdk=appletvos*]" = Dark;
+				"INFOPLIST_KEY_UIUserInterfaceStyle[sdk=appletvsimulator*]" = Dark;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";

--- a/Lume/Services/AppearanceSettings.swift
+++ b/Lume/Services/AppearanceSettings.swift
@@ -6,7 +6,12 @@
 //  as a plain string and applied at the scene root, so a device in Light Mode
 //  can still run Lume permanently dark (and vice versa). `system` keeps the
 //  previous follow-the-device behaviour. Not offered on tvOS — the TV UI is
-//  designed dark, so the setting isn't shown there and the applier is a no-op.
+//  designed dark and the whole app is pinned dark via the Info.plist
+//  `UIUserInterfaceStyle` key (`INFOPLIST_KEY_UIUserInterfaceStyle
+//  [sdk=appletv*]` in the target build settings), so the applier is a no-op.
+//  A runtime window override is not enough on tvOS: the system draws the
+//  scene backdrop behind the (transparent) window from the *device*
+//  appearance, so content pinned dark still sat on a light backdrop (#140).
 //
 //  Applied as a *window-level* style override (`overrideUserInterfaceStyle` /
 //  `NSApp.appearance`) rather than `.preferredColorScheme`: once that modifier
@@ -76,7 +81,8 @@ extension View {
     /// file header for why this is not `.preferredColorScheme`). Views that
     /// force their own scheme (the players' `.preferredColorScheme(.dark)`)
     /// still win for their presentation. No-op on tvOS, which has no
-    /// Appearance setting — the TV UI is designed dark.
+    /// Appearance setting — the TV UI is pinned dark by the Info.plist
+    /// `UIUserInterfaceStyle` key (see the file header).
     func appAppearance(_ appearance: AppAppearance) -> some View {
         #if os(tvOS)
             return self


### PR DESCRIPTION
## Summary
When the Apple TV is set to Light appearance (or Automatic during the day), Lume's tvOS UI became unreadable: Live TV rendered white category/channel names on a light backdrop, while Settings and the playlist-sync screen mixed adaptive dark text with hardcoded-dark surfaces. The TV UI is designed dark, but nothing enforced it — the `appAppearance` window override is deliberately a no-op on tvOS and no `UIUserInterfaceStyle` key was set.

## Implementation
The whole tvOS app is now pinned dark via the generated Info.plist: `INFOPLIST_KEY_UIUserInterfaceStyle[sdk=appletvos*/appletvsimulator*] = Dark` on the Lume target (Debug/Release/Sideload). iOS/macOS/visionOS builds are unaffected, so the user-facing Appearance setting from #135 keeps working there.

The issue suggested `preferredColorScheme(.dark)` at the scene root; a runtime override (tried first as the window-level `overrideUserInterfaceStyle` applier Lume already uses on iOS) turned out to be insufficient on tvOS 26: the trait chain (window → hosting controller → views) resolved dark, but the system draws the scene backdrop behind the transparent window from the *device* appearance, leaving dark-mode text sitting on a light gray backdrop. The Info.plist key pins the entire process — scene backdrop, launch UI, and every window — which only a launch-time declaration can do. That finding is documented in `AppearanceSettings.swift`'s header next to the (still no-op) tvOS branch.

Verified on the tvOS 26.5 simulator with the device appearance driven to Light through the tvOS Settings app: the playlist-sync screen, Home, and the Live TV guide (the original customer report) all render dark and readable; flipping back to Dark is unchanged.

## Testing
- [x] Acceptance criteria met (Live TV, sync progress, Home verified readable in Light appearance)
- [x] Builds clean (XcodeBuildMCP `build_sim`, iOS 26.4 + tvOS 26.5)
- [x] SwiftLint clean
- [ ] Tests added — skipped: build-configuration + comment change, no new testable logic (existing `AppearanceSettingsTests` still cover `AppAppearance`)
- [x] UI verified on simulator (tvOS 26.5, Light and Dark device appearance)

## Platforms
- [ ] iOS / iPadOS
- [x] tvOS
- [ ] macOS
- [ ] visionOS

## Related
Closes #140