### PR TITLE
feat(live-tv): add Clear button to the Recently Watched channel list

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -5376,6 +5376,58 @@
         }
       }
     },
+    "Clear Recently Watched" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kürzlich gesehen löschen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar vistos recientemente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer les éléments vus récemment"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella visti di recente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近視聴した項目を消去"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 시청함 지우기"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpar Assistidos Recentemente"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除最近观看"
+          }
+        }
+      }
+    },
     "Clear Watch History" : {
       "localizations" : {
         "de" : {
@@ -29475,6 +29527,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此类别中无剧集"
+          }
+        }
+      }
+    },
+    "This clears the list of channels you've recently watched. Your favorites and the channels themselves aren't affected." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Liste der kürzlich gesehenen Sender wird geleert. Favoriten und die Sender selbst sind nicht betroffen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se borrará la lista de canales vistos recientemente. Los favoritos y los canales en sí no se verán afectados."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La liste des chaînes vues récemment sera effacée. Les favoris et les chaînes elles-mêmes ne sont pas affectés."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’elenco dei canali guardati di recente verrà cancellato. I preferiti e i canali stessi non verranno modificati."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近視聴したチャンネルのリストが消去されます。お気に入りやチャンネル自体には影響しません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근에 시청한 채널 목록이 지워집니다. 즐겨찾기와 채널 자체에는 영향을 주지 않습니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A lista de canais assistidos recentemente será apagada. Os favoritos e os próprios canais não serão afetados."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近观看的频道列表将被清除。收藏和频道本身不受影响。"
           }
         }
       }

--- a/Lume/Services/Storage/StorageManager.swift
+++ b/Lume/Services/Storage/StorageManager.swift
@@ -209,6 +209,39 @@ enum StorageManager {
         }.value
     }
 
+    /// Clears the active profile's Recently Watched *live channels* for a single
+    /// playlist by nulling `lastWatchedDate` on every matching `LiveStream`. Live
+    /// has no resumable progress or `isWatched`, so the timestamp is the only
+    /// watch state to reset — favorites and the channels themselves are left
+    /// alone.
+    ///
+    /// Runs on a private background context, like `clearWatchHistory`, so its
+    /// saves merge back into the main context and the Recently Watched section
+    /// updates as soon as they land. A live channel's `lastWatchedDate` is
+    /// deliberately device-local — it's never projected to the CloudKit mirror
+    /// (see `liveEntries()`) — so this is a purely local reset, matching the
+    /// per-channel "remove from recently watched". Scoped in-memory by the
+    /// playlist id prefix — the same approach the virtual collections use, since
+    /// SwiftData can't parameterise a predicate on it.
+    static func clearRecentlyWatchedChannels(playlistPrefix: String, container: ModelContainer) async {
+        await Task.detached(priority: .userInitiated) {
+            let context = ModelContext(container)
+            context.autosaveEnabled = false
+            do {
+                let channels = try context.fetch(FetchDescriptor<LiveStream>(
+                    predicate: #Predicate { $0.lastWatchedDate != nil }
+                )).filter { $0.id.hasPrefix(playlistPrefix) }
+                for (index, channel) in channels.enumerated() {
+                    channel.lastWatchedDate = nil
+                    if (index + 1).isMultiple(of: clearBatchSize) { try context.save() }
+                }
+                try context.save()
+            } catch {
+                logger.error("Failed to clear recently watched channels: \(error.localizedDescription)")
+            }
+        }.value
+    }
+
     #if DEBUG
         /// DEBUG-only: wipes the on-device search index end to end — the TMDB/MDBList
         /// enrichment (via `clearMetadataEnrichment`), the embedding vectors, the

--- a/Lume/Views/LiveTV/LiveTVTVComponents.swift
+++ b/Lume/Views/LiveTV/LiveTVTVComponents.swift
@@ -27,6 +27,8 @@
         /// How many channels are currently rendered. Grows by a page as the list
         /// nears its end so a large category loads lazily instead of all at once.
         @State private var visibleCount = LiveChannelQuery.pageSize
+        /// Drives the "Clear Recently Watched" confirmation alert.
+        @State private var confirmingClear = false
 
         init(scope: LiveChannelScope, playlistPrefix: String, sort: ContentSortOption, onPlay: @escaping (LiveStream) -> Void) {
             self.scope = scope
@@ -52,6 +54,9 @@
                         )
                         .padding(.top, 80)
                     } else {
+                        if scope == .recentlyWatched {
+                            clearButton
+                        }
                         ForEach(visible) { stream in
                             TVChannelRow(
                                 stream: stream,
@@ -77,6 +82,27 @@
             .task(id: "\(channels.count)-\(visible.count)-\(epgSync.isSyncing)") {
                 await loadEPG(for: visible)
             }
+            .alert("Clear Recently Watched", isPresented: $confirmingClear) {
+                Button("Clear", role: .destructive) { clearRecentlyWatched() }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This clears the list of channels you've recently watched. Your favorites and the channels themselves aren't affected.")
+            }
+        }
+
+        /// A full-width focusable "Clear" pill pinned above the Recently Watched
+        /// rows. Full-width so the focus engine reliably catches a "down" move
+        /// into it from the category rail and out of it into the first channel.
+        private var clearButton: some View {
+            Button(role: .destructive) {
+                confirmingClear = true
+            } label: {
+                Label("Clear Recently Watched", systemImage: "trash")
+                    .font(.system(size: 28, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 20)
+            }
+            .buttonStyle(TVCardButtonStyle(focusScale: 1.02))
         }
 
         private func loadEPG(for channels: [LiveStream]) async {
@@ -97,6 +123,14 @@
         private func removeFromRecentlyWatched(_ stream: LiveStream) {
             stream.lastWatchedDate = nil
             try? modelContext.save()
+        }
+
+        /// Empties the whole Recently Watched list for the active playlist. The
+        /// section drops away on its own once the last timestamp clears (its
+        /// parent gates it on `hasRecents`).
+        private func clearRecentlyWatched() {
+            let container = modelContext.container
+            Task { await StorageManager.clearRecentlyWatchedChannels(playlistPrefix: playlistPrefix, container: container) }
         }
     }
 

--- a/Lume/Views/LiveTV/LiveTVView.swift
+++ b/Lume/Views/LiveTV/LiveTVView.swift
@@ -509,6 +509,8 @@ struct ChannelsList: View {
     /// How many channels are currently rendered. Grows by a page as the list
     /// nears its end so a large category loads lazily instead of all at once.
     @State private var visibleCount = LiveChannelQuery.pageSize
+    /// Drives the "Clear Recently Watched" confirmation alert.
+    @State private var confirmingClear = false
 
     init(scope: LiveChannelScope, playlistPrefix: String, sort: ContentSortOption, onPlay: @escaping (LiveStream) -> Void) {
         self.scope = scope
@@ -529,44 +531,81 @@ struct ChannelsList: View {
         try? modelContext.save()
     }
 
+    /// Empties the whole Recently Watched list for the active playlist. The
+    /// section drops away on its own once the last timestamp clears (its parent
+    /// gates it on `hasRecents`).
+    private func clearRecentlyWatched() {
+        let container = modelContext.container
+        Task { await StorageManager.clearRecentlyWatchedChannels(playlistPrefix: playlistPrefix, container: container) }
+    }
+
+    /// A trailing "Clear" button shown above the Recently Watched list. Stays
+    /// out of the scroll view so it's always reachable no matter how far the
+    /// list is scrolled.
+    private var clearHeader: some View {
+        HStack {
+            Spacer()
+            Button(role: .destructive) {
+                confirmingClear = true
+            } label: {
+                Label("Clear", systemImage: "trash")
+                    .font(.subheadline)
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+
     var body: some View {
         let channels = scopedStreams
         let visible = Array(channels.prefix(visibleCount))
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                if channels.isEmpty {
-                    ContentUnavailableView(
-                        "No Channels",
-                        systemImage: "antenna.radiowaves.left.and.right",
-                        description: Text("This category has no channels")
-                    )
-                } else {
-                    ForEach(visible) { stream in
-                        Button {
-                            onPlay(stream)
-                        } label: {
-                            LiveStreamCardView(stream: stream, epg: epgByChannel[stream.epgChannelId ?? ""])
-                                .padding(.horizontal)
-                                .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .recentlyWatchedRemoveMenu(scope == .recentlyWatched ? { removeFromRecentlyWatched(stream) } : nil)
-                        .onAppear {
-                            if stream.id == visible.last?.id, visibleCount < channels.count {
-                                visibleCount = min(visibleCount + LiveChannelQuery.pageSize, channels.count)
+        VStack(spacing: 0) {
+            if scope == .recentlyWatched, !channels.isEmpty {
+                clearHeader
+            }
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    if channels.isEmpty {
+                        ContentUnavailableView(
+                            "No Channels",
+                            systemImage: "antenna.radiowaves.left.and.right",
+                            description: Text("This category has no channels")
+                        )
+                    } else {
+                        ForEach(visible) { stream in
+                            Button {
+                                onPlay(stream)
+                            } label: {
+                                LiveStreamCardView(stream: stream, epg: epgByChannel[stream.epgChannelId ?? ""])
+                                    .padding(.horizontal)
+                                    .contentShape(Rectangle())
                             }
-                        }
+                            .buttonStyle(.plain)
+                            .recentlyWatchedRemoveMenu(scope == .recentlyWatched ? { removeFromRecentlyWatched(stream) } : nil)
+                            .onAppear {
+                                if stream.id == visible.last?.id, visibleCount < channels.count {
+                                    visibleCount = min(visibleCount + LiveChannelQuery.pageSize, channels.count)
+                                }
+                            }
 
-                        Divider()
-                            .padding(.leading, 88)
+                            Divider()
+                                .padding(.leading, 88)
+                        }
                     }
                 }
             }
+            // Reload when the visible window or channel set changes, or a guide
+            // import settles — EPG is resolved only for the channels on screen.
+            .task(id: "\(channels.count)-\(visible.count)-\(epgSync.isSyncing)") {
+                await loadEPG(for: visible)
+            }
         }
-        // Reload when the visible window or channel set changes, or a guide
-        // import settles — EPG is resolved only for the channels on screen.
-        .task(id: "\(channels.count)-\(visible.count)-\(epgSync.isSyncing)") {
-            await loadEPG(for: visible)
+        .alert("Clear Recently Watched", isPresented: $confirmingClear) {
+            Button("Clear", role: .destructive) { clearRecentlyWatched() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This clears the list of channels you've recently watched. Your favorites and the channels themselves aren't affected.")
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a **Clear** action to the Live TV **Recently Watched** channel list, so the whole list can be emptied in one step instead of removing channels one at a time.

## Motivation

Live TV is browsed by *channel-surfing* — flipping through channels to see what's on. Every channel you land on, even for a few seconds, lands in **Recently Watched**, which auto-pins above the category list. In normal use this rail fills up quickly with channels you tried once and don't care about, and there's currently no good way to tidy it:

- **Per-channel remove** exists, but clearing a surfed-through list one channel at a time is tedious.
- **Settings → Storage & Cache → Clear Watch History** is far too blunt — it's global and also wipes movie/series watch **progress** and watched status — and it's buried several screens away from where the list actually lives.

There's also a **privacy** angle that makes this more than a convenience. Unlike movie/series watch state, a live channel's recently-watched history is **device-local** — it is deliberately never mirrored to iCloud (see `liveEntries()`, to avoid one mirror record per channel). That means:

- On a **shared or household device** (an Apple TV in the living room, a shared Mac), the recently-watched channel list is a visible record of what was on, and today the only way to clear it in-place is one channel at a time.
- Because the list never leaves the device, an **on-device Clear is exactly the right tool** — there's no cross-device state to reconcile, so the action is instant, local, and has no surprising side effects on the user's other devices.

This PR fills that gap with a focused, in-place Clear that affects **only** the active playlist's recently-watched channels.

## Changes

- **`StorageManager.clearRecentlyWatchedChannels(playlistPrefix:container:)`** — nulls `lastWatchedDate` on every `LiveStream` in the active playlist on a background `ModelContext`. A live channel's `lastWatchedDate` is device-local (never mirrored to CloudKit — see `liveEntries()`), so this is a purely local reset, matching the existing per-channel remove.
  - A background full-clear is used (rather than clearing only the on-screen rows) because the Recently Watched query is capped at 50, so the visible list isn't guaranteed to be the complete set.
- **`ChannelsList`** (iOS / iPadOS / macOS) — a trailing **Clear** button pinned above the list, shown only for the Recently Watched scope and only when non-empty.
- **`TVChannelsList`** (tvOS) — a full-width, focusable **Clear Recently Watched** button at the top of the list, sized full-width so the focus engine reliably catches a "down" move into and out of it.
- Both surfaces show a destructive confirmation alert before clearing.
- New user-facing strings added to `Localizable.xcstrings` with translations for all 9 supported languages, normalized via `Scripts/normalize-xcstrings.swift`.

## Behavior

- Only `lastWatchedDate` is reset — watch progress, favorites, and the channels themselves are untouched.
- After clearing, the Recently Watched section removes itself automatically (its parent gates on `hasRecents`).
- The in-player "last channel" recall list is intentionally left alone.

## Scope / notes

- **Live TV only.** Movies, Series, and the Home rail share the same `lastWatchedDate` mechanism and could get the same treatment later; out of scope here.
- The Clear button appears in the **List** layout. In **Guide** (EPG) layout the per-channel remove still works; a bulk clear there isn't included yet.

## Testing

- Built and ran the macOS app; cleared the Recently Watched list interactively and confirmed the whole list empties, the section disappears, and per-channel remove still works.
- iOS/iPadOS share the `ChannelsList` code path; tvOS uses `TVChannelsList`.
