### PR TITLE
fix(macos): make the Search tab visible on macOS 15 / iOS 18

### DIFF
--- a/Lume/Views/MainTabView.swift
+++ b/Lume/Views/MainTabView.swift
@@ -172,8 +172,16 @@ struct MainTabView: View {
                     LiveTVView()
                 }
 
+                // An explicit label is required: the `Tab(_:systemImage:value:role:)`
+                // convenience is 26-only, and the label-less initializer's
+                // `DefaultTabLabel` renders nothing in the pre-Liquid Glass macOS 15
+                // tab bar — the search tab was invisible there. Supplying the label
+                // keeps `role: .search` (so 26 still gets the dedicated search
+                // treatment) while staying visible on macOS 15 / iOS 18.
                 Tab(value: AppTab.search, role: .search) {
                     SearchView()
+                } label: {
+                    Label("Search", systemImage: "magnifyingglass")
                 }
             }
         }


### PR DESCRIPTION
Users on macOS versions without Liquid Glass reported that the search icon is not visible.

## Root cause

The search tab used the label-less initializer:

```swift
Tab(value: AppTab.search, role: .search) { SearchView() }
```

That form binds `Label == DefaultTabLabel`, which lets the system derive the tab's appearance from its role. The Liquid Glass tab bar on OS 26 turns that into the dedicated search button, so it looks correct there. The pre-Liquid Glass macOS 15 tab bar has no role-derived rendering, so the item drew as a blank tab — the search entry was effectively invisible.

The obvious one-line fix doesn't compile. Every labelled convenience that *also* takes a role — `Tab(_:systemImage:value:role:content:)` — is annotated `@available(iOS 26.0, macOS 26.0, ...)` in the SDK, so it's unavailable at our deployment target. That's presumably why the label-less form was used in the first place.

## Fix

`init(value:role:content:label:)` carries no per-init availability annotation, so it inherits the type's iOS 18 / macOS 15 availability and can supply the label at our deployment target:

```swift
Tab(value: AppTab.search, role: .search) {
    SearchView()
} label: {
    Label("Search", systemImage: "magnifyingglass")
}
```

Keeping `role: .search` means OS 26 still gets the dedicated search treatment, while older systems now have something concrete to draw.

This fixes the same latent bug on **iOS 18** as well, and labels the tab for VoiceOver, which previously read it as unlabeled. `"Search"` was already localized in all 9 locales, so no string catalog changes were needed.

## Verification

- **macOS build** (`platform=macOS,arch=arm64`): BUILD SUCCEEDED — confirms the initializer is valid at the macOS 15 deployment target.
- **iOS 26 simulator**: Search still renders as the icon-only glass button at the trailing edge of the tab bar, *not* as a labelled tab — no regression on the Liquid Glass path.
- **Accessibility tree**: now reports `tab|Search` where it was previously unlabeled.
- SwiftFormat + SwiftLint (`--strict`) clean.

## Caveat

The macOS 15 rendering itself was **not** visually verified — no macOS 15 host or SDK was available. The diagnosis rests on the SDK availability annotations plus the reported symptom, and the fix is verified to compile for that target. Confirming the pixels needs a reviewer on macOS 15.