### PR TITLE
fix: keep playlist credentials out of exported diagnostic logs

### DIFF
--- a/Lume/Services/Debug/DebugLogExporter.swift
+++ b/Lume/Services/Debug/DebugLogExporter.swift
@@ -83,7 +83,11 @@ nonisolated struct DebugLogExporter {
             .compactMap { $0 as? OSLogEntryLog }
             .map { entry in
                 let time = Self.entryStamp.string(from: entry.date)
-                return "\(time)  [\(entry.category)] \(Self.label(for: entry.level))  \(entry.composedMessage)"
+                // Last line of defense: even if a future call site accidentally
+                // interpolates a URL with `privacy: .public`, it must not reach
+                // a shared report — stream URLs carry playlist credentials.
+                let message = LogRedaction.scrubURLs(in: entry.composedMessage)
+                return "\(time)  [\(entry.category)] \(Self.label(for: entry.level))  \(message)"
             }
     }
 

--- a/Lume/Services/Network/StalkerSupport.swift
+++ b/Lume/Services/Network/StalkerSupport.swift
@@ -148,6 +148,34 @@ enum StalkerError: LocalizedError {
         }
     }
 
+    /// Credential-free summary for diagnostic logs. Interpolated with
+    /// `privacy: .public` so user-exported logs stay actionable — which means
+    /// it must never contain a URL: Stalker portal links carry the MAC
+    /// address and short-lived tokens, and underlying `NSError` descriptions
+    /// can embed the failing URL.
+    var logDescription: String {
+        switch self {
+        case .invalidURL:
+            return "invalid portal URL"
+        case .handshakeFailed:
+            return "portal handshake failed"
+        case .authenticationFailed:
+            return "portal rejected the MAC address"
+        case .noStreamURL:
+            return "no playable stream in portal response"
+        case let .networkError(error):
+            let nsError = error as NSError
+            return "network error (\(nsError.domain) \(nsError.code))"
+        case let .decodingError(error):
+            let nsError = error as NSError
+            return "undecodable portal response (\(nsError.domain) \(nsError.code))"
+        case .invalidResponse:
+            return "non-HTTP response"
+        case let .serverError(code):
+            return "HTTP \(code)"
+        }
+    }
+
     /// Whether the failure is likely transient and worth retrying.
     var isRetriable: Bool {
         switch self {

--- a/Lume/Services/Sync/CloudSync/CloudSyncCoordinator.swift
+++ b/Lume/Services/Sync/CloudSync/CloudSyncCoordinator.swift
@@ -381,8 +381,11 @@ final class CloudSyncCoordinator {
            let perItem = ckError.partialErrorsByItemID, !perItem.isEmpty
         {
             for (itemID, itemError) in perItem {
+                // LogRedaction.describe, not String(reflecting:): conflict
+                // errors can dump the whole CKRecord, and synced-playlist
+                // records carry server URLs and account credentials.
                 Logger.sync.error(
-                    "CloudKit \(phase, privacy: .public) rejected \(String(describing: itemID), privacy: .public): \(String(reflecting: itemError), privacy: .public)"
+                    "CloudKit \(phase, privacy: .public) rejected \(String(describing: itemID), privacy: .public): \(LogRedaction.describe(itemError), privacy: .public)"
                 )
             }
             // Records usually all fail identically; collapse to the distinct
@@ -391,7 +394,7 @@ final class CloudSyncCoordinator {
             return messages.sorted().joined(separator: "; ")
         }
 
-        Logger.sync.error("CloudKit \(phase, privacy: .public) failed: \(String(reflecting: error), privacy: .public)")
+        Logger.sync.error("CloudKit \(phase, privacy: .public) failed: \(LogRedaction.describe(error), privacy: .public)")
         return error.localizedDescription
     }
 

--- a/Lume/Utils/LogRedaction.swift
+++ b/Lume/Utils/LogRedaction.swift
@@ -1,0 +1,41 @@
+//
+//  LogRedaction.swift
+//  Lume
+//
+//  Scrubs sensitive material out of strings that are interpolated into the
+//  unified log with `privacy: .public` (and therefore end up verbatim in
+//  user-exported diagnostic reports — see DebugLogExporter).
+//
+//  Playlist, EPG, and Stalker URLs carry account credentials: Xtream embeds
+//  the username/password in the path or query, M3U links carry them as query
+//  items, and Stalker portal links include the MAC address and short-lived
+//  tokens. Any third-party message that echoes a URL (libvlc, FFmpeg,
+//  CloudKit record dumps) must pass through here before going public.
+//
+
+import Foundation
+
+nonisolated enum LogRedaction {
+    /// Replaces every URL-like substring with `scheme://<redacted>`, keeping
+    /// the surrounding message intact so the log line stays actionable.
+    static func scrubURLs(in message: String) -> String {
+        guard message.contains("://") else { return message }
+        return message.replacing(urlPattern) { match in
+            "\(match.output.scheme)://<redacted>"
+        }
+    }
+
+    /// Compact, credential-free rendering of an error for public log
+    /// interpolation: domain + code + scrubbed message. Never use
+    /// `String(reflecting:)` on errors bound for public logs — CloudKit
+    /// conflict errors can dump whole CKRecords, and synced-playlist records
+    /// carry server URLs and account credentials.
+    static func describe(_ error: Error) -> String {
+        let nsError = error as NSError
+        return "\(nsError.domain) \(nsError.code): \(scrubURLs(in: nsError.localizedDescription))"
+    }
+
+    /// Matches `scheme://` followed by everything up to whitespace or a
+    /// quote/bracket that commonly delimits URLs in log prose.
+    private static let urlPattern = /(?<scheme>[A-Za-z][A-Za-z0-9+.\-]*):\/\/[^\s'"<>]+/
+}

--- a/Lume/Views/Player/FullScreenPlayerView.swift
+++ b/Lume/Views/Player/FullScreenPlayerView.swift
@@ -398,7 +398,8 @@ struct FullScreenPlayerView: View {
             resolvedMedia = try await StalkerStreamResolver.resolve(activeMedia, container: modelContext.container)
         } catch {
             resolveError = error.localizedDescription
-            Logger.player.error("Stalker stream resolution failed: \(error.localizedDescription, privacy: .public)")
+            let detail = (error as? StalkerError)?.logDescription ?? LogRedaction.describe(error)
+            Logger.player.error("Stalker stream resolution failed: \(detail, privacy: .public)")
         }
     }
 

--- a/Lume/Views/Player/LumeEngineCoordinator.swift
+++ b/Lume/Views/Player/LumeEngineCoordinator.swift
@@ -306,11 +306,11 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
             Logger.player.warning("LumeEngine stalled at \(position, format: .fixed(precision: 2))s")
             onStalled?()
         case let .error(error):
-            Logger.player.error("LumeEngine error: \(String(describing: error), privacy: .public)")
+            Logger.player.error("LumeEngine error: \(LogRedaction.scrubURLs(in: String(describing: error)), privacy: .public)")
         case let .didSeek(position):
             Logger.player.info("LumeEngine didSeek → \(position, format: .fixed(precision: 2))s")
         case let .decoderDowngraded(error):
-            Logger.player.warning("LumeEngine decoder downgraded: \(String(describing: error), privacy: .public)")
+            Logger.player.warning("LumeEngine decoder downgraded: \(LogRedaction.scrubURLs(in: String(describing: error)), privacy: .public)")
         case .opened:
             break
         }

--- a/Lume/Views/Player/VLCPlayerCoordinator+Diagnostics.swift
+++ b/Lume/Views/Player/VLCPlayerCoordinator+Diagnostics.swift
@@ -106,16 +106,20 @@ private final class VLCLogBridge: NSObject, VLCLogging {
         // harmless, and drowns out everything else. Drop it.
         if message.contains("lookup failed (-25300") { return }
 
+        // libvlc echoes the full MRL in many messages ("open of '…' failed",
+        // redirects, access setup) — and stream URLs carry the playlist
+        // credentials, so scrub before the public interpolation.
+        let scrubbed = LogRedaction.scrubURLs(in: message)
         let module = context?.module ?? "vlc"
         switch logLevel {
         case .error:
-            Logger.player.error("libvlc[\(module, privacy: .public)] \(message, privacy: .public)")
+            Logger.player.error("libvlc[\(module, privacy: .public)] \(scrubbed, privacy: .public)")
         case .warning:
-            Logger.player.warning("libvlc[\(module, privacy: .public)] \(message, privacy: .public)")
+            Logger.player.warning("libvlc[\(module, privacy: .public)] \(scrubbed, privacy: .public)")
         case .info:
-            Logger.player.info("libvlc[\(module, privacy: .public)] \(message, privacy: .public)")
+            Logger.player.info("libvlc[\(module, privacy: .public)] \(scrubbed, privacy: .public)")
         default:
-            Logger.player.debug("libvlc[\(module, privacy: .public)] \(message, privacy: .public)")
+            Logger.player.debug("libvlc[\(module, privacy: .public)] \(scrubbed, privacy: .public)")
         }
     }
 }

--- a/LumeTests/Services/LogRedactionTests.swift
+++ b/LumeTests/Services/LogRedactionTests.swift
@@ -1,0 +1,54 @@
+//
+//  LogRedactionTests.swift
+//  LumeTests
+//
+//  Guards the diagnostic-log scrubber: messages interpolated with
+//  `privacy: .public` (libvlc bridge, CloudKit error summaries, engine
+//  errors) must never carry playlist URLs or credentials into a
+//  user-exported report.
+//
+
+import Foundation
+@testable import Lume
+import Testing
+
+struct LogRedactionTests {
+    @Test func `strips xtream credentials in path`() {
+        let message = "open of 'http://iptv.example.com:8080/live/myuser/mypass/1234.ts' failed"
+        let scrubbed = LogRedaction.scrubURLs(in: message)
+        #expect(scrubbed == "open of 'http://<redacted>' failed")
+        #expect(!scrubbed.contains("myuser"))
+        #expect(!scrubbed.contains("mypass"))
+    }
+
+    @Test func `strips credentials in query items`() {
+        let message = "GET https://host.tld/get.php?username=alice&password=s3cret&type=m3u_plus returned 404"
+        let scrubbed = LogRedaction.scrubURLs(in: message)
+        #expect(scrubbed == "GET https://<redacted> returned 404")
+    }
+
+    @Test func `strips userinfo URLs`() {
+        let scrubbed = LogRedaction.scrubURLs(in: "redirecting to rtsp://user:pass@10.0.0.1/stream")
+        #expect(scrubbed == "redirecting to rtsp://<redacted>")
+    }
+
+    @Test func `scrubs every URL in a message`() {
+        let message = "moved http://a.example/user/pass/1.ts to https://b.example/user/pass/1.ts"
+        let scrubbed = LogRedaction.scrubURLs(in: message)
+        #expect(scrubbed == "moved http://<redacted> to https://<redacted>")
+    }
+
+    @Test func `leaves URL free messages untouched`() {
+        let message = "buffering complete (rebuffered 1.52s)"
+        #expect(LogRedaction.scrubURLs(in: message) == message)
+    }
+
+    @Test func `describe scrubs embedded URL`() {
+        let error = NSError(
+            domain: "TestDomain",
+            code: 7,
+            userInfo: [NSLocalizedDescriptionKey: "could not load http://iptv.example.com/live/u/p/9.m3u8"]
+        )
+        #expect(LogRedaction.describe(error) == "TestDomain 7: could not load http://<redacted>")
+    }
+}


### PR DESCRIPTION
## Problem

Diagnostic exports (`DebugLogExporter`) rely on os_log `<private>` redaction, so anything interpolated with `privacy: .public` lands verbatim in the report a user shares with support. An audit of all ~50 public log sites found four that could still carry a full stream URL — and Xtream/M3U URLs embed the account username/password, while Stalker links carry the MAC address and short-lived tokens:

1. **libvlc log bridge** (`VLCPlayerCoordinator+Diagnostics.swift`) forwarded libvlc messages verbatim; libvlc routinely echoes the full MRL (`open of 'http://host/live/user/pass/1.ts' failed`, redirects, access setup).
2. **CloudKit sync errors** (`CloudSyncCoordinator.swift`) were logged via `String(reflecting:)`, which can dump whole CKRecords — and `SyncedPlaylist` records carry the server URL, username, password, and MAC.
3. **Stalker resolution failures** (`FullScreenPlayerView.swift`) logged `error.localizedDescription`, which for wrapped `NSError`s can embed the failing portal URL.
4. **LumeEngine errors** (`LumeEngineCoordinator.swift`) were logged verbatim; the engine's external-subtitle path builds `EngineError` messages containing the full URL (latent today — the app doesn't call it yet).

## Fix

- New `LogRedaction` utility: `scrubURLs(in:)` replaces any `scheme://…` substring with `scheme://<redacted>`; `describe(_:)` renders errors as `domain code: scrubbed-message` instead of reflection. All four sites above now route through it.
- `StalkerError` gains a credential-free `logDescription`, matching the existing `XtreamError` / `M3UError` convention.
- Defense in depth: `DebugLogExporter` now scrubs every `composedMessage` at export time, so a future accidental public URL interpolation can never reach a shared report.

## Verified clean

- Stream-URL log sites in the player coordinators use `.private(mask: .hash)`.
- `XtreamError` / `M3UError` `logDescription`s and `EPGSyncManager` were already credential-free.
- Audio-route logging uses `portType.rawValue`, not personal device names.
- KSPlayer/FFmpeg internal logs never enter the export (subsystem predicate); Demuxer error contexts contain no URLs.

## Testing

- `LumeTests/Services/LogRedactionTests.swift`: Xtream path credentials, query-item credentials, userinfo URLs, multi-URL messages, URL-free passthrough, error descriptions.
- Full build + `LogRedactionTests` / `DebugLogExporterTests` pass on iPhone 17 Pro simulator.