### PR TITLE
fix: tolerate Xtream panel type drift and log which endpoint/field failed

### DIFF
--- a/Lume/Services/Network/XtreamClient.swift
+++ b/Lume/Services/Network/XtreamClient.swift
@@ -103,12 +103,15 @@ class XtreamClient: APIClient {
 
     /// Performs a request with retry-and-backoff for transient failures.
     ///
+    /// - Parameter action: constant API-action label (e.g. `get_live_streams`)
+    ///   included in failure logs so diagnostics can pinpoint the endpoint.
+    ///   Must never carry request parameters — logged as `privacy: .public`.
     /// - Parameter retryAuthFailure: when `true`, HTTP 401/403 is also treated
     ///   as transient. Sync/content calls set this because, after `getInfo`
     ///   has already proven the credentials, a 401/403 is almost always the
     ///   provider's connection/rate limit rather than bad credentials. Login
     ///   (`getInfo`) leaves it `false` so wrong credentials fail fast.
-    private func request<T: Decodable>(_ url: URL, retryAuthFailure: Bool = true) async throws -> T {
+    private func request<T: Decodable>(_ url: URL, action: String, retryAuthFailure: Bool = true) async throws -> T {
         var attempt = 0
         while true {
             attempt += 1
@@ -118,7 +121,7 @@ class XtreamClient: APIClient {
                 let retriable = error.isRetriable || (retryAuthFailure && error.isAuthFailure)
                 guard retriable, attempt < Self.maxAttempts else {
                     Logger.network.error(
-                        "Xtream request failed permanently (\(error.logDescription, privacy: .public)) after \(attempt) attempt(s)"
+                        "Xtream \(action, privacy: .public) request failed permanently (\(error.logDescription, privacy: .public)) after \(attempt) attempt(s)"
                     )
                     throw error
                 }
@@ -127,7 +130,7 @@ class XtreamClient: APIClient {
                 // release the connection slot / clear the rate-limit window.
                 let delay = pow(2.0, Double(attempt))
                 Logger.network.warning(
-                    "Xtream request failed (\(error.logDescription, privacy: .public)); retry \(attempt)/\(Self.maxAttempts - 1) in \(delay)s"
+                    "Xtream \(action, privacy: .public) request failed (\(error.logDescription, privacy: .public)); retry \(attempt)/\(Self.maxAttempts - 1) in \(delay)s"
                 )
                 try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             }
@@ -179,7 +182,7 @@ class XtreamClient: APIClient {
         }
 
         // Login: a 401/403 means bad credentials, so don't retry it.
-        return try await request(url, retryAuthFailure: false)
+        return try await request(url, action: "auth", retryAuthFailure: false)
     }
 
     /// 2. Get Live Categories
@@ -194,7 +197,8 @@ class XtreamClient: APIClient {
             throw XtreamError.invalidURL
         }
 
-        return try await request(url)
+        let list: XtreamList<XtreamCategory> = try await request(url, action: "get_live_categories")
+        return list.items
     }
 
     /// 3. Get Live Streams
@@ -212,7 +216,8 @@ class XtreamClient: APIClient {
             throw XtreamError.invalidURL
         }
 
-        return try await request(url)
+        let list: XtreamList<XtreamLiveStream> = try await request(url, action: "get_live_streams")
+        return list.items
     }
 
     /// 4. Get VOD Categories
@@ -227,7 +232,8 @@ class XtreamClient: APIClient {
             throw XtreamError.invalidURL
         }
 
-        return try await request(url)
+        let list: XtreamList<XtreamCategory> = try await request(url, action: "get_vod_categories")
+        return list.items
     }
 
     /// 5. Get VOD Streams
@@ -245,7 +251,8 @@ class XtreamClient: APIClient {
             throw XtreamError.invalidURL
         }
 
-        return try await request(url)
+        let list: XtreamList<XtreamVODStream> = try await request(url, action: "get_vod_streams")
+        return list.items
     }
 
     /// 6. Get VOD Info
@@ -261,7 +268,7 @@ class XtreamClient: APIClient {
             throw XtreamError.invalidURL
         }
 
-        return try await request(url)
+        return try await request(url, action: "get_vod_info")
     }
 
     /// 7. Get Series Categories
@@ -276,7 +283,8 @@ class XtreamClient: APIClient {
             throw XtreamError.invalidURL
         }
 
-        return try await request(url)
+        let list: XtreamList<XtreamCategory> = try await request(url, action: "get_series_categories")
+        return list.items
     }
 
     /// 8. Get Series
@@ -294,7 +302,8 @@ class XtreamClient: APIClient {
             throw XtreamError.invalidURL
         }
 
-        return try await request(url)
+        let list: XtreamList<XtreamSeries> = try await request(url, action: "get_series")
+        return list.items
     }
 
     /// 9. Get Series Info
@@ -310,7 +319,7 @@ class XtreamClient: APIClient {
             throw XtreamError.invalidURL
         }
 
-        return try await request(url)
+        return try await request(url, action: "get_series_info")
     }
 
     /// 10. Get Short EPG
@@ -329,17 +338,13 @@ class XtreamClient: APIClient {
             throw XtreamError.invalidURL
         }
 
-        struct ShortEPGResponse: Decodable {
-            let epgListings: [XtreamShortEPG]
-        }
-
         do {
-            let response: ShortEPGResponse = try await request(url)
-            return response.epgListings
+            let response: ShortEPGResponse = try await request(url, action: "get_short_epg")
+            return response.epgListings.items
         } catch {
             // Try array fallback if not wrapped
-            if let arrayResponse: [XtreamShortEPG] = try? await request(url) {
-                return arrayResponse
+            if let arrayResponse: XtreamList<XtreamShortEPG> = try? await request(url, action: "get_short_epg") {
+                return arrayResponse.items
             }
             throw error
         }
@@ -524,6 +529,15 @@ final nonisolated class XMLTVParser: NSObject, XMLParserDelegate {
 }
 
 // MARK: - Supporting Types
+
+/// Wrapper some panels put around `get_short_epg` listings.
+private struct ShortEPGResponse: Decodable {
+    let epgListings: XtreamList<XtreamShortEPG>
+
+    enum CodingKeys: String, CodingKey {
+        case epgListings = "epg_listings"
+    }
+}
 
 enum StreamFormat: String {
     case m3u8

--- a/Lume/Services/Network/XtreamDTOs.swift
+++ b/Lume/Services/Network/XtreamDTOs.swift
@@ -1,5 +1,104 @@
 import Foundation
 
+// MARK: - Lenient field decoding
+
+/// Xtream panel forks disagree on JSON types field by field — the same key can
+/// arrive as a string on one provider and a number on the next. These helpers
+/// accept either representation (and swallow null / absent keys) so a single
+/// odd field can't fail a whole response.
+extension KeyedDecodingContainer {
+    func lenientString(forKey key: Key) -> String? {
+        if let string = try? decodeIfPresent(String.self, forKey: key) { return string }
+        if let int = try? decodeIfPresent(Int.self, forKey: key) { return String(int) }
+        if let double = try? decodeIfPresent(Double.self, forKey: key) { return String(double) }
+        return nil
+    }
+
+    func lenientInt(forKey key: Key) -> Int? {
+        if let int = try? decodeIfPresent(Int.self, forKey: key) { return int }
+        if let string = try? decodeIfPresent(String.self, forKey: key) { return Int(string) }
+        if let double = try? decodeIfPresent(Double.self, forKey: key) { return Int(double) }
+        return nil
+    }
+
+    func lenientDouble(forKey key: Key) -> Double? {
+        if let double = try? decodeIfPresent(Double.self, forKey: key) { return double }
+        if let string = try? decodeIfPresent(String.self, forKey: key) { return Double(string) }
+        return nil
+    }
+}
+
+// MARK: - Lenient list decoding
+
+/// A list endpoint payload. Panels return either a JSON array or — on some
+/// forks — an object keyed by index ("0", "1", …); an individual element that
+/// still fails to decode is dropped rather than failing the whole request.
+///
+/// If the payload has entries but *none* decodes (e.g. an HTML block page that
+/// happens to be JSON, or an `{"error": …}` body), the first element error is
+/// rethrown: reporting garbage as "zero items" would let the sync prune the
+/// entire catalog.
+struct XtreamList<Element: Decodable>: Decodable {
+    let items: [Element]
+
+    /// Decoded in place of an element that failed, purely to advance the
+    /// unkeyed container past the bad value.
+    private struct SkippedValue: Decodable {
+        init(from _: Decoder) throws {}
+    }
+
+    private struct IndexKey: CodingKey {
+        let stringValue: String
+        let intValue: Int?
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+            intValue = Int(stringValue)
+        }
+
+        init?(intValue: Int) {
+            stringValue = String(intValue)
+            self.intValue = intValue
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        if var unkeyed = try? decoder.unkeyedContainer() {
+            var result: [Element] = []
+            var firstError: Error?
+            while !unkeyed.isAtEnd {
+                do {
+                    try result.append(unkeyed.decode(Element.self))
+                } catch {
+                    firstError = firstError ?? error
+                    if (try? unkeyed.decode(SkippedValue.self)) == nil {
+                        break // cannot advance past the bad value — bail rather than spin
+                    }
+                }
+            }
+            if result.isEmpty, let firstError { throw firstError }
+            items = result
+            return
+        }
+
+        let keyed = try decoder.container(keyedBy: IndexKey.self)
+        let sortedKeys = keyed.allKeys.sorted {
+            ($0.intValue ?? .max, $0.stringValue) < ($1.intValue ?? .max, $1.stringValue)
+        }
+        var result: [Element] = []
+        var firstError: Error?
+        for key in sortedKeys {
+            do {
+                try result.append(keyed.decode(Element.self, forKey: key))
+            } catch {
+                firstError = firstError ?? error
+            }
+        }
+        if result.isEmpty, let firstError { throw firstError }
+        items = result
+    }
+}
+
 // MARK: - Server & User Info
 
 struct XtreamAuthResponse: Decodable {
@@ -27,6 +126,16 @@ struct XtreamUserInfo: Decodable {
         case activeCons = "active_cons"
         case maxConnections = "max_connections"
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        username = container.lenientString(forKey: .username)
+        status = container.lenientString(forKey: .status)
+        expDate = container.lenientString(forKey: .expDate)
+        isTrial = container.lenientString(forKey: .isTrial)
+        activeCons = container.lenientString(forKey: .activeCons)
+        maxConnections = container.lenientString(forKey: .maxConnections)
+    }
 }
 
 struct XtreamServerInfo: Decodable {
@@ -45,6 +154,17 @@ struct XtreamServerInfo: Decodable {
         case timestampNow = "timestamp_now"
         case timeNow = "time_now"
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        url = container.lenientString(forKey: .url)
+        port = container.lenientString(forKey: .port)
+        httpsPort = container.lenientString(forKey: .httpsPort)
+        serverProtocol = container.lenientString(forKey: .serverProtocol)
+        timezone = container.lenientString(forKey: .timezone)
+        timestampNow = container.lenientInt(forKey: .timestampNow)
+        timeNow = container.lenientString(forKey: .timeNow)
+    }
 }
 
 // MARK: - Categories
@@ -58,6 +178,24 @@ struct XtreamCategory: Decodable {
         case categoryId = "category_id"
         case categoryName = "category_name"
         case parentId = "parent_id"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // A category is unusable without an id (sync keys on it) — throwing
+        // here drops just this entry when decoded through `XtreamList`.
+        guard let id = container.lenientString(forKey: .categoryId) else {
+            throw DecodingError.keyNotFound(
+                CodingKeys.categoryId,
+                DecodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: "category_id missing or not a string/number"
+                )
+            )
+        }
+        categoryId = id
+        categoryName = container.lenientString(forKey: .categoryName) ?? ""
+        parentId = container.lenientInt(forKey: .parentId)
     }
 }
 
@@ -93,47 +231,18 @@ struct XtreamLiveStream: Decodable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        num = try? container.decodeIfPresent(Int.self, forKey: .num)
-        name = try? container.decodeIfPresent(String.self, forKey: .name)
-        streamType = try? container.decodeIfPresent(String.self, forKey: .streamType)
-        streamId = try? container.decodeIfPresent(Int.self, forKey: .streamId)
-        streamIcon = try? container.decodeIfPresent(String.self, forKey: .streamIcon)
-        epgChannelId = try? container.decodeIfPresent(String.self, forKey: .epgChannelId)
-        added = try? container.decodeIfPresent(String.self, forKey: .added)
-
-        if let isAdultInt = try? container.decodeIfPresent(Int.self, forKey: .isAdult) {
-            isAdult = isAdultInt
-        } else if let isAdultString = try? container.decodeIfPresent(String.self, forKey: .isAdult) {
-            isAdult = Int(isAdultString)
-        } else {
-            isAdult = 0
-        }
-
-        if let catIdStr = try? container.decodeIfPresent(String.self, forKey: .categoryId) {
-            categoryId = catIdStr
-        } else if let catIdInt = try? container.decodeIfPresent(Int.self, forKey: .categoryId) {
-            categoryId = String(catIdInt)
-        } else {
-            categoryId = nil
-        }
-
-        customSid = try? container.decodeIfPresent(String.self, forKey: .customSid)
-
-        if let tvArchInt = try? container.decodeIfPresent(Int.self, forKey: .tvArchive) {
-            tvArchive = tvArchInt
-        } else if let tvArchStr = try? container.decodeIfPresent(String.self, forKey: .tvArchive) {
-            tvArchive = Int(tvArchStr)
-        } else {
-            tvArchive = 0
-        }
-
-        if let tvArchDurInt = try? container.decodeIfPresent(Int.self, forKey: .tvArchiveDuration) {
-            tvArchiveDuration = tvArchDurInt
-        } else if let tvArchDurStr = try? container.decodeIfPresent(String.self, forKey: .tvArchiveDuration) {
-            tvArchiveDuration = Int(tvArchDurStr)
-        } else {
-            tvArchiveDuration = 0
-        }
+        num = container.lenientInt(forKey: .num)
+        name = container.lenientString(forKey: .name)
+        streamType = container.lenientString(forKey: .streamType)
+        streamId = container.lenientInt(forKey: .streamId)
+        streamIcon = container.lenientString(forKey: .streamIcon)
+        epgChannelId = container.lenientString(forKey: .epgChannelId)
+        added = container.lenientString(forKey: .added)
+        isAdult = container.lenientInt(forKey: .isAdult) ?? 0
+        categoryId = container.lenientString(forKey: .categoryId)
+        customSid = container.lenientString(forKey: .customSid)
+        tvArchive = container.lenientInt(forKey: .tvArchive) ?? 0
+        tvArchiveDuration = container.lenientInt(forKey: .tvArchiveDuration) ?? 0
     }
 }
 
@@ -170,58 +279,19 @@ struct XtreamVODStream: Decodable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        num = try? container.decodeIfPresent(Int.self, forKey: .num)
-        name = try? container.decodeIfPresent(String.self, forKey: .name)
-        streamType = try? container.decodeIfPresent(String.self, forKey: .streamType)
-        streamId = try? container.decodeIfPresent(Int.self, forKey: .streamId)
-        streamIcon = try? container.decodeIfPresent(String.self, forKey: .streamIcon)
-        rating = Self.decodeDouble(from: container, forKey: .rating) ?? 0
-        rating5Based = Self.decodeDouble(from: container, forKey: .rating5Based) ?? 0
-        added = try? container.decodeIfPresent(String.self, forKey: .added)
-        isAdult = Self.decodeInt(from: container, forKey: .isAdult) ?? 0
-        categoryId = Self.decodeCategoryID(from: container, forKey: .categoryId)
-        containerExtension = try? container.decodeIfPresent(String.self, forKey: .containerExtension)
-        tmdb = Self.decodeTMDB(from: container)
-    }
-
-    private static func decodeDouble(from container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) -> Double? {
-        if let value = try? container.decodeIfPresent(Double.self, forKey: key) {
-            return value
-        } else if let str = try? container.decodeIfPresent(String.self, forKey: key) {
-            return Double(str)
-        }
-        return nil
-    }
-
-    private static func decodeInt(from container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) -> Int? {
-        if let value = try? container.decodeIfPresent(Int.self, forKey: key) {
-            return value
-        } else if let str = try? container.decodeIfPresent(String.self, forKey: key) {
-            return Int(str)
-        }
-        return nil
-    }
-
-    private static func decodeCategoryID(from container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) -> String? {
-        if let str = try? container.decodeIfPresent(String.self, forKey: key) {
-            return str
-        } else if let int = try? container.decodeIfPresent(Int.self, forKey: key) {
-            return String(int)
-        }
-        return nil
-    }
-
-    private static func decodeTMDB(from container: KeyedDecodingContainer<CodingKeys>) -> String? {
-        if let str = try? container.decodeIfPresent(String.self, forKey: .tmdb) {
-            return str
-        } else if let int = try? container.decodeIfPresent(Int.self, forKey: .tmdb) {
-            return String(int)
-        } else if let str = try? container.decodeIfPresent(String.self, forKey: .tmdbId) {
-            return str
-        } else if let int = try? container.decodeIfPresent(Int.self, forKey: .tmdbId) {
-            return String(int)
-        }
-        return nil
+        num = container.lenientInt(forKey: .num)
+        name = container.lenientString(forKey: .name)
+        streamType = container.lenientString(forKey: .streamType)
+        streamId = container.lenientInt(forKey: .streamId)
+        streamIcon = container.lenientString(forKey: .streamIcon)
+        rating = container.lenientDouble(forKey: .rating) ?? 0
+        rating5Based = container.lenientDouble(forKey: .rating5Based) ?? 0
+        added = container.lenientString(forKey: .added)
+        isAdult = container.lenientInt(forKey: .isAdult) ?? 0
+        categoryId = container.lenientString(forKey: .categoryId)
+        containerExtension = container.lenientString(forKey: .containerExtension)
+        // Some playlists use "tmdb", others "tmdb_id".
+        tmdb = container.lenientString(forKey: .tmdb) ?? container.lenientString(forKey: .tmdbId)
     }
 }
 
@@ -234,6 +304,14 @@ struct XtreamVODInfo: Decodable {
     enum CodingKeys: String, CodingKey {
         case info
         case movieData = "movie_data"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Panels emit an empty array instead of an object when a section has
+        // no data — tolerate any malformed section rather than fail the call.
+        info = try? container.decodeIfPresent(XtreamVODMetadata.self, forKey: .info)
+        movieData = try? container.decodeIfPresent(XtreamVODStreamData.self, forKey: .movieData)
     }
 }
 
@@ -262,31 +340,17 @@ struct XtreamVODMetadata: Decodable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        name = try? container.decodeIfPresent(String.self, forKey: .name)
-        movieImage = try? container.decodeIfPresent(String.self, forKey: .movieImage)
-        releaseDate = try? container.decodeIfPresent(String.self, forKey: .releaseDate)
-        youtubeTrailer = try? container.decodeIfPresent(String.self, forKey: .youtubeTrailer)
-        director = try? container.decodeIfPresent(String.self, forKey: .director)
-        actors = try? container.decodeIfPresent(String.self, forKey: .actors)
-        description = try? container.decodeIfPresent(String.self, forKey: .description)
-        plot = try? container.decodeIfPresent(String.self, forKey: .plot)
-        genre = try? container.decodeIfPresent(String.self, forKey: .genre)
-
-        if let tmdbStr = try? container.decodeIfPresent(String.self, forKey: .tmdbId) {
-            tmdbId = tmdbStr
-        } else if let tmdbInt = try? container.decodeIfPresent(Int.self, forKey: .tmdbId) {
-            tmdbId = String(tmdbInt)
-        } else {
-            tmdbId = nil
-        }
-
-        if let durInt = try? container.decodeIfPresent(Int.self, forKey: .durationSecs) {
-            durationSecs = durInt
-        } else if let durStr = try? container.decodeIfPresent(String.self, forKey: .durationSecs) {
-            durationSecs = Int(durStr)
-        } else {
-            durationSecs = nil
-        }
+        tmdbId = container.lenientString(forKey: .tmdbId)
+        name = container.lenientString(forKey: .name)
+        movieImage = container.lenientString(forKey: .movieImage)
+        releaseDate = container.lenientString(forKey: .releaseDate)
+        durationSecs = container.lenientInt(forKey: .durationSecs)
+        youtubeTrailer = container.lenientString(forKey: .youtubeTrailer)
+        director = container.lenientString(forKey: .director)
+        actors = container.lenientString(forKey: .actors)
+        description = container.lenientString(forKey: .description)
+        plot = container.lenientString(forKey: .plot)
+        genre = container.lenientString(forKey: .genre)
     }
 }
 
@@ -297,6 +361,12 @@ struct XtreamVODStreamData: Decodable {
     enum CodingKeys: String, CodingKey {
         case streamId = "stream_id"
         case containerExtension = "container_extension"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        streamId = container.lenientInt(forKey: .streamId)
+        containerExtension = container.lenientString(forKey: .containerExtension)
     }
 }
 
@@ -333,39 +403,21 @@ struct XtreamSeries: Decodable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        num = try? container.decodeIfPresent(Int.self, forKey: .num)
-        name = try? container.decodeIfPresent(String.self, forKey: .name)
-        seriesId = try? container.decodeIfPresent(Int.self, forKey: .seriesId)
-        cover = try? container.decodeIfPresent(String.self, forKey: .cover)
-        plot = try? container.decodeIfPresent(String.self, forKey: .plot)
-        cast = try? container.decodeIfPresent(String.self, forKey: .cast)
-        director = try? container.decodeIfPresent(String.self, forKey: .director)
-        genre = try? container.decodeIfPresent(String.self, forKey: .genre)
-        releaseDate = try? container.decodeIfPresent(String.self, forKey: .releaseDate)
-        lastModified = try? container.decodeIfPresent(String.self, forKey: .lastModified)
-        rating = try? container.decodeIfPresent(String.self, forKey: .rating)
-        rating5Based = try? container.decodeIfPresent(String.self, forKey: .rating5Based)
-
-        if let catIdStr = try? container.decodeIfPresent(String.self, forKey: .categoryId) {
-            categoryId = catIdStr
-        } else if let catIdInt = try? container.decodeIfPresent(Int.self, forKey: .categoryId) {
-            categoryId = String(catIdInt)
-        } else {
-            categoryId = nil
-        }
-
-        // Some playlists use "tmdb", others "tmdb_id"; accept either as String or Int.
-        if let tmdbStr = try? container.decodeIfPresent(String.self, forKey: .tmdb) {
-            tmdb = tmdbStr
-        } else if let tmdbInt = try? container.decodeIfPresent(Int.self, forKey: .tmdb) {
-            tmdb = String(tmdbInt)
-        } else if let tmdbStr = try? container.decodeIfPresent(String.self, forKey: .tmdbId) {
-            tmdb = tmdbStr
-        } else if let tmdbInt = try? container.decodeIfPresent(Int.self, forKey: .tmdbId) {
-            tmdb = String(tmdbInt)
-        } else {
-            tmdb = nil
-        }
+        num = container.lenientInt(forKey: .num)
+        name = container.lenientString(forKey: .name)
+        seriesId = container.lenientInt(forKey: .seriesId)
+        cover = container.lenientString(forKey: .cover)
+        plot = container.lenientString(forKey: .plot)
+        cast = container.lenientString(forKey: .cast)
+        director = container.lenientString(forKey: .director)
+        genre = container.lenientString(forKey: .genre)
+        releaseDate = container.lenientString(forKey: .releaseDate)
+        lastModified = container.lenientString(forKey: .lastModified)
+        rating = container.lenientString(forKey: .rating)
+        rating5Based = container.lenientString(forKey: .rating5Based)
+        categoryId = container.lenientString(forKey: .categoryId)
+        // Some playlists use "tmdb", others "tmdb_id".
+        tmdb = container.lenientString(forKey: .tmdb) ?? container.lenientString(forKey: .tmdbId)
     }
 }
 
@@ -374,6 +426,32 @@ struct XtreamSeries: Decodable {
 struct XtreamSeriesInfoResponse: Decodable {
     let info: XtreamSeriesInfo?
     let episodes: [String: [XtreamEpisode]]?
+
+    enum CodingKeys: String, CodingKey {
+        case info, episodes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        info = try? container.decodeIfPresent(XtreamSeriesInfo.self, forKey: .info)
+
+        // Canonically an object keyed by season number, but panels also send a
+        // flat episode array or an array of per-season arrays.
+        if let dict = try? container.decodeIfPresent([String: XtreamList<XtreamEpisode>].self, forKey: .episodes) {
+            episodes = dict.mapValues(\.items)
+        } else if let flat = try? container.decodeIfPresent(XtreamList<XtreamEpisode>.self, forKey: .episodes) {
+            episodes = Dictionary(grouping: flat.items) { String($0.season ?? 1) }
+        } else if let seasons = try? container.decodeIfPresent([XtreamList<XtreamEpisode>].self, forKey: .episodes) {
+            var grouped: [String: [XtreamEpisode]] = [:]
+            for (index, season) in seasons.enumerated() where !season.items.isEmpty {
+                let seasonNum = season.items.first?.season ?? index + 1
+                grouped[String(seasonNum), default: []] += season.items
+            }
+            episodes = grouped.isEmpty ? nil : grouped
+        } else {
+            episodes = nil
+        }
+    }
 }
 
 struct XtreamSeriesInfo: Decodable {
@@ -393,6 +471,20 @@ struct XtreamSeriesInfo: Decodable {
         case releaseDate
         case lastModified = "last_modified"
         case rating, tmdb
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = container.lenientString(forKey: .name)
+        cover = container.lenientString(forKey: .cover)
+        plot = container.lenientString(forKey: .plot)
+        cast = container.lenientString(forKey: .cast)
+        director = container.lenientString(forKey: .director)
+        genre = container.lenientString(forKey: .genre)
+        releaseDate = container.lenientString(forKey: .releaseDate)
+        lastModified = container.lenientString(forKey: .lastModified)
+        rating = container.lenientString(forKey: .rating)
+        tmdb = container.lenientString(forKey: .tmdb)
     }
 }
 
@@ -420,30 +512,15 @@ struct XtreamEpisode: Decodable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        episodeNum = try? container.decodeIfPresent(Int.self, forKey: .episodeNum)
-        title = try? container.decodeIfPresent(String.self, forKey: .title)
-        containerExtension = try? container.decodeIfPresent(String.self, forKey: .containerExtension)
-        customSid = try? container.decodeIfPresent(String.self, forKey: .customSid)
-        added = try? container.decodeIfPresent(String.self, forKey: .added)
-
-        if let sInt = try? container.decodeIfPresent(Int.self, forKey: .season) {
-            season = sInt
-        } else if let sStr = try? container.decodeIfPresent(String.self, forKey: .season) {
-            season = Int(sStr)
-        } else {
-            season = nil
-        }
-
-        directSource = try? container.decodeIfPresent(String.self, forKey: .directSource)
+        id = container.lenientString(forKey: .id)
+        episodeNum = container.lenientInt(forKey: .episodeNum)
+        title = container.lenientString(forKey: .title)
+        containerExtension = container.lenientString(forKey: .containerExtension)
+        customSid = container.lenientString(forKey: .customSid)
+        added = container.lenientString(forKey: .added)
+        season = container.lenientInt(forKey: .season)
+        directSource = container.lenientString(forKey: .directSource)
         info = try? container.decodeIfPresent(XtreamEpisodeInfo.self, forKey: .info)
-
-        if let idStr = try? container.decodeIfPresent(String.self, forKey: .id) {
-            id = idStr
-        } else if let idInt = try? container.decodeIfPresent(Int.self, forKey: .id) {
-            id = String(idInt)
-        } else {
-            id = nil
-        }
     }
 }
 
@@ -465,33 +542,11 @@ struct XtreamEpisodeInfo: Decodable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        if let adStr = try? container.decodeIfPresent(String.self, forKey: .airDate) {
-            airDate = adStr
-        } else if let rdStr = try? container.decodeIfPresent(String.self, forKey: .releaseDate) {
-            airDate = rdStr
-        } else {
-            airDate = nil
-        }
-
-        movieImage = try? container.decodeIfPresent(String.self, forKey: .movieImage)
-        plot = try? container.decodeIfPresent(String.self, forKey: .plot)
-
-        if let rDouble = try? container.decodeIfPresent(Double.self, forKey: .rating) {
-            rating = rDouble
-        } else if let rString = try? container.decodeIfPresent(String.self, forKey: .rating) {
-            rating = Double(rString)
-        } else {
-            rating = nil
-        }
-
-        if let durInt = try? container.decodeIfPresent(Int.self, forKey: .durationSecs) {
-            durationSecs = durInt
-        } else if let durStr = try? container.decodeIfPresent(String.self, forKey: .durationSecs) {
-            durationSecs = Int(durStr)
-        } else {
-            durationSecs = nil
-        }
+        airDate = container.lenientString(forKey: .airDate) ?? container.lenientString(forKey: .releaseDate)
+        movieImage = container.lenientString(forKey: .movieImage)
+        durationSecs = container.lenientInt(forKey: .durationSecs)
+        rating = container.lenientDouble(forKey: .rating)
+        plot = container.lenientString(forKey: .plot)
     }
 }
 
@@ -502,6 +557,18 @@ struct XtreamShortEPG: Decodable {
     let end: String?
     let title: String?
     let description: String?
+
+    enum CodingKeys: String, CodingKey {
+        case start, end, title, description
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        start = container.lenientString(forKey: .start)
+        end = container.lenientString(forKey: .end)
+        title = container.lenientString(forKey: .title)
+        description = container.lenientString(forKey: .description)
+    }
 }
 
 // MARK: - Bulk EPG (get_simple_data_table)

--- a/Lume/Services/Network/XtreamError.swift
+++ b/Lume/Services/Network/XtreamError.swift
@@ -71,16 +71,37 @@ enum XtreamError: LocalizedError {
             return "network error (\(nsError.domain) \(nsError.code))"
         case let .decodingError(error):
             switch error as? DecodingError {
-            case .dataCorrupted: return "undecodable response (not valid JSON)"
-            case .keyNotFound: return "undecodable response (missing key)"
-            case .typeMismatch: return "undecodable response (type mismatch)"
-            case .valueNotFound: return "undecodable response (missing value)"
-            default: return "undecodable response"
+            case .dataCorrupted:
+                return "undecodable response (not valid JSON)"
+            case let .keyNotFound(key, context):
+                return "undecodable response (missing key '\(key.stringValue)' at \(Self.path(context.codingPath)))"
+            case let .typeMismatch(type, context):
+                return "undecodable response (type mismatch: expected \(type) at \(Self.path(context.codingPath)))"
+            case let .valueNotFound(type, context):
+                return "undecodable response (missing \(type) value at \(Self.path(context.codingPath)))"
+            default:
+                return "undecodable response"
             }
         case .invalidResponse:
             return "non-HTTP response"
         case let .serverError(code):
             return "HTTP \(code)"
         }
+    }
+
+    /// Renders a decoding path as e.g. `user_info.exp_date` or
+    /// `[12].category_id` — key names and indexes only, never values, so it
+    /// stays credential-free.
+    private static func path(_ codingPath: [any CodingKey]) -> String {
+        guard !codingPath.isEmpty else { return "response root" }
+        var result = ""
+        for key in codingPath {
+            if let index = key.intValue {
+                result += "[\(index)]"
+            } else {
+                result += result.isEmpty ? key.stringValue : ".\(key.stringValue)"
+            }
+        }
+        return result
     }
 }

--- a/LumeTests/Decoding/DTODecodingEdgeCaseTests.swift
+++ b/LumeTests/Decoding/DTODecodingEdgeCaseTests.swift
@@ -268,4 +268,133 @@ struct DTODecodingEdgeCaseTests {
         #expect(server.timestampNow == 1_700_000_000)
         #expect(server.timeNow == "2024-01-01 00:00:00")
     }
+
+    @Test func `auth response decodes numeric fields sent as numbers`() throws {
+        // Real panels routinely send ports / dates / counters as numbers where
+        // others send strings — the auth response must accept both.
+        let json = Data("""
+        {
+            "user_info": {
+                "username": "test",
+                "exp_date": 1770000000,
+                "is_trial": 0,
+                "active_cons": 1,
+                "max_connections": 2
+            },
+            "server_info": {
+                "url": "example.com",
+                "port": 8080,
+                "https_port": 443,
+                "timestamp_now": "1700000000"
+            }
+        }
+        """.utf8)
+        let response = try JSONDecoder().decode(XtreamAuthResponse.self, from: json)
+        #expect(response.userInfo.expDate == "1770000000")
+        #expect(response.userInfo.isTrial == "0")
+        #expect(response.userInfo.activeCons == "1")
+        #expect(response.userInfo.maxConnections == "2")
+        #expect(response.serverInfo.port == "8080")
+        #expect(response.serverInfo.httpsPort == "443")
+        #expect(response.serverInfo.timestampNow == 1_700_000_000)
+    }
+
+    // MARK: - XtreamCategory coercion
+
+    @Test func `category decodes int id and string parent id`() throws {
+        let json = Data("""
+        {"category_id": 42, "category_name": "Movies", "parent_id": "7"}
+        """.utf8)
+        let category = try JSONDecoder().decode(XtreamCategory.self, from: json)
+        #expect(category.categoryId == "42")
+        #expect(category.categoryName == "Movies")
+        #expect(category.parentId == 7)
+    }
+
+    @Test func `category without id fails alone but is dropped from a list`() throws {
+        let missingId = Data("""
+        {"category_name": "Orphan"}
+        """.utf8)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(XtreamCategory.self, from: missingId)
+        }
+
+        let json = Data("""
+        [
+            {"category_id": "1", "category_name": "Keep"},
+            {"category_name": "Drop"},
+            {"category_id": 2, "category_name": "Keep too"}
+        ]
+        """.utf8)
+        let list = try JSONDecoder().decode(XtreamList<XtreamCategory>.self, from: json)
+        #expect(list.items.map(\.categoryId) == ["1", "2"])
+    }
+
+    // MARK: - XtreamList payload shapes
+
+    @Test func `list decodes index-keyed object payload`() throws {
+        let json = Data("""
+        {
+            "10": {"category_id": "b", "category_name": "Second"},
+            "2": {"category_id": "a", "category_name": "First"}
+        }
+        """.utf8)
+        let list = try JSONDecoder().decode(XtreamList<XtreamCategory>.self, from: json)
+        #expect(list.items.map(\.categoryId) == ["a", "b"])
+    }
+
+    @Test func `list decodes empty array`() throws {
+        let list = try JSONDecoder().decode(XtreamList<XtreamCategory>.self, from: Data("[]".utf8))
+        #expect(list.items.isEmpty)
+    }
+
+    @Test func `list with only undecodable entries throws instead of returning empty`() {
+        // An {"error": …} body must not sync as "zero items" — that would let
+        // the prune pass wipe the catalog.
+        let json = Data("""
+        {"error": "account expired"}
+        """.utf8)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(XtreamList<XtreamCategory>.self, from: json)
+        }
+    }
+
+    // MARK: - XtreamSeriesInfoResponse episode payload shapes
+
+    @Test func `series info decodes flat episode array`() throws {
+        let json = Data("""
+        {
+            "info": {"name": "Show", "rating": 8},
+            "episodes": [
+                {"id": "1", "episode_num": 1, "season": 2},
+                {"id": "2", "episode_num": 2, "season": 2}
+            ]
+        }
+        """.utf8)
+        let response = try JSONDecoder().decode(XtreamSeriesInfoResponse.self, from: json)
+        #expect(response.info?.rating == "8")
+        #expect(response.episodes?["2"]?.map(\.id) == ["1", "2"])
+    }
+
+    @Test func `series info decodes array of season arrays`() throws {
+        let json = Data("""
+        {
+            "episodes": [
+                [{"id": "1", "season": 1}],
+                [{"id": "2", "season": 2}, {"id": "3", "season": 2}]
+            ]
+        }
+        """.utf8)
+        let response = try JSONDecoder().decode(XtreamSeriesInfoResponse.self, from: json)
+        #expect(response.episodes?["1"]?.map(\.id) == ["1"])
+        #expect(response.episodes?["2"]?.map(\.id) == ["2", "3"])
+    }
+
+    @Test func `series info tolerates empty episodes array`() throws {
+        let json = Data("""
+        {"info": {"name": "Show"}, "episodes": []}
+        """.utf8)
+        let response = try JSONDecoder().decode(XtreamSeriesInfoResponse.self, from: json)
+        #expect(response.episodes?.isEmpty != false)
+    }
 }

--- a/LumeTests/Services/XtreamErrorTests.swift
+++ b/LumeTests/Services/XtreamErrorTests.swift
@@ -2,6 +2,24 @@ import Foundation
 @testable import Lume
 import Testing
 
+/// Deliberately strict decoding fixtures (no lenient coercion) so a type
+/// mismatch can be provoked to exercise `XtreamError.logDescription`.
+private struct StrictUserInfoFixture: Decodable {
+    let expDate: String?
+
+    enum CodingKeys: String, CodingKey {
+        case expDate = "exp_date"
+    }
+}
+
+private struct StrictAuthFixture: Decodable {
+    let userInfo: StrictUserInfoFixture
+
+    enum CodingKeys: String, CodingKey {
+        case userInfo = "user_info"
+    }
+}
+
 struct XtreamErrorTests {
     // MARK: - XtreamError
 
@@ -50,6 +68,54 @@ struct XtreamErrorTests {
         let error = XtreamError.serverError(502)
         #expect(error.errorDescription?.contains("502") == true)
         #expect(error.isRetriable == true)
+    }
+
+    // MARK: - Decoding-error log descriptions
+
+    @Test func `decoding log description includes coding path for type mismatch`() throws {
+        let json = Data("""
+        {"user_info": {"exp_date": 1770000000}, "server_info": {}}
+        """.utf8)
+        do {
+            _ = try JSONDecoder().decode(StrictAuthFixture.self, from: json)
+            Issue.record("expected a type mismatch")
+        } catch {
+            let description = XtreamError.decodingError(error).logDescription
+            #expect(description.contains("type mismatch"))
+            #expect(description.contains("user_info.exp_date"))
+        }
+    }
+
+    @Test func `decoding log description names array root and missing keys`() {
+        do {
+            _ = try JSONDecoder().decode([XtreamCategory].self, from: Data("{\"k\": 1}".utf8))
+        } catch {
+            let description = XtreamError.decodingError(error).logDescription
+            #expect(description.contains("type mismatch"))
+            #expect(description.contains("response root"))
+        }
+
+        do {
+            _ = try JSONDecoder().decode(XtreamAuthResponse.self, from: Data("{}".utf8))
+        } catch {
+            let description = XtreamError.decodingError(error).logDescription
+            #expect(description.contains("missing key"))
+            #expect(description.contains("user_info"))
+        }
+    }
+
+    @Test func `decoding log description never contains values`() {
+        // The path renderer must emit key names and indexes only.
+        do {
+            _ = try JSONDecoder().decode(
+                [XtreamCategory].self,
+                from: Data("[{\"category_id\": \"1\", \"category_name\": \"x\"}, \"secret\"]".utf8)
+            )
+        } catch {
+            let description = XtreamError.decodingError(error).logDescription
+            #expect(!description.contains("secret"))
+            #expect(description.contains("[1]"))
+        }
     }
 
     // MARK: - StreamFormat


### PR DESCRIPTION
## Problem

A user diagnostic log showed an Xtream playlist that never syncs:

```
[Network] error  Xtream request failed permanently (undecodable response (type mismatch)) after 1 attempt(s)
```

Two compounding issues:

1. **Fragile decoding.** The content DTOs (`XtreamLiveStream`, `XtreamVODStream`, …) already coerce string-or-number fields, but `XtreamUserInfo`, `XtreamServerInfo`, and `XtreamCategory` still used strict synthesized decoding. Real panels routinely send numeric `port`/`exp_date`/`is_trial`/`active_cons`, Int `category_id`, or string `parent_id` — and since decoding errors are (correctly) non-retriable and the Xtream sync is strictly sequential, one odd field aborts the entire playlist sync, forever.
2. **Undiagnosable logs.** The credential-redaction in `logDescription` stripped the endpoint and field, so a report couldn't say *which* of nine endpoints failed, let alone which key.

## Changes

**Lenient decoding (`XtreamDTOs.swift`)**
- Shared `lenientString/lenientInt/lenientDouble(forKey:)` helpers on `KeyedDecodingContainer` accept either representation; they replace ~10 copies of hand-rolled per-DTO coercion and are now used by every Xtream DTO, including the previously strict auth response and categories.
- New `XtreamList<Element>` wrapper for all list endpoints: accepts array **or** index-keyed-object payloads and drops individual undecodable entries — but deliberately **throws when a payload has entries and none decodes**, so an `{"error": …}` body can't sync as "zero items" and let the prune pass wipe the catalog.
- `XtreamSeriesInfoResponse.episodes` accepts all real-world shapes: season-keyed dict (canonical), flat episode array, array-of-season-arrays, and PHP's empty `[]`.
- Drive-by fix: `getShortEPG`'s wrapper decoded key `epgListings`, but the API sends `epg_listings` — the wrapped path could never have matched.

**Actionable, still credential-free logging (`XtreamClient.swift`, `XtreamError.swift`)**
- Every request carries a constant action label: `Xtream get_vod_categories request failed permanently (…)`.
- Decoding failures include the coding path and expected type: `undecodable response (type mismatch: expected String at user_info.exp_date)`. Key names and indexes only — never values — preserving the exported-diagnostics redaction guarantee (with a test asserting values don't leak).

## Testing

- 12 new tests: numeric auth fields, category coercion, every `XtreamList` payload shape (incl. the error-object-must-throw guard), episode shape variants, log-path rendering, and a no-values-leaked assertion.
- `DTODecodingTests`, `DTODecodingEdgeCaseTests`, `XtreamErrorTests`, and `ContentSyncTests` all pass on iPhone 17 Pro simulator; SwiftFormat/SwiftLint clean.

Note: the test target's pre-existing "main actor-isolated conformance … to 'Decodable'" warnings are unchanged by this PR; marking the DTOs `nonisolated` is a separate cleanup before any strict Swift 6 move.