### PR TITLE
fix(player): present live channel player on tvOS from search

### DIFF
--- a/Lume/Views/SearchView.swift
+++ b/Lume/Views/SearchView.swift
@@ -125,7 +125,7 @@ struct SearchView: View {
                     await updateResults()
                 }
         }
-        #if os(iOS)
+        #if os(iOS) || os(tvOS)
         .fullScreenCover(item: $playingMedia) { media in
             FullScreenPlayerView(media: media)
         }


### PR DESCRIPTION
## What

On **tvOS**, tapping a live TV channel in global search now opens the player. Previously it did nothing.

## Why

`SearchView.playChannel(_:)` sets `playingMedia = media`, but the only presenter observing it was gated behind `#if os(iOS)`:

```swift
#if os(iOS)
.fullScreenCover(item: $playingMedia) { media in
    FullScreenPlayerView(media: media)
}
#endif
```

tvOS is a distinct platform (`os(tvOS)`, not `os(iOS)`), so on Apple TV the state was set and no view ever presented the player. Movies/series are unaffected because they route through `NavigationLink`; only live channels use the `playingMedia` path.

`LiveTVView` presents the identical `playingMedia`/`FullScreenPlayerView` with the correct condition `#if os(iOS) || os(tvOS)`, which is why live playback works there. This change brings `SearchView` in line.

## Change

```diff
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 .fullScreenCover(item: $playingMedia) { media in
     FullScreenPlayerView(media: media)
 }
 #endif
```

## Verification

- Verified by inspection: the search-result live-channel path is now structurally identical to the working `LiveTVView` presenter on tvOS.
- I was not able to build/run the tvOS scheme locally, so a maintainer confirming on an Apple TV would be appreciated.

## Notes

- Per `CONTRIBUTING.md` an issue is usually opened first — happy to file one if you'd like it tracked separately.
- Possible related gap (not touched here to keep the PR single-purpose): the same `os(iOS) || os(tvOS)` convention in both `SearchView` and `LiveTVView` excludes **visionOS**. If live playback is expected on Vision Pro, both presenters may need `#if !os(macOS)`. Let me know and I can follow up.