### PR TITLE
fix(m3u): upgrade type=m3u playlist URLs to m3u_plus so artwork loads

### DIFF
--- a/Lume/Services/Network/M3UClient.swift
+++ b/Lume/Services/Network/M3UClient.swift
@@ -251,19 +251,23 @@ nonisolated class M3UClient {
         return false
     }
 
-    /// Xtream `get.php` links only yield an m3u when `type` is `m3u` or
-    /// `m3u_plus`. Any other value (`gigablue`, `dreambox`, `enigma2`, …)
-    /// returns a set-top-box bouquet that can't be parsed, so rewrite it to
-    /// `m3u_plus`. Non-`get.php` URLs and already-valid types pass through
-    /// untouched. Keeping this in the client means both freshly-added and
-    /// already-stored playlists self-heal on their next fetch.
+    /// Xtream `get.php` links yield a parseable playlist for `type=m3u` and
+    /// `type=m3u_plus`; any other value (`gigablue`, `dreambox`, `enigma2`, …)
+    /// returns a set-top-box bouquet that can't be parsed. We always rewrite to
+    /// `m3u_plus` — including plain `m3u`, which is the canonical `get.php`
+    /// default users paste — because `m3u_plus` is a strict superset: plain
+    /// `m3u` omits the `tvg-logo` / `tvg-id` / `group-title` attributes, so
+    /// posters, channel logos and categories all go missing, while `m3u_plus`
+    /// carries them. Only already-`m3u_plus` URLs and non-`get.php` URLs pass
+    /// through untouched. Keeping this in the client means both freshly-added
+    /// and already-stored playlists self-heal on their next fetch.
     static func normalizedPlaylistURL(_ urlString: String) -> String {
         guard var components = URLComponents(string: urlString),
               components.path.hasSuffix("get.php"),
               var items = components.queryItems,
               let index = items.firstIndex(where: { $0.name == "type" }),
               let type = items[index].value?.lowercased(),
-              type != "m3u", type != "m3u_plus"
+              type != "m3u_plus"
         else { return urlString }
 
         items[index].value = "m3u_plus"

--- a/LumeTests/Services/M3UParserTests.swift
+++ b/LumeTests/Services/M3UParserTests.swift
@@ -255,16 +255,20 @@ struct M3UClientValidationTests {
         #expect(!M3UClient.looksLikeEnigma2Bouquet(Data()))
     }
 
-    @Test func `rewrites xtream bouquet type to m3u_plus`() {
+    @Test func `rewrites xtream type to m3u_plus`() {
         let base = "http://host/get.php?username=u&password=p&output=ts"
         #expect(M3UClient.normalizedPlaylistURL(base + "&type=gigablue")
             == base + "&type=m3u_plus")
         #expect(M3UClient.normalizedPlaylistURL(base + "&type=dreambox")
             == base + "&type=m3u_plus")
-        // Already-valid types and non-get.php URLs pass through untouched.
+        // Plain `m3u` is upgraded to `m3u_plus`: both parse, but `m3u_plus` is a
+        // superset that carries tvg-logo / tvg-id / group-title (plain `m3u`
+        // drops them, so artwork and categories would be missing).
+        #expect(M3UClient.normalizedPlaylistURL(base + "&type=m3u")
+            == base + "&type=m3u_plus")
+        // Already-`m3u_plus` and non-get.php URLs pass through untouched.
         let valid = base + "&type=m3u_plus"
         #expect(M3UClient.normalizedPlaylistURL(valid) == valid)
-        #expect(M3UClient.normalizedPlaylistURL(base + "&type=m3u") == base + "&type=m3u")
         let plain = "http://host/playlist.m3u?type=gigablue"
         #expect(M3UClient.normalizedPlaylistURL(plain) == plain)
         #expect(M3UClient.normalizedPlaylistURL("not a url") == "not a url")


### PR DESCRIPTION
## Problem

Movie posters and channel logos render as blank placeholders for M3U playlists whose URL uses `type=m3u` — the canonical `get.php` URL most users paste.

`M3UClient.normalizedPlaylistURL` rewrites exotic Xtream `type=` values (`gigablue`, `dreambox`, …) to `m3u_plus`, but deliberately left plain `type=m3u` **untouched** as "already valid". It *is* parseable — but most Xtream panels omit the extended `tvg-logo` / `tvg-id` / `group-title` attributes from the plain `m3u` output and only include them in `m3u_plus`. So a `type=m3u` URL imports a catalog with **no `streamIcon`, no `epgChannelId`, and no categories**, and every card falls back to a placeholder (on iOS, macOS, and tvOS alike, since they share the URL).

## Fix

Always rewrite `get.php` URLs to `m3u_plus` — `m3u_plus` is a strict superset of `m3u` (same streams, plus the extended attributes). Only already-`m3u_plus` and non-`get.php` URLs pass through untouched. Existing stored playlists self-heal on their next fetch.

One-line change in the guard (`type != "m3u", type != "m3u_plus"` → `type != "m3u_plus"`), plus a doc-comment update and the corresponding test.

## Verification

Reproduced end-to-end against a real provider:

- Same account/server: `type=m3u` → **0** entries with `tvg-logo`; `type=m3u_plus` → **167,520**.
- Before the fix, an import stored `streamIcon` for **0 / 11,491** movies and **0 / 7,499** channels.
- After the fix, **11,488 / 11,491** movies and **7,301 / 7,499** channels get a `streamIcon`, and logos fetch + render (verified via instrumented logs: `HTTP 200 image/jpeg` from the logo host). The small remainder genuinely have no `tvg-logo` even in `m3u_plus`.

Updated `M3UClientValidationTests` to assert `type=m3u` → `type=m3u_plus` (previously it asserted the buggy pass-through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)