### PR TITLE
feat(perf): dedicated benchmark suite, signposts and field telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,37 @@ Every test `ModelConfiguration` must set `cloudKitDatabase: .none` — `@Attribu
 
 ---
 
+## Performance testing
+
+Benchmarks live in their own target (`LumePerformanceTests`), scheme
+(`LumePerformance`), test plan (`Performance.xctestplan`) and build configuration
+(**Benchmark** = Release + `ENABLE_TESTABILITY`). They are *not* in the `Lume`
+scheme, so a normal `xcodebuild test` never runs them.
+
+```bash
+Scripts/run-performance-tests.sh                    # whole suite + measurements
+Scripts/run-performance-tests.sh ParsingBenchmarks  # one suite
+```
+
+- Never benchmark in Debug — `-Onone` makes parser/import numbers fiction. That's
+  what the Benchmark configuration exists for.
+- Store benchmarks use **on-disk** containers (`PerfStore`); in-memory skips
+  SQLite, the very cost being measured.
+- Fixtures are generated per run from a fixed seed (`PerfFixtures`), never
+  committed.
+- App-defined phases are named once in `Services/Diagnostics/PerformanceSignposts.swift`
+  (`Perf.begin`/`Perf.end`). Those names are a contract with `SignpostBenchmarks`
+  and feed Instruments' Points of Interest lane — rename one and update both.
+- Field layer, in the shipping app: `AppPerformanceMetrics` (MetricKit; compiled
+  out on tvOS) and `PlaybackQoE` (join time, rebuffer ratio, exits before video
+  start, engine fallbacks). Both surface in the exported diagnostic report.
+- `PlaybackQoE` flushes to `UserDefaults` at session boundaries only — never
+  periodically, which is what used to hitch KSPlayer.
+
+See `LumePerformanceTests/README.md` for baselines and why there is no CI gate.
+
+---
+
 ## Architecture
 
 ```
@@ -54,6 +85,7 @@ Lume/
 │   ├── Network/             XtreamClient, M3UClient, TMDBClient, MDBListClient, TraktService
 │   ├── Sync/                ContentSyncManager (background catalog indexing + enrichment)
 │   ├── Player/              PlayerSettings, PlayerHistory, NextUp resolver
+│   ├── Diagnostics/         Perf signposts, PlaybackQoE, MetricKit subscriber
 │   └── Images/              CachedAsyncImage, ImagePipeline
 └── Views/                   SwiftUI, platform-adaptive
     ├── Home/                Hero carousel, rails, tvOS fold

--- a/Lume.xcodeproj/project.pbxproj
+++ b/Lume.xcodeproj/project.pbxproj
@@ -28,6 +28,13 @@
 			remoteGlobalIDString = C67C02BF2F880F2200842DBA;
 			remoteInfo = Lume;
 		};
+		C6BE110000000000000000A7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C67C02B82F880F2200842DBA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C67C02BF2F880F2200842DBA;
+			remoteInfo = Lume;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -49,6 +56,7 @@
 		C67C02C02F880F2200842DBA /* Lume.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Lume.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C67C02D12F880F2400842DBA /* LumeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LumeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C67C02DB2F880F2400842DBA /* LumeUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LumeUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6BE110000000000000000A1 /* LumePerformanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LumePerformanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -80,6 +88,11 @@
 			path = LumeUITests;
 			sourceTree = "<group>";
 		};
+		C6BE110000000000000000A2 /* LumePerformanceTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = LumePerformanceTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,6 +120,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C6BE110000000000000000A3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -117,6 +137,7 @@
 				C67C02C22F880F2200842DBA /* Lume */,
 				C67C02D42F880F2400842DBA /* LumeTests */,
 				C67C02DE2F880F2400842DBA /* LumeUITests */,
+				C6BE110000000000000000A2 /* LumePerformanceTests */,
 				C67C02C12F880F2200842DBA /* Products */,
 			);
 			sourceTree = "<group>";
@@ -127,6 +148,7 @@
 				C67C02C02F880F2200842DBA /* Lume.app */,
 				C67C02D12F880F2400842DBA /* LumeTests.xctest */,
 				C67C02DB2F880F2400842DBA /* LumeUITests.xctest */,
+				C6BE110000000000000000A1 /* LumePerformanceTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -208,6 +230,29 @@
 			productReference = C67C02DB2F880F2400842DBA /* LumeUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		C6BE110000000000000000A6 /* LumePerformanceTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C6BE110000000000000000A9 /* Build configuration list for PBXNativeTarget "LumePerformanceTests" */;
+			buildPhases = (
+				C6BE110000000000000000A4 /* Sources */,
+				C6BE110000000000000000A3 /* Frameworks */,
+				C6BE110000000000000000A5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C6BE110000000000000000A8 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				C6BE110000000000000000A2 /* LumePerformanceTests */,
+			);
+			name = LumePerformanceTests;
+			packageProductDependencies = (
+			);
+			productName = LumePerformanceTests;
+			productReference = C6BE110000000000000000A1 /* LumePerformanceTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -227,6 +272,9 @@
 					};
 					C67C02DA2F880F2400842DBA = {
 						CreatedOnToolsVersion = 26.4;
+						TestTargetID = C67C02BF2F880F2200842DBA;
+					};
+					C6BE110000000000000000A6 = {
 						TestTargetID = C67C02BF2F880F2200842DBA;
 					};
 				};
@@ -261,6 +309,7 @@
 				C67C02BF2F880F2200842DBA /* Lume */,
 				C67C02D02F880F2400842DBA /* LumeTests */,
 				C67C02DA2F880F2400842DBA /* LumeUITests */,
+				C6BE110000000000000000A6 /* LumePerformanceTests */,
 			);
 		};
 /* End PBXProject section */
@@ -281,6 +330,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		C67C02D92F880F2400842DBA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C6BE110000000000000000A5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -354,6 +410,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C6BE110000000000000000A4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -366,6 +429,11 @@
 			isa = PBXTargetDependency;
 			target = C67C02BF2F880F2200842DBA /* Lume */;
 			targetProxy = C67C02DC2F880F2400842DBA /* PBXContainerItemProxy */;
+		};
+		C6BE110000000000000000A8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C67C02BF2F880F2200842DBA /* Lume */;
+			targetProxy = C6BE110000000000000000A7 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -853,6 +921,270 @@
 			};
 			name = Sideload;
 		};
+		C6BE110000000000000000B1 /* Benchmark */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Benchmark;
+		};
+		C6BE110000000000000000B2 /* Benchmark */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = Lume;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				CODE_SIGN_ENTITLEMENTS = Lume/Lume.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 15;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				ENABLE_APP_SANDBOX = YES;
+				"ENABLE_APP_SANDBOX[sdk=macosx*]" = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Lume/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;
+				"INFOPLIST_KEY_UIUserInterfaceStyle[sdk=appletvos*]" = Dark;
+				"INFOPLIST_KEY_UIUserInterfaceStyle[sdk=appletvsimulator*]" = Dark;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.5.2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bilipp.lume;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
+				TVOS_DEPLOYMENT_TARGET = 18.0;
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Benchmark;
+		};
+		C6BE110000000000000000B3 /* Benchmark */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 15;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.5.2;
+				PRODUCT_BUNDLE_IDENTIFIER = bilipp.LumeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Lume.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Lume";
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Benchmark;
+		};
+		C6BE110000000000000000B4 /* Benchmark */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 15;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.5.2;
+				PRODUCT_BUNDLE_IDENTIFIER = bilipp.LumeUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_TARGET_NAME = Lume;
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Benchmark;
+		};
+		C6BE110000000000000000AA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 15;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.5.2;
+				PRODUCT_BUNDLE_IDENTIFIER = bilipp.LumePerformanceTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Lume.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Lume";
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		C6BE110000000000000000AB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 15;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.5.2;
+				PRODUCT_BUNDLE_IDENTIFIER = bilipp.LumePerformanceTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Lume.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Lume";
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		C6BE110000000000000000AC /* Sideload */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 15;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.5.2;
+				PRODUCT_BUNDLE_IDENTIFIER = bilipp.LumePerformanceTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Lume.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Lume";
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Sideload;
+		};
+		C6BE110000000000000000AD /* Benchmark */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 15;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.5.2;
+				PRODUCT_BUNDLE_IDENTIFIER = bilipp.LumePerformanceTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Lume.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Lume";
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Benchmark;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -862,6 +1194,7 @@
 				C67C02E72F880F2400842DBA /* Debug */,
 				C67C02E82F880F2400842DBA /* Release */,
 				C67C02F12F880F2400842DBA /* Sideload */,
+				C6BE110000000000000000B1 /* Benchmark */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -872,6 +1205,7 @@
 				C67C02E52F880F2400842DBA /* Debug */,
 				C67C02E62F880F2400842DBA /* Release */,
 				C67C02F22F880F2400842DBA /* Sideload */,
+				C6BE110000000000000000B2 /* Benchmark */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -882,6 +1216,7 @@
 				C67C02EA2F880F2400842DBA /* Debug */,
 				C67C02EB2F880F2400842DBA /* Release */,
 				C67C02F32F880F2400842DBA /* Sideload */,
+				C6BE110000000000000000B3 /* Benchmark */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -892,9 +1227,21 @@
 				C67C02ED2F880F2400842DBA /* Debug */,
 				C67C02EE2F880F2400842DBA /* Release */,
 				C67C02F42F880F2400842DBA /* Sideload */,
+				C6BE110000000000000000B4 /* Benchmark */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		C6BE110000000000000000A9 /* Build configuration list for PBXNativeTarget "LumePerformanceTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C6BE110000000000000000AA /* Debug */,
+				C6BE110000000000000000AB /* Release */,
+				C6BE110000000000000000AC /* Sideload */,
+				C6BE110000000000000000AD /* Benchmark */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Benchmark;
 		};
 /* End XCConfigurationList section */
 

--- a/Lume.xcodeproj/xcshareddata/xcschemes/LumePerformance.xcscheme
+++ b/Lume.xcodeproj/xcshareddata/xcschemes/LumePerformance.xcscheme
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2650"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C67C02BF2F880F2200842DBA"
+               BuildableName = "Lume.app"
+               BlueprintName = "Lume"
+               ReferencedContainer = "container:Lume.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Benchmark"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "NO">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Performance.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Benchmark"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C67C02BF2F880F2200842DBA"
+            BuildableName = "Lume.app"
+            BlueprintName = "Lume"
+            ReferencedContainer = "container:Lume.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Benchmark"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C67C02BF2F880F2200842DBA"
+            BuildableName = "Lume.app"
+            BlueprintName = "Lume"
+            ReferencedContainer = "container:Lume.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Benchmark">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Benchmark"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Lume/LumeApp.swift
+++ b/Lume/LumeApp.swift
@@ -190,6 +190,14 @@ struct LumeApp: App {
                 .environment(playlistSwitch)
                 .environment(parentalControls)
                 .task {
+                    // Subscribe to MetricKit before anything else: payloads for a
+                    // previous run are delivered shortly after launch, and one
+                    // missed registration loses a day of field data. Compiles out
+                    // on tvOS, where MetricKit doesn't exist.
+                    #if canImport(MetricKit) && !os(tvOS)
+                        AppPerformanceMetrics.shared.start()
+                    #endif
+
                     // Give DownloadManager access to the model container so it
                     // can persist download state from its delegate callbacks.
                     #if !os(tvOS)

--- a/Lume/Services/Debug/DebugLogExporter.swift
+++ b/Lume/Services/Debug/DebugLogExporter.swift
@@ -29,6 +29,11 @@ nonisolated struct DebugLogExporter {
         var osVersion: String
         var deviceModel: String
         var engineSummary: String
+        /// Per-engine playback QoE lines (join time, rebuffering, failures).
+        /// Pre-rendered because `PlaybackQoE` is MainActor-isolated.
+        var playbackQoE: [String] = []
+        /// The newest MetricKit payload summary, when one has been delivered.
+        var fieldMetrics: [String] = []
     }
 
     /// Oldest entries to include when the session start is unknown or very old.
@@ -44,6 +49,7 @@ nonisolated struct DebugLogExporter {
     /// Reads the unified log off the main actor.
     func makeReport(now: Date = Date()) async throws -> String {
         var lines = header(now: now)
+        lines.append(contentsOf: performanceSection())
         let entries = try collectEntries(now: now)
         lines.append("")
         lines.append("--- Log entries (\(entries.count)) ---")
@@ -114,6 +120,56 @@ nonisolated struct DebugLogExporter {
         ]
     }
 
+    // MARK: - Performance section
+
+    /// Playback QoE and field metrics, when there is anything to report. These
+    /// numbers turn "streams are slow to start" into an actual measurement, so
+    /// they belong in the report a user sends rather than in a localized screen.
+    func performanceSection() -> [String] {
+        var lines: [String] = []
+        if !metadata.playbackQoE.isEmpty {
+            lines.append("")
+            lines.append("--- Playback quality of experience ---")
+            lines.append(contentsOf: metadata.playbackQoE)
+        }
+        if !metadata.fieldMetrics.isEmpty {
+            lines.append("")
+            lines.append("--- Latest MetricKit payload ---")
+            lines.append(contentsOf: metadata.fieldMetrics)
+        }
+        return lines
+    }
+
+    /// Renders one line per engine that has seen a playback attempt.
+    static func qoeLines(_ summary: PlaybackQoESummary) -> [String] {
+        guard summary.totalSessions > 0 else { return [] }
+        var lines: [String] = []
+        for kind in PlayerEngineKind.allCases {
+            guard let stats = summary.engines[kind.rawValue], stats.sessions > 0 else { continue }
+            var parts = [
+                "sessions=\(stats.sessions)",
+                "firstFrames=\(stats.firstFrames)",
+                "meanJoin=\(String(format: "%.2f", stats.meanJoinTime))s",
+                "worstJoin=\(String(format: "%.2f", stats.joinTimeWorst))s",
+                "rebuffers=\(stats.rebuffers)"
+            ]
+            if let ratio = stats.rebufferRatio {
+                parts.append("rebufferRatio=\(String(format: "%.4f", ratio))")
+            }
+            if stats.startupFailures > 0 {
+                parts.append("startupFailures=\(stats.startupFailures)")
+            }
+            if stats.exitsBeforeVideoStart > 0 {
+                parts.append("exitsBeforeVideoStart=\(stats.exitsBeforeVideoStart)")
+            }
+            lines.append("\(kind.displayName): \(parts.joined(separator: " "))")
+        }
+        if summary.engineFallbacks > 0 {
+            lines.append("Engine fallbacks: \(summary.engineFallbacks)")
+        }
+        return lines
+    }
+
     // MARK: - Metadata
 
     /// Gather app / device context. Runs on the main actor because it reads the
@@ -127,13 +183,21 @@ nonisolated struct DebugLogExporter {
             .map(\.displayName)
             .joined(separator: " › ")
 
+        #if canImport(MetricKit) && !os(tvOS)
+            let fieldMetrics = AppPerformanceMetrics.shared.latestSummary
+        #else
+            let fieldMetrics: [String] = []
+        #endif
+
         return Metadata(
             appVersion: SupportInfo.appVersion,
             buildNumber: Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "—",
             platform: platformName,
             osVersion: ProcessInfo.processInfo.operatingSystemVersionString,
             deviceModel: deviceModel,
-            engineSummary: engineSummary
+            engineSummary: engineSummary,
+            playbackQoE: qoeLines(PlaybackQoE.shared.summary),
+            fieldMetrics: fieldMetrics
         )
     }
 

--- a/Lume/Services/Diagnostics/AppPerformanceMetrics.swift
+++ b/Lume/Services/Diagnostics/AppPerformanceMetrics.swift
@@ -1,0 +1,196 @@
+//
+//  AppPerformanceMetrics.swift
+//  Lume
+//
+//  The field layer of performance testing: MetricKit.
+//
+//  Signposts and `LumePerformanceTests` tell us whether a phase regressed on
+//  *our* machine. MetricKit tells us what users actually experience — daily
+//  aggregates of launch time, hang rate, scroll hitch ratio, memory and disk
+//  writes, plus diagnostics for hangs and crashes, all sampled by the OS with no
+//  measurement overhead of ours.
+//
+//  Payloads arrive at most once a day (and on the next launch after one was
+//  queued), so this only ever runs cold. Each payload is summarized into the
+//  unified log — where the debug log exporter picks it up — and its raw JSON is
+//  kept on disk so a support report can carry the full histograms.
+//
+//  MetricKit is unavailable on tvOS, so the whole subscriber compiles out there.
+//
+
+import Foundation
+import OSLog
+
+#if canImport(MetricKit) && !os(tvOS)
+    import MetricKit
+
+    /// Subscribes to MetricKit for the lifetime of the process.
+    final class AppPerformanceMetrics: NSObject, MXMetricManagerSubscriber {
+        static let shared = AppPerformanceMetrics()
+
+        /// The most recent payload summary, for the debug screen.
+        private(set) var latestSummary: [String] = []
+
+        private var isRegistered = false
+
+        /// Register with MetricKit. Idempotent; call once at launch.
+        func start() {
+            guard !isRegistered else { return }
+            isRegistered = true
+            MXMetricManager.shared.add(self)
+            Logger.performance.info("MetricKit subscriber registered")
+        }
+
+        // MARK: - Metrics
+
+        func didReceive(_ payloads: [MXMetricPayload]) {
+            for payload in payloads {
+                let lines = Self.summarize(payload)
+                latestSummary = lines
+                for line in lines {
+                    Logger.performance.info("MetricKit \(line, privacy: .public)")
+                }
+                Self.archive(payload.jsonRepresentation(), kind: "metrics", date: payload.timeStampEnd)
+            }
+        }
+
+        // MARK: - Diagnostics
+
+        func didReceive(_ payloads: [MXDiagnosticPayload]) {
+            for payload in payloads {
+                var counts = [
+                    ("hang", payload.hangDiagnostics?.count ?? 0),
+                    ("crash", payload.crashDiagnostics?.count ?? 0),
+                    ("diskWrite", payload.diskWriteExceptionDiagnostics?.count ?? 0)
+                ]
+                // Launch diagnostics are iOS-family only.
+                #if !os(macOS)
+                    counts.append(("launch", payload.appLaunchDiagnostics?.count ?? 0))
+                #endif
+                counts = counts.filter { $0.1 > 0 }
+                let description = counts.map { "\($0.0)=\($0.1)" }.joined(separator: " ")
+                if !description.isEmpty {
+                    Logger.performance.error("MetricKit diagnostics \(description, privacy: .public)")
+                }
+                for hang in payload.hangDiagnostics ?? [] {
+                    let duration = hang.hangDuration.converted(to: .seconds).value
+                    Logger.performance.error(
+                        "MetricKit hang \(duration, format: .fixed(precision: 2), privacy: .public)s"
+                    )
+                }
+                Self.archive(payload.jsonRepresentation(), kind: "diagnostics", date: payload.timeStampEnd)
+            }
+        }
+
+        // MARK: - Summarizing
+
+        /// A handful of headline numbers from a daily payload. Deliberately
+        /// short: the archived JSON keeps the full detail.
+        static func summarize(_ payload: MXMetricPayload) -> [String] {
+            var lines: [String] = []
+
+            if let launch = payload.applicationLaunchMetrics {
+                if let mean = meanMilliseconds(launch.histogrammedTimeToFirstDraw) {
+                    lines.append("timeToFirstDraw≈\(Int(mean))ms")
+                }
+                if let mean = meanMilliseconds(launch.histogrammedApplicationResumeTime) {
+                    lines.append("resumeTime≈\(Int(mean))ms")
+                }
+            }
+            if let responsiveness = payload.applicationResponsivenessMetrics,
+               let mean = meanMilliseconds(responsiveness.histogrammedApplicationHangTime)
+            {
+                lines.append("hangTime≈\(Int(mean))ms")
+            }
+            if let animation = payload.animationMetrics {
+                let ratio = animation.scrollHitchTimeRatio.value
+                lines.append("scrollHitchRatio=\(String(format: "%.4f", ratio))")
+            }
+            if let memory = payload.memoryMetrics {
+                let peak = memory.peakMemoryUsage.converted(to: .megabytes).value
+                lines.append("peakMemory=\(Int(peak))MB")
+            }
+            if let disk = payload.diskIOMetrics {
+                let written = disk.cumulativeLogicalWrites.converted(to: .megabytes).value
+                lines.append("logicalWrites=\(Int(written))MB")
+            }
+            if let exits = payload.applicationExitMetrics {
+                let watchdogs = exits.foregroundExitData.cumulativeAppWatchdogExitCount
+                if watchdogs > 0 {
+                    lines.append("watchdogExits=\(watchdogs)")
+                }
+            }
+            return lines.isEmpty ? ["payload contained no metrics"] : lines
+        }
+
+        /// Bucket-weighted mean of a duration histogram, in milliseconds.
+        /// MetricKit reports histograms rather than raw samples, so a mean is the
+        /// most we can reconstruct — the archived JSON keeps the buckets.
+        private static func meanMilliseconds(_ histogram: MXHistogram<UnitDuration>) -> Double? {
+            var totalCount = 0
+            var weighted = 0.0
+            let enumerator = histogram.bucketEnumerator
+            while let bucket = enumerator.nextObject() as? MXHistogramBucket<UnitDuration> {
+                let start = bucket.bucketStart.converted(to: .milliseconds).value
+                let end = bucket.bucketEnd.converted(to: .milliseconds).value
+                let midpoint = (start + end) / 2
+                weighted += midpoint * Double(bucket.bucketCount)
+                totalCount += bucket.bucketCount
+            }
+            guard totalCount > 0 else { return nil }
+            return weighted / Double(totalCount)
+        }
+
+        // MARK: - Archiving
+
+        /// Where archived payloads live. Excluded from backup — they are
+        /// re-derivable diagnostics, not user data.
+        static var archiveDirectory: URL? {
+            guard let support = FileManager.default.urls(
+                for: .applicationSupportDirectory, in: .userDomainMask
+            ).first else { return nil }
+            return support.appendingPathComponent("Diagnostics", isDirectory: true)
+        }
+
+        /// Keeps the newest payloads and prunes the rest, so the directory can't
+        /// grow without bound on a long-lived install.
+        private static let maxArchivedPayloads = 14
+
+        private static func archive(_ json: Data, kind: String, date: Date) {
+            guard let directory = archiveDirectory else { return }
+            let manager = FileManager.default
+            do {
+                if !manager.fileExists(atPath: directory.path) {
+                    try manager.createDirectory(at: directory, withIntermediateDirectories: true)
+                    var resourceValues = URLResourceValues()
+                    resourceValues.isExcludedFromBackup = true
+                    var mutableDirectory = directory
+                    try? mutableDirectory.setResourceValues(resourceValues)
+                }
+                let name = "\(kind)-\(Int(date.timeIntervalSince1970)).json"
+                try json.write(to: directory.appendingPathComponent(name), options: .atomic)
+                prune(in: directory)
+            } catch {
+                let reason = error.localizedDescription
+                Logger.performance.error("MetricKit archive failed: \(reason, privacy: .public)")
+            }
+        }
+
+        private static func prune(in directory: URL) {
+            let manager = FileManager.default
+            let contents = (try? manager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.contentModificationDateKey]
+            )) ?? []
+            guard contents.count > maxArchivedPayloads else { return }
+            let sorted = contents.sorted { lhs, rhs in
+                let lhsDate = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
+                let rhsDate = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
+                return (lhsDate ?? .distantPast) > (rhsDate ?? .distantPast)
+            }
+            for url in sorted.dropFirst(maxArchivedPayloads) {
+                try? manager.removeItem(at: url)
+            }
+        }
+    }
+#endif

--- a/Lume/Services/Diagnostics/PerformanceSignposts.swift
+++ b/Lume/Services/Diagnostics/PerformanceSignposts.swift
@@ -1,0 +1,132 @@
+//
+//  PerformanceSignposts.swift
+//  Lume
+//
+//  The one place app-defined performance milestones are named.
+//
+//  Every phase we have ever had to profile by hand (playlist sync, EPG ingest,
+//  guide window loads, time-to-first-frame) emits an `OSSignposter` interval
+//  from here. That single instrumentation buys three things:
+//
+//  1. A Points of Interest lane in Instruments, so a device trace shows the
+//     phase boundaries instead of an undifferentiated wall of stack samples.
+//  2. `XCTOSSignpostMetric` assertions in `LumePerformanceTests`, so a phase
+//     getting slower is a test failure rather than a customer complaint.
+//  3. Free `os_log`-based timing in the field, readable via the debug log
+//     exporter without attaching a debugger.
+//
+//  The names below are a contract with the performance tests — renaming one
+//  silently detaches its benchmark, so change `Name` and the test together.
+//
+
+import Foundation
+import OSLog
+
+// MARK: - Signpost names
+
+/// A named performance milestone.
+///
+/// `OSSignposter` requires a `StaticString` name, while `XCTOSSignpostMetric`
+/// needs the same text as a `String`; wrapping the literal once keeps the two
+/// from drifting apart.
+nonisolated struct PerfSignpost {
+    let name: StaticString
+
+    init(_ name: StaticString) {
+        self.name = name
+    }
+
+    /// The same name as a `String`, for `XCTOSSignpostMetric(subsystem:category:name:)`.
+    var metricName: String {
+        name.description
+    }
+}
+
+nonisolated extension PerfSignpost {
+    // Content sync
+    static let playlistSync = PerfSignpost("PlaylistSync")
+    static let syncCategories = PerfSignpost("SyncCategories")
+    static let syncMovies = PerfSignpost("SyncMovies")
+    static let syncSeries = PerfSignpost("SyncSeries")
+    static let syncLiveStreams = PerfSignpost("SyncLiveStreams")
+    static let m3uDownload = PerfSignpost("M3UDownload")
+    static let m3uImport = PerfSignpost("M3UImport")
+
+    // EPG
+    static let epgSourceSync = PerfSignpost("EPGSourceSync")
+    static let epgIngest = PerfSignpost("EPGIngest")
+    static let channelEPGLoad = PerfSignpost("ChannelEPGLoad")
+    static let guideWindowLoad = PerfSignpost("GuideWindowLoad")
+
+    // Home
+    static let homeTrendingLoad = PerfSignpost("HomeTrendingLoad")
+    static let homeRecommendations = PerfSignpost("HomeRecommendations")
+
+    // Player
+    static let playerStartup = PerfSignpost("PlayerStartup")
+    static let playerRebuffer = PerfSignpost("PlayerRebuffer")
+    static let playerEngineFallback = PerfSignpost("PlayerEngineFallback")
+    static let playerStartupFailure = PerfSignpost("PlayerStartupFailure")
+}
+
+// MARK: - Interval handle
+
+/// An in-flight signpost interval. Opaque on purpose: callers either use
+/// `Perf.measure` or pair `Perf.begin`/`Perf.end` in a `defer`.
+nonisolated struct PerfInterval {
+    fileprivate let signpost: PerfSignpost
+    fileprivate let state: OSSignpostIntervalState
+}
+
+// MARK: - Facade
+
+/// Emits the app's performance signposts.
+///
+/// `nonisolated` throughout because the hottest call sites — the streaming
+/// parsers and the off-main EPG loaders — are themselves `nonisolated`.
+/// `OSSignposter` no-ops cheaply when nothing is recording, so these calls are
+/// safe to leave in shipping builds (and are what makes a field trace useful).
+nonisolated enum Perf {
+    /// Matches `Logger`'s subsystem so a single Instruments/`log` filter covers
+    /// both the app's log messages and its signposts.
+    static let subsystem = Bundle.main.bundleIdentifier ?? "com.bilipp.lume"
+    static let category = "Performance"
+
+    private static let signposter = OSSignposter(subsystem: subsystem, category: category)
+
+    /// Whether anything is currently recording signposts. Worth checking before
+    /// building an expensive interval message, not before the interval itself.
+    static var isEnabled: Bool {
+        signposter.isEnabled
+    }
+
+    static func begin(_ signpost: PerfSignpost) -> PerfInterval {
+        let state = signposter.beginInterval(signpost.name, id: signposter.makeSignpostID())
+        return PerfInterval(signpost: signpost, state: state)
+    }
+
+    static func end(_ interval: PerfInterval) {
+        signposter.endInterval(interval.signpost.name, interval.state)
+    }
+
+    /// Emit a zero-length event — for things that happen rather than take time
+    /// (a rebuffer starting, an engine handing off).
+    static func event(_ signpost: PerfSignpost) {
+        signposter.emitEvent(signpost.name)
+    }
+
+    /// Wrap a synchronous phase.
+    static func measure<T>(_ signpost: PerfSignpost, _ body: () throws -> T) rethrows -> T {
+        let interval = begin(signpost)
+        defer { end(interval) }
+        return try body()
+    }
+
+    /// Wrap an asynchronous phase. The interval state never leaves the caller's
+    /// isolation domain, so it may safely live across the `await`.
+    static func measure<T>(_ signpost: PerfSignpost, _ body: () async throws -> T) async rethrows -> T {
+        let interval = begin(signpost)
+        defer { end(interval) }
+        return try await body()
+    }
+}

--- a/Lume/Services/Diagnostics/PlaybackQoE.swift
+++ b/Lume/Services/Diagnostics/PlaybackQoE.swift
@@ -1,0 +1,250 @@
+//
+//  PlaybackQoE.swift
+//  Lume
+//
+//  Quality-of-experience accounting for playback — the metric set video
+//  services actually measure, rather than CPU time:
+//
+//  * **Join time** (time-to-first-frame): playback requested → first frame
+//    rendered, per engine. This is the number behind "streams take ages to
+//    start".
+//  * **Rebuffer ratio**: seconds stalled mid-stream over seconds watched.
+//  * **Exit before video start**: sessions the user abandoned while still
+//    spinning — the harshest signal that startup is too slow.
+//  * **Startup failures / engine fallbacks**: how often the preferred engine
+//    can't open a stream and hands off.
+//
+//  All four engines report into this one object at choke points they already
+//  have (`hasStartedPlayback` flipping true, the startup watchdog arming), so
+//  the numbers are directly comparable across KSPlayer, VLCKit, AVPlayer and
+//  LumeEngine. It also emits the `PlayerStartup` signpost interval, which is
+//  what `LumePerformanceTests` and Instruments read.
+//
+//  Counters are aggregated in memory and flushed to `UserDefaults` at session
+//  boundaries only — never periodically. A recurring write during playback is
+//  exactly what used to hitch KSPlayer every few seconds.
+//
+
+import Foundation
+import OSLog
+
+// MARK: - Persisted summary
+
+/// Rolling per-engine startup statistics. Plain values, `nonisolated` so tests
+/// and the debug screen can build and inspect one off the main actor.
+nonisolated struct EngineQoEStats: Codable, Equatable {
+    var sessions = 0
+    var firstFrames = 0
+    var joinTimeTotal: TimeInterval = 0
+    var joinTimeWorst: TimeInterval = 0
+    var lastJoinTime: TimeInterval = 0
+    var startupFailures = 0
+    var exitsBeforeVideoStart = 0
+    var rebuffers = 0
+    var rebufferSeconds: TimeInterval = 0
+    /// Wall-clock seconds since the first frame, summed across sessions. The
+    /// denominator for `rebufferRatio` — stall time included, matching how
+    /// player analytics vendors report it.
+    var watchedSeconds: TimeInterval = 0
+
+    var meanJoinTime: TimeInterval {
+        firstFrames > 0 ? joinTimeTotal / Double(firstFrames) : 0
+    }
+
+    /// Fraction of watch time spent stalled. `nil` until something was watched.
+    var rebufferRatio: Double? {
+        watchedSeconds > 0 ? rebufferSeconds / watchedSeconds : nil
+    }
+}
+
+/// The whole QoE picture, keyed by `PlayerEngineKind.rawValue`.
+nonisolated struct PlaybackQoESummary: Codable, Equatable {
+    var engines: [String: EngineQoEStats] = [:]
+    var engineFallbacks = 0
+    var updatedAt: Date?
+
+    var totalSessions: Int {
+        engines.values.reduce(0) { $0 + $1.sessions }
+    }
+}
+
+// MARK: - Tracker
+
+/// Records QoE for the current playback session. `MainActor`-isolated (project
+/// default) because every engine reports from the main thread.
+@Observable
+final class PlaybackQoE {
+    static let shared = PlaybackQoE()
+
+    /// Rolling totals, restored from `UserDefaults` at launch.
+    private(set) var summary: PlaybackQoESummary
+
+    private static let storageKey = "playbackQoESummary"
+
+    // Current session
+    private var engine: PlayerEngineKind?
+    private var isLive = false
+    private var startupBegan: Date?
+    private var firstFrameAt: Date?
+    private var stallBegan: Date?
+    private var interval: PerfInterval?
+
+    /// Internal rather than private so tests can build an instance backed by a
+    /// scratch suite. Sharing `UserDefaults.standard` between a test and the
+    /// singleton is a known source of cross-test flakiness in this project.
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: Self.storageKey),
+           let decoded = try? JSONDecoder().decode(PlaybackQoESummary.self, from: data)
+        {
+            summary = decoded
+        } else {
+            summary = PlaybackQoESummary()
+        }
+    }
+
+    private let defaults: UserDefaults
+
+    // MARK: - Session lifecycle
+
+    /// A playback attempt has started: the engine has been handed a URL and the
+    /// spinner is up. Opens the `PlayerStartup` interval.
+    ///
+    /// Safe to call again for a retry or a live-channel swap — the previous
+    /// attempt is closed out first, so a zap counts as its own session.
+    func beginStartup(engine: PlayerEngineKind, isLive: Bool) {
+        if startupBegan != nil {
+            endSession()
+        }
+        self.engine = engine
+        self.isLive = isLive
+        startupBegan = Date()
+        firstFrameAt = nil
+        stallBegan = nil
+        interval = Perf.begin(.playerStartup)
+        mutate(engine) { $0.sessions += 1 }
+    }
+
+    /// The first frame is on screen. Closes the startup interval and records
+    /// join time. Idempotent within a session.
+    func noteFirstFrame() {
+        guard let startupBegan, firstFrameAt == nil, let engine else { return }
+        let now = Date()
+        let joinTime = now.timeIntervalSince(startupBegan)
+        firstFrameAt = now
+        if let interval {
+            Perf.end(interval)
+            self.interval = nil
+        }
+        mutate(engine) {
+            $0.firstFrames += 1
+            $0.joinTimeTotal += joinTime
+            $0.lastJoinTime = joinTime
+            $0.joinTimeWorst = max($0.joinTimeWorst, joinTime)
+        }
+        let name = engine.rawValue
+        let live = isLive
+        Logger.performance.log(
+            "join time \(joinTime, format: .fixed(precision: 2), privacy: .public)s engine=\(name, privacy: .public) live=\(live, privacy: .public)"
+        )
+        persist()
+    }
+
+    /// A mid-stream stall began (startup buffering doesn't count — that's join
+    /// time). No-op before the first frame or while already stalled.
+    func noteStallBegan() {
+        guard firstFrameAt != nil, stallBegan == nil else { return }
+        stallBegan = Date()
+        Perf.event(.playerRebuffer)
+    }
+
+    /// The stall cleared. Adds its duration to the rebuffer total.
+    func noteStallEnded() {
+        guard let stallBegan, let engine else { return }
+        let seconds = Date().timeIntervalSince(stallBegan)
+        self.stallBegan = nil
+        mutate(engine) {
+            $0.rebuffers += 1
+            $0.rebufferSeconds += seconds
+        }
+        persist()
+    }
+
+    /// The engine gave up before producing a frame.
+    func noteStartupFailure() {
+        guard let engine else { return }
+        Perf.event(.playerStartupFailure)
+        mutate(engine) { $0.startupFailures += 1 }
+        persist()
+    }
+
+    /// The host is switching to the next engine in the priority list.
+    func noteEngineFallback(to next: PlayerEngineKind) {
+        Perf.event(.playerEngineFallback)
+        summary.engineFallbacks += 1
+        let previous = engine?.rawValue ?? "none"
+        let replacement = next.rawValue
+        Logger.performance.log(
+            "engine fallback \(previous, privacy: .public) -> \(replacement, privacy: .public)"
+        )
+        persist()
+    }
+
+    /// Playback ended (view torn down, channel closed, app backgrounded). Closes
+    /// any open interval and — if no frame ever arrived — counts an exit before
+    /// video start.
+    func endSession() {
+        guard let engine, let startupBegan else { return }
+        if let interval {
+            Perf.end(interval)
+            self.interval = nil
+        }
+        if let stallBegan {
+            let seconds = Date().timeIntervalSince(stallBegan)
+            mutate(engine) {
+                $0.rebuffers += 1
+                $0.rebufferSeconds += seconds
+            }
+        }
+        if let firstFrameAt {
+            let watched = Date().timeIntervalSince(firstFrameAt)
+            mutate(engine) { $0.watchedSeconds += watched }
+        } else {
+            let waited = Date().timeIntervalSince(startupBegan)
+            mutate(engine) { $0.exitsBeforeVideoStart += 1 }
+            let name = engine.rawValue
+            Logger.performance.log(
+                "exit before video start after \(waited, format: .fixed(precision: 1), privacy: .public)s engine=\(name, privacy: .public)"
+            )
+        }
+        self.engine = nil
+        self.startupBegan = nil
+        firstFrameAt = nil
+        stallBegan = nil
+        persist()
+    }
+
+    // MARK: - Maintenance
+
+    /// Clears every counter (debug screen "Reset statistics").
+    func reset() {
+        summary = PlaybackQoESummary()
+        persist()
+    }
+
+    // MARK: - Private
+
+    private func mutate(_ engine: PlayerEngineKind, _ body: (inout EngineQoEStats) -> Void) {
+        var stats = summary.engines[engine.rawValue] ?? EngineQoEStats()
+        body(&stats)
+        summary.engines[engine.rawValue] = stats
+    }
+
+    /// Flushed only at boundaries — first frame, stall end, session end — never
+    /// on a timer, so playback is never interrupted by our own bookkeeping.
+    private func persist() {
+        summary.updatedAt = Date()
+        guard let data = try? JSONEncoder().encode(summary) else { return }
+        defaults.set(data, forKey: Self.storageKey)
+    }
+}

--- a/Lume/Services/Sync/ContentSyncManager+M3U.swift
+++ b/Lume/Services/Sync/ContentSyncManager+M3U.swift
@@ -228,12 +228,19 @@ extension ContentSyncManager {
         // Local imported files are parsed in place; only downloads are temp
         // files we own and must clean up.
         let isRemote = !(URL(string: serverURL)?.isFileURL ?? false)
+        let downloadInterval = Perf.begin(.m3uDownload)
         let fileURL = try await client.downloadPlaylist(from: serverURL)
+        Perf.end(downloadInterval)
         defer { if isRemote { try? FileManager.default.removeItem(at: fileURL) } }
         await progress?.complete(.playlistDownload)
 
         await progress?.start(.playlistImport)
+        // Download and import are separate intervals on purpose: profiling a
+        // 600k-entry playlist showed the SwiftData import — not the download —
+        // owning the multi-minute wait, and one combined number hid that.
+        let importInterval = Perf.begin(.m3uImport)
         let summary = try importM3UFile(fileURL, playlistId: playlistId, progress: progress)
+        Perf.end(importInterval)
         Logger.database.info(
             "m3u import finished: \(summary.liveCount) live, \(summary.movieCount) movies, \(summary.episodeCount) episodes"
         )

--- a/Lume/Services/Sync/ContentSyncManager.swift
+++ b/Lume/Services/Sync/ContentSyncManager.swift
@@ -116,6 +116,11 @@ actor ContentSyncManager {
     }
 
     private func performSync(playlistId: UUID, progress: SyncProgress?, full: Bool) async throws {
+        // Whole-sync interval: the umbrella every phase below nests under, so a
+        // trace (or `XCTOSSignpostMetric`) shows both the total and the split.
+        let interval = Perf.begin(.playlistSync)
+        defer { Perf.end(interval) }
+
         let statusContext = ModelContext(modelContainer)
         statusContext.autosaveEnabled = false
         guard let playlist = try statusContext.fetch(
@@ -206,6 +211,9 @@ actor ContentSyncManager {
     }
 
     private func syncCategories(_ dtos: [XtreamCategory], type: CategoryType, playlistId: UUID) throws {
+        let interval = Perf.begin(.syncCategories)
+        defer { Perf.end(interval) }
+
         let context = ModelContext(modelContainer)
         context.autosaveEnabled = false
 
@@ -254,6 +262,9 @@ actor ContentSyncManager {
     /// no SwiftData relationship — so each insert avoids the inverse-array
     /// updates that previously slowed sync as categories grew.
     func syncMovies(for playlist: Playlist, playlistId: UUID, progress: SyncProgress? = nil) async throws {
+        let interval = Perf.begin(.syncMovies)
+        defer { Perf.end(interval) }
+
         await progress?.start(.movies)
         let movieDTOs = try await xtreamClient.getVODStreams(playlist: playlist)
         let totalCount = movieDTOs.count
@@ -307,6 +318,9 @@ actor ContentSyncManager {
 
     /// Syncs series in memory-bounded batches.
     func syncSeries(for playlist: Playlist, playlistId: UUID, progress: SyncProgress? = nil) async throws {
+        let interval = Perf.begin(.syncSeries)
+        defer { Perf.end(interval) }
+
         await progress?.start(.series)
         let seriesDTOs = try await xtreamClient.getSeries(playlist: playlist)
         let totalCount = seriesDTOs.count
@@ -434,6 +448,9 @@ actor ContentSyncManager {
 
     /// Syncs live streams in memory-bounded batches.
     func syncLiveStreams(for playlist: Playlist, playlistId: UUID, progress: SyncProgress? = nil) async throws {
+        let interval = Perf.begin(.syncLiveStreams)
+        defer { Perf.end(interval) }
+
         await progress?.start(.liveStreams)
         let streamDTOs = try await xtreamClient.getLiveStreams(playlist: playlist)
         let totalCount = streamDTOs.count

--- a/Lume/Services/Sync/EPGSyncManager.swift
+++ b/Lume/Services/Sync/EPGSyncManager.swift
@@ -55,6 +55,9 @@ actor EPGSyncManager {
     // MARK: - Per-source sync
 
     private func sync(sourceID: UUID, url: String, knownChannelIDs: Set<String>) async -> Bool {
+        let interval = Perf.begin(.epgSourceSync)
+        defer { Perf.end(interval) }
+
         markStatus(sourceID, .syncing)
         guard !url.isEmpty else {
             markStatus(sourceID, .error)
@@ -139,6 +142,9 @@ actor EPGSyncManager {
     /// memory flat, but inserts accumulate on a single context and save only
     /// every `saveThreshold` listings to minimise main-context merges.
     private func insertListings(from fileURL: URL, knownChannelIDs: Set<String>) -> Int {
+        let interval = Perf.begin(.epgIngest)
+        defer { Perf.end(interval) }
+
         var insertedCount = 0
         var pendingInserts = 0
         let context = ModelContext(modelContainer)

--- a/Lume/Utils/Logger.swift
+++ b/Lume/Utils/Logger.swift
@@ -10,4 +10,7 @@ nonisolated extension Logger {
     static let indexing = Logger(subsystem: subsystem, category: "Indexing")
     static let premium = Logger(subsystem: subsystem, category: "Premium")
     static let memory = Logger(subsystem: subsystem, category: "Memory")
+    /// Shares its category with `Perf`'s signposts, so one filter shows both the
+    /// phase boundaries and the messages explaining them.
+    static let performance = Logger(subsystem: subsystem, category: "Performance")
 }

--- a/Lume/Views/Home/HomeView+Trending.swift
+++ b/Lume/Views/Home/HomeView+Trending.swift
@@ -30,6 +30,8 @@ extension HomeView {
             return
         }
         trendingState = .loading
+        let interval = Perf.begin(.homeTrendingLoad)
+        defer { Perf.end(interval) }
         do {
             async let movieTitles = client.trending(.movie)
             async let tvTitles = client.trending(.tvShow)

--- a/Lume/Views/Home/HomeView.swift
+++ b/Lume/Views/Home/HomeView.swift
@@ -401,6 +401,9 @@ private extension HomeView {
         // loading placeholder) in place; the task re-fires once `isSyncBusy` clears.
         guard !isSyncBusy else { return }
 
+        let interval = Perf.begin(.homeRecommendations)
+        defer { Perf.end(interval) }
+
         let engine = RecommendationEngine(modelContainer: modelContext.container)
         let scored = await engine.recommendations()
         var items: [HomeMediaItem] = []

--- a/Lume/Views/LiveTV/ChannelEPGSnapshot.swift
+++ b/Lume/Views/LiveTV/ChannelEPGSnapshot.swift
@@ -37,6 +37,9 @@ enum ChannelEPGLoader {
     ) -> [String: ChannelEPG] {
         guard !channelIds.isEmpty else { return [:] }
 
+        let interval = Perf.begin(.channelEPGLoad)
+        defer { Perf.end(interval) }
+
         let context = ModelContext(container)
         // Only currently-airing or upcoming listings matter for now/next; the
         // `end > now` bound (plus the channel-id scope) keeps this to a small,
@@ -95,6 +98,9 @@ enum EPGGuideLoader {
         windowEnd: Date
     ) -> [String: [EPGWindowListing]] {
         guard !channelIds.isEmpty else { return [:] }
+
+        let interval = Perf.begin(.guideWindowLoad)
+        defer { Perf.end(interval) }
 
         let context = ModelContext(container)
         // Channel-id scope is index-served; the time bounds trim it to the

--- a/Lume/Views/Player/AVPlayerCoordinator.swift
+++ b/Lume/Views/Player/AVPlayerCoordinator.swift
@@ -162,6 +162,7 @@ final class AVPlayerCoordinator: NSObject, ObservableObject {
         isBuffering = true
         hasStartedPlayback = false
         didReportFailure = false
+        PlaybackQoE.shared.beginStartup(engine: .avPlayer, isLive: media.isLive)
         startStartupWatchdog()
 
         let asset = AVURLAsset(url: media.url)
@@ -203,6 +204,9 @@ final class AVPlayerCoordinator: NSObject, ObservableObject {
     private func reportFailure() {
         guard !didReportFailure else { return }
         didReportFailure = true
+        if !hasStartedPlayback {
+            PlaybackQoE.shared.noteStartupFailure()
+        }
         cancelStartupWatchdog()
         Logger.player.error("AVPlayer playback failure reported")
         onPlaybackFailure?()
@@ -220,6 +224,7 @@ final class AVPlayerCoordinator: NSObject, ObservableObject {
         teardownItemObservers()
         trackLoadTask?.cancel()
         cancelStartupWatchdog()
+        PlaybackQoE.shared.endSession()
         pipController?.stopPictureInPicture()
         pipController = nil
         player.pause()
@@ -391,8 +396,14 @@ final class AVPlayerCoordinator: NSObject, ObservableObject {
                 guard let self else { return }
                 isPlaying = player.timeControlStatus != .paused
                 isBuffering = player.timeControlStatus == .waitingToPlayAtSpecifiedRate
+                if isBuffering {
+                    PlaybackQoE.shared.noteStallBegan()
+                } else {
+                    PlaybackQoE.shared.noteStallEnded()
+                }
                 if player.timeControlStatus == .playing {
                     hasStartedPlayback = true
+                    PlaybackQoE.shared.noteFirstFrame()
                     cancelStartupWatchdog()
                 }
             }

--- a/Lume/Views/Player/FullScreenPlayerView.swift
+++ b/Lume/Views/Player/FullScreenPlayerView.swift
@@ -138,6 +138,7 @@ struct FullScreenPlayerView: View {
         guard hasFallbackEngine else { return }
         let failed = engine
         engineAttempt += 1
+        PlaybackQoE.shared.noteEngineFallback(to: engine)
         Logger.player.log("engine \(failed.rawValue, privacy: .public) could not start the stream; falling back to \(engine.rawValue, privacy: .public)")
     }
 

--- a/Lume/Views/Player/KSPlayerEngineView+Playback.swift
+++ b/Lume/Views/Player/KSPlayerEngineView+Playback.swift
@@ -48,6 +48,13 @@ extension KSPlayerEngineView {
     /// the value is already correct (avoids redundant SwiftUI diffs).
     private func setBuffering(_ buffering: Bool) {
         guard isBuffering != buffering else { return }
+        // QoE only counts *mid-stream* stalls; a spinner before the first frame
+        // is join time, and `PlaybackQoE` discards these until it has one.
+        if buffering {
+            PlaybackQoE.shared.noteStallBegan()
+        } else {
+            PlaybackQoE.shared.noteStallEnded()
+        }
         withAnimation(.easeInOut(duration: 0.25)) { isBuffering = buffering }
     }
 
@@ -78,6 +85,7 @@ extension KSPlayerEngineView {
     func markPlaybackStarted() {
         guard !hasStartedPlayback, hasSeenReadyToPlay else { return }
         hasStartedPlayback = true
+        PlaybackQoE.shared.noteFirstFrame()
         cancelStartupWatchdog()
     }
 
@@ -230,6 +238,9 @@ extension KSPlayerEngineView {
     /// first frame (`markPlaybackStarted`) disarms it.
     func startStartupWatchdog() {
         startupWatchdog?.cancel()
+        // Every startup attempt goes through here — open, channel swap, retry —
+        // which makes it the one place join time can be started from.
+        PlaybackQoE.shared.beginStartup(engine: .ksPlayer, isLive: media.isLive)
         // With a fallback engine available, wait only the shorter fallback
         // timeout before declaring the stream dead, so a silently-hanging engine
         // hands off to the next one promptly instead of stalling on a black
@@ -259,6 +270,9 @@ extension KSPlayerEngineView {
         guard !loadFailed else { return }
         cancelStartupWatchdog()
         reconnector.cancel()
+        if !hasStartedPlayback {
+            PlaybackQoE.shared.noteStartupFailure()
+        }
         if !hasStartedPlayback, reportsStartupFailure {
             onPlaybackFailed?()
             return

--- a/Lume/Views/Player/KSPlayerEngineView.swift
+++ b/Lume/Views/Player/KSPlayerEngineView.swift
@@ -270,6 +270,7 @@ struct KSPlayerEngineView: View {
                 reconnector.cancel()
                 cancelStartupWatchdog()
                 cancelStallWatchdog()
+                PlaybackQoE.shared.endSession()
                 coordinator.resetPlayer()
             }
             .onChange(of: engine.isPlaying) { _, _ in
@@ -454,6 +455,7 @@ struct KSPlayerEngineView: View {
                 reconnector.cancel()
                 cancelStartupWatchdog()
                 cancelStallWatchdog()
+                PlaybackQoE.shared.endSession()
                 coordinator.resetPlayer()
             }
             .onTapGesture {

--- a/Lume/Views/Player/LumeEngineCoordinator.swift
+++ b/Lume/Views/Player/LumeEngineCoordinator.swift
@@ -96,6 +96,9 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
         tearDown()
         currentMedia = media
         reportedFailure = false
+        // After `tearDown` (which closes any previous session) so a reload counts
+        // as its own startup attempt rather than extending the last one.
+        PlaybackQoE.shared.beginStartup(engine: .lumeEngine, isLive: media.isLive)
 
         let session = PlayerSession(configuration: makeConfiguration(for: media))
         self.session = session
@@ -175,6 +178,7 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
     }
 
     func tearDown() {
+        PlaybackQoE.shared.endSession()
         eventTask?.cancel()
         tickTask?.cancel()
         startupTask?.cancel()
@@ -288,8 +292,14 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
             Logger.player.info("LumeEngine state → \(String(describing: state), privacy: .public)")
             isPlaying = state == .playing
             isBuffering = state == .buffering || state == .opening
+            if isBuffering {
+                PlaybackQoE.shared.noteStallBegan()
+            } else {
+                PlaybackQoE.shared.noteStallEnded()
+            }
             if state == .playing {
                 hasStartedPlayback = true
+                PlaybackQoE.shared.noteFirstFrame()
                 onRecovered?()
             }
             if state == .failed {
@@ -382,6 +392,9 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
     private func reportFailure() {
         guard !reportedFailure else { return }
         reportedFailure = true
+        if !hasStartedPlayback {
+            PlaybackQoE.shared.noteStartupFailure()
+        }
         onPlaybackFailure?()
     }
 

--- a/Lume/Views/Player/VLCPlayerCoordinator+Diagnostics.swift
+++ b/Lume/Views/Player/VLCPlayerCoordinator+Diagnostics.swift
@@ -11,6 +11,31 @@ import OSLog
 import VLCKit
 
 extension VLCPlayerCoordinator {
+    // MARK: - State logging
+
+    /// Log player state transitions. Buffering is no longer a discrete state in
+    /// VLCKit 4 — its duration is measured separately in
+    /// ``mediaPlayerBufferingChanged(_:)``, which also feeds `PlaybackQoE`.
+    ///
+    /// Lives here rather than beside its caller purely for file size; it is
+    /// called from `mediaPlayerStateChanged(_:)` on the main queue.
+    func logStateChange() {
+        let state = mediaPlayer.state
+        let name = VLCMediaPlayerStateToString(state)
+        guard name != lastStateName else { return }
+        lastStateName = name
+
+        Logger.player.log("state → \(name, privacy: .public)")
+
+        // Re-assert deinterlace once a vout exists: the runtime setting doesn't
+        // survive the output being (re)created, e.g. across a stream reload.
+        if state == .playing { applyDeinterlace() }
+
+        if state == .error {
+            Logger.player.error("player entered error state")
+        }
+    }
+
     // MARK: - Diagnostics
 
     private static var didInstallLogBridge = false

--- a/Lume/Views/Player/VLCPlayerCoordinator.swift
+++ b/Lume/Views/Player/VLCPlayerCoordinator.swift
@@ -81,7 +81,9 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
 
     var statsTimer: Timer?
     var lastStats: VLCMedia.Stats?
-    private var lastStateName: String?
+    /// Internal so `logStateChange()` can live in the +Diagnostics file, which
+    /// exists to keep this one under the project's 600-line cap.
+    var lastStateName: String?
     private var bufferingStartedAt: Date?
 
     /// Drives bounded backoff reconnects when the stream drops (see
@@ -135,6 +137,7 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
         retry.reset()
         hasStartedPlayback = false
         didReportFailure = false
+        PlaybackQoE.shared.beginStartup(engine: .vlcKit, isLive: media.isLive)
         startStartupWatchdog()
         mediaPlayer.delegate = self
 
@@ -172,7 +175,8 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
         if let synchro = options.clockSynchro { media.addOption(":clock-synchro=\(synchro)") }
     }
 
-    private func applyDeinterlace() {
+    /// Internal so `logStateChange()` (in +Diagnostics) can re-assert it.
+    func applyDeinterlace() {
         if options.deinterlace {
             mediaPlayer.setDeinterlace(.on, withFilter: options.deinterlaceMode)
         } else {
@@ -196,6 +200,7 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
         retry.reset()
         hasStartedPlayback = false
         didReportFailure = false
+        PlaybackQoE.shared.beginStartup(engine: .vlcKit, isLive: media.isLive)
         startStartupWatchdog()
 
         let vlcMedia = VLCMedia(url: media.url)
@@ -223,6 +228,7 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
             if state == .playing {
                 retry.reset()
                 hasStartedPlayback = true
+                PlaybackQoE.shared.noteFirstFrame()
                 cancelStartupWatchdog()
             }
         case .error:
@@ -270,6 +276,9 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
     private func reportFailure() {
         guard !didReportFailure else { return }
         didReportFailure = true
+        if !hasStartedPlayback {
+            PlaybackQoE.shared.noteStartupFailure()
+        }
         cancelStartupWatchdog()
         retry.cancel()
         Logger.player.error("playback failure reported")
@@ -373,6 +382,7 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
         stopStatsLogging()
         retry.cancel()
         cancelStartupWatchdog()
+        PlaybackQoE.shared.endSession()
         Logger.player.log("tearDown")
         mediaPlayer.delegate = nil
         if mediaPlayer.isPlaying { mediaPlayer.stop() }
@@ -466,26 +476,6 @@ extension VLCPlayerCoordinator: VLCMediaPlayerDelegate {
         }
     }
 
-    /// Log player state transitions. Buffering is no longer a discrete state in
-    /// VLCKit 4 — its duration is measured separately in
-    /// ``mediaPlayerBufferingChanged(_:)``.
-    private func logStateChange() {
-        let state = mediaPlayer.state
-        let name = VLCMediaPlayerStateToString(state)
-        guard name != lastStateName else { return }
-        lastStateName = name
-
-        Logger.player.log("state → \(name, privacy: .public)")
-
-        // Re-assert deinterlace once a vout exists: the runtime setting doesn't
-        // survive the output being (re)created, e.g. across a stream reload.
-        if state == .playing { applyDeinterlace() }
-
-        if state == .error {
-            Logger.player.error("player entered error state")
-        }
-    }
-
     /// Measure how long each buffering episode lasts — frequent or long
     /// rebuffers are the clearest fingerprint of a struggling live stream.
     /// VLCKit 4 reports buffering as a progress signal rather than a state:
@@ -494,12 +484,16 @@ extension VLCPlayerCoordinator: VLCMediaPlayerDelegate {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             if progress >= 1.0 {
+                PlaybackQoE.shared.noteStallEnded()
                 if let started = bufferingStartedAt {
                     let elapsed = Date().timeIntervalSince(started)
                     bufferingStartedAt = nil
                     Logger.player.log("buffering complete (rebuffered \(elapsed, format: .fixed(precision: 2), privacy: .public)s)")
                 }
             } else if bufferingStartedAt == nil {
+                // Mid-stream only; `PlaybackQoE` ignores stalls before the first
+                // frame, which are join time rather than rebuffering.
+                PlaybackQoE.shared.noteStallBegan()
                 bufferingStartedAt = Date()
                 Logger.player.log("buffering started")
             }

--- a/LumePerformanceTests/EPGQueryBenchmarks.swift
+++ b/LumePerformanceTests/EPGQueryBenchmarks.swift
@@ -1,0 +1,130 @@
+//
+//  EPGQueryBenchmarks.swift
+//  LumePerformanceTests
+//
+//  The two off-main EPG fetches that back every channel list and the guide grid.
+//  Both exist because the view-context `@Query` versions of them froze the app:
+//  hundreds of per-cell observers each scanning the guide table, all re-firing on
+//  every sync write. The fetches are now scoped, indexed and off-main — and these
+//  benchmarks are what keep them that way.
+//
+//  Each test seeds a realistic guide once (outside the measured region) and then
+//  measures only the fetch, since seeding costs far more than the query.
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import XCTest
+
+final class EPGQueryBenchmarks: XCTestCase {
+    private var store: (container: ModelContainer, directory: URL)!
+
+    /// 400 channels × 96 half-hour slots ≈ two days of guide for a mid-size
+    /// playlist.
+    private let channelCount = 400
+    private let slotsPerChannel = 96
+    private let epoch = Date(timeIntervalSince1970: 1_800_000_000)
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        store = try PerfStore.makeOnDiskContainer()
+        seedGuide()
+    }
+
+    override func tearDownWithError() throws {
+        if let store {
+            PerfStore.destroy(directory: store.directory)
+        }
+        store = nil
+        try super.tearDownWithError()
+    }
+
+    /// Now/next for every channel in a large category — the fetch a channel list
+    /// runs once per load.
+    func testChannelEPGLoadFor400Channels() {
+        let channelIds = (0 ..< channelCount).map { "ch\($0)" }
+        // Mid-guide, so the `end > now` bound has to discard roughly half the rows.
+        let now = epoch.addingTimeInterval(Double(slotsPerChannel) * 1800 / 2)
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            let result = ChannelEPGLoader.load(
+                container: store.container, channelIds: channelIds, now: now
+            )
+            XCTAssertEqual(result.count, channelCount)
+        }
+    }
+
+    /// Now/next for one screenful of channels — the common case, and the one that
+    /// must stay fast enough to run on every scroll-driven reload.
+    func testChannelEPGLoadForVisibleWindow() {
+        let channelIds = (0 ..< 30).map { "ch\($0)" }
+        let now = epoch.addingTimeInterval(Double(slotsPerChannel) * 1800 / 2)
+
+        measure(metrics: [XCTClockMetric()]) {
+            let result = ChannelEPGLoader.load(
+                container: store.container, channelIds: channelIds, now: now
+            )
+            XCTAssertEqual(result.count, 30)
+        }
+    }
+
+    /// The guide grid's window fetch: every listing (not just now/next) for the
+    /// channels on screen, over a 3-hour window.
+    func testGuideWindowLoadForVisibleChannels() {
+        let channelIds = (0 ..< 30).map { "ch\($0)" }
+        let windowStart = epoch.addingTimeInterval(3600)
+        let windowEnd = windowStart.addingTimeInterval(3 * 3600)
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            let result = EPGGuideLoader.load(
+                container: store.container,
+                channelIds: channelIds,
+                windowStart: windowStart,
+                windowEnd: windowEnd
+            )
+            XCTAssertEqual(result.count, 30)
+        }
+    }
+
+    /// The pathological case the old `@Query` hit on every guide open: the whole
+    /// channel set over a wide window. Kept as a benchmark because it is what an
+    /// unscoped regression would silently degrade into.
+    func testGuideWindowLoadForAllChannels() {
+        let channelIds = (0 ..< channelCount).map { "ch\($0)" }
+        let windowEnd = epoch.addingTimeInterval(Double(slotsPerChannel) * 1800)
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            let result = EPGGuideLoader.load(
+                container: store.container,
+                channelIds: channelIds,
+                windowStart: epoch,
+                windowEnd: windowEnd
+            )
+            XCTAssertEqual(result.count, channelCount)
+        }
+    }
+
+    // MARK: - Seeding
+
+    private func seedGuide() {
+        let context = ModelContext(store.container)
+        context.autosaveEnabled = false
+        for channel in 0 ..< channelCount {
+            autoreleasepool {
+                for slot in 0 ..< slotsPerChannel {
+                    let start = epoch.addingTimeInterval(Double(slot) * 1800)
+                    context.insert(EPGListing(
+                        id: "ch\(channel)-\(Int(start.timeIntervalSince1970))",
+                        channelId: "ch\(channel)",
+                        title: "Programme \(channel)-\(slot)",
+                        listingDescription: "A synthetic description for slot \(slot).",
+                        start: start,
+                        end: start.addingTimeInterval(1800)
+                    ))
+                }
+            }
+        }
+        try? context.save()
+    }
+}

--- a/LumePerformanceTests/ParsingBenchmarks.swift
+++ b/LumePerformanceTests/ParsingBenchmarks.swift
@@ -1,0 +1,191 @@
+//
+//  ParsingBenchmarks.swift
+//  LumePerformanceTests
+//
+//  Tier A: pure-CPU benchmarks over the three hot parse paths — the m3u playlist
+//  parser, the XMLTV SAX parser, and Xtream DTO decoding. No network, no store,
+//  no UI, so the numbers are stable enough to compare against a baseline on the
+//  same machine.
+//
+//  These are the benchmarks that would have caught the `XMLTVDate` regression
+//  (a `DateFormatter` per programme, 44.8% of a post-sync freeze) the day it
+//  landed rather than after a user complained.
+//
+//  Sizes are a compromise: large enough that per-entry cost dominates fixture
+//  generation, small enough that the suite finishes in a couple of minutes.
+//  Bump `entryCount` locally when hunting a specific regression.
+//
+
+import Foundation
+@testable import Lume
+import XCTest
+
+final class ParsingBenchmarks: XCTestCase {
+    private var scratch: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        scratch = try PerfFixtures.makeScratchDirectory()
+    }
+
+    override func tearDownWithError() throws {
+        if let scratch {
+            try? FileManager.default.removeItem(at: scratch)
+        }
+        scratch = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - m3u
+
+    /// Streaming parse of a 120k-entry playlist. Measures wall clock and peak
+    /// memory together: the parser's contract is *flat* memory regardless of
+    /// playlist size, so a regression that buffers the file would show up as a
+    /// memory failure even if it parsed faster.
+    func testM3UParse120kEntries() throws {
+        let fixture = try PerfFixtures.writeM3U(entryCount: 120_000, to: scratch)
+        assertFixtureIsSubstantial(fixture, minimumBytes: 5_000_000)
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            var count = 0
+            var urlBytes = 0
+            do {
+                count = try M3UParser.parse(fileURL: fixture, batchSize: 2000) { batch in
+                    // Touch every entry so the optimizer can't discard the parse.
+                    for entry in batch {
+                        urlBytes += entry.url.utf8.count
+                    }
+                }
+            } catch {
+                XCTFail("m3u parse threw: \(error)")
+            }
+            XCTAssertEqual(count, 120_000)
+            XCTAssertGreaterThan(urlBytes, 0)
+        }
+    }
+
+    /// `#EXTINF` attribute scanning in isolation. It runs once per playlist line,
+    /// so a constant-factor regression here multiplies by hundreds of thousands.
+    func testM3UExtInfAttributeScan() {
+        let line = "#EXTINF:-1 tvg-id=\"ch4711\" tvg-name=\"Channel 4711\" "
+            + "tvg-logo=\"https://example.invalid/logo/4711.png\" "
+            + "group-title=\"Sports, News & More\" type=\"video\",Channel 4711 HD, Extra"
+
+        // Assertion outside the loop: per-iteration XCTAsserts would dominate.
+        measure(metrics: [XCTClockMetric()]) {
+            var matches = 0
+            for _ in 0 ..< 20000 where M3UParser.parseExtInf(line).tvgId == "ch4711" {
+                matches += 1
+            }
+            XCTAssertEqual(matches, 20000)
+        }
+    }
+
+    /// Classification is the other per-entry cost of an m3u import — it decides
+    /// live vs movie vs episode for every single line.
+    func testM3UClassification() {
+        let names = [
+            "Channel 12 HD",
+            "Movie Title 2019 (2019)",
+            "Show Name S03E11",
+            "Some Show 1x04 Pilot"
+        ]
+        let entries = (0 ..< 4000).map { index in
+            M3UEntry(
+                name: names[index % names.count],
+                url: "https://example.invalid/stream/\(index).ts",
+                tvgId: index.isMultiple(of: 2) ? "ch\(index)" : nil,
+                logo: nil,
+                group: "Group \(index % 100)",
+                type: nil
+            )
+        }
+
+        measure(metrics: [XCTClockMetric()]) {
+            for entry in entries {
+                _ = M3UClassifier.classify(entry)
+            }
+        }
+    }
+
+    // MARK: - XMLTV
+
+    /// Streaming SAX parse of a ~120k-programme guide (400 channels × 300 slots).
+    /// This is the phase that froze the app for ~9s after a sync.
+    func testXMLTVParse120kProgrammes() throws {
+        let fixture = try PerfFixtures.writeXMLTV(
+            channelCount: 400, programmesPerChannel: 300, to: scratch
+        )
+        assertFixtureIsSubstantial(fixture, minimumBytes: 10_000_000)
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            var total = 0
+            _ = XMLTVParser.parse(fileURL: fixture, batchSize: 2000) { batch in
+                total += batch.count
+            }
+            XCTAssertEqual(total, 120_000)
+        }
+    }
+
+    /// XMLTV timestamp parsing on its own. Called twice per programme, so it is
+    /// the single most-executed function in a guide refresh — and was once 45%
+    /// of it (a `DateFormatter` per call, before the hand-rolled fast path).
+    ///
+    /// Only canonical `YYYYMMDDHHMMSS ±HHMM` stamps here: that is the shape the
+    /// fast path serves, and >99% of real guide data. The assertion is outside
+    /// the loop on purpose — 500k `XCTAssert` calls cost far more than the code
+    /// being measured and would swamp the number.
+    func testXMLTVDateFastPathParsing() {
+        let stamps = [
+            "20260730120000 +0000",
+            "20260730123000 +0200",
+            "20260730133000 -0500"
+        ]
+
+        measure(metrics: [XCTClockMetric()]) {
+            var checksum = 0.0
+            for index in 0 ..< 100_000 {
+                checksum += XMLTVDate.parse(stamps[index % stamps.count])?.timeIntervalSince1970 ?? 0
+            }
+            XCTAssertGreaterThan(checksum, 0, "every canonical stamp should parse")
+        }
+    }
+
+    /// The fallback path: a stamp with no UTC offset. `XMLTVDate` rejects it in
+    /// the fast path and `DateFormatter` (`yyyyMMddHHmmss Z`) can't parse it
+    /// either, so the result is nil — but the ICU attempt still costs, and a
+    /// provider that omits offsets pays it twice per programme.
+    ///
+    /// Fewer iterations because this path is orders of magnitude slower. If this
+    /// number ever matters in the field, the fix is to widen `XMLTVDate`, not to
+    /// speed up ICU.
+    func testXMLTVDateFallbackParsing() {
+        measure(metrics: [XCTClockMetric()]) {
+            var nilCount = 0
+            for index in 0 ..< 2000
+                where XMLTVDate.parse("2026073013\(String(format: "%04d", index % 6000))") == nil
+            {
+                nilCount += 1
+            }
+            XCTAssertEqual(nilCount, 2000, "offset-less stamps are expected to fail to parse")
+        }
+    }
+
+    // MARK: - Xtream DTO decoding
+
+    /// Decoding a 50k-movie `get_vod_streams` payload. Xtream syncs decode the
+    /// whole catalog in one shot, so this is on the critical path of every sync.
+    func testXtreamVODStreamDecoding() throws {
+        let payload = try PerfFixtures.xtreamVODStreamsJSON(count: 50000)
+        XCTAssertGreaterThan(payload.count, 5_000_000)
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            do {
+                let decoded = try JSONDecoder().decode(XtreamList<XtreamVODStream>.self, from: payload)
+                XCTAssertEqual(decoded.items.count, 50000)
+            } catch {
+                XCTFail("Xtream VOD decode threw: \(error)")
+            }
+        }
+    }
+}

--- a/LumePerformanceTests/PerfSupport.swift
+++ b/LumePerformanceTests/PerfSupport.swift
@@ -1,0 +1,209 @@
+//
+//  PerfSupport.swift
+//  LumePerformanceTests
+//
+//  Shared scaffolding for the benchmarks: an on-disk store factory and the
+//  fixture generators.
+//
+//  Two deliberate choices here, both learned the hard way:
+//
+//  * **On-disk stores, not in-memory.** An in-memory `ModelContainer` skips
+//    SQLite entirely, so it understates import cost by an order of magnitude and
+//    hides SQL-generation behaviour outright. Import is the phase users wait on,
+//    so it has to be measured against a real store file.
+//  * **Generators, not checked-in fixtures.** A 600k-entry playlist is ~60 MB;
+//    the repo carries the ~60-line generator instead, exactly as `ExampleData`
+//    stays out of git. Generated content is deterministic (a fixed-seed LCG), so
+//    a benchmark's input never changes underneath its baseline.
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import XCTest
+
+// MARK: - Deterministic pseudo-randomness
+
+/// A fixed-seed linear congruential generator. `SystemRandomNumberGenerator`
+/// would make every run's fixture different, which is indistinguishable from a
+/// performance regression when comparing against a baseline.
+struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64 = 0x5EED_1234_ABCD_0001) {
+        state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+        return state
+    }
+}
+
+// MARK: - Store factory
+
+enum PerfStore {
+    /// The catalog schema, matching `LumeApp.makeModelContainers`.
+    static var catalogSchema: Schema {
+        Schema([
+            Playlist.self,
+            Lume.Category.self,
+            LiveStream.self,
+            Movie.self,
+            Series.self,
+            Episode.self,
+            CastMember.self,
+            EPGListing.self,
+            EPGSource.self
+        ])
+    }
+
+    /// A fresh on-disk container in a unique temp directory.
+    ///
+    /// `cloudKitDatabase: .none` is mandatory — the catalog's
+    /// `@Attribute(.unique)` models crash container load when CloudKit mirroring
+    /// is left at `.automatic` on an entitled host.
+    static func makeOnDiskContainer() throws -> (container: ModelContainer, directory: URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LumePerf-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let configuration = ModelConfiguration(
+            schema: catalogSchema,
+            url: directory.appendingPathComponent("perf.store"),
+            cloudKitDatabase: .none
+        )
+        let container = try ModelContainer(for: catalogSchema, configurations: configuration)
+        return (container, directory)
+    }
+
+    static func destroy(directory: URL) {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}
+
+// MARK: - Fixture generators
+
+enum PerfFixtures {
+    /// Scratch space for generated fixtures, cleaned up by the test that made it.
+    static func makeScratchDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LumeFixtures-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    /// Writes an extended-m3u playlist with `entryCount` entries, mixing live
+    /// channels, movies and episode-shaped names in roughly the proportions a
+    /// provider export has — so `M3UClassifier` does representative work.
+    @discardableResult
+    static func writeM3U(entryCount: Int, to directory: URL) throws -> URL {
+        var generator = SeededGenerator()
+        let url = directory.appendingPathComponent("playlist.m3u")
+        var text = "#EXTM3U url-tvg=\"https://example.invalid/guide.xml.gz\"\n"
+        text.reserveCapacity(entryCount * 180)
+
+        for index in 0 ..< entryCount {
+            let bucket = Int.random(in: 0 ..< 100, using: &generator)
+            let group = "Group \(index % 400)"
+            if bucket < 45 {
+                text += "#EXTINF:-1 tvg-id=\"ch\(index)\" tvg-name=\"Channel \(index)\" "
+                text += "tvg-logo=\"https://example.invalid/logo/\(index).png\" group-title=\"\(group)\","
+                text += "Channel \(index) HD\n"
+                text += "https://example.invalid/live/user/pass/\(index).ts\n"
+            } else if bucket < 80 {
+                text += "#EXTINF:-1 tvg-id=\"\" tvg-logo=\"https://example.invalid/poster/\(index).jpg\" "
+                text += "group-title=\"VOD \(group)\",Movie Title \(index) (20\(10 + index % 15))\n"
+                text += "https://example.invalid/movie/user/pass/\(index).mkv\n"
+            } else {
+                let season = 1 + index % 6
+                let episode = 1 + index % 24
+                text += "#EXTINF:-1 group-title=\"Series \(group)\","
+                text += "Show \(index % 900) S\(String(format: "%02d", season))E\(String(format: "%02d", episode))\n"
+                text += "https://example.invalid/series/user/pass/\(index).mp4\n"
+            }
+        }
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    /// Writes an XMLTV guide with `channelCount` channels × `programmesPerChannel`
+    /// programmes. Timestamps use the `+0000` offset form, which is the shape
+    /// `XMLTVDate` has to parse fastest.
+    @discardableResult
+    static func writeXMLTV(
+        channelCount: Int,
+        programmesPerChannel: Int,
+        to directory: URL
+    ) throws -> URL {
+        let url = directory.appendingPathComponent("guide.xml")
+        var text = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tv>\n"
+        text.reserveCapacity(channelCount * programmesPerChannel * 220)
+
+        for channel in 0 ..< channelCount {
+            text += "<channel id=\"ch\(channel)\"><display-name>Channel \(channel)</display-name></channel>\n"
+        }
+
+        // Fixed epoch (not `Date()`) so the generated guide is byte-identical run
+        // to run — a moving window would change parse and query costs.
+        let epoch = Date(timeIntervalSince1970: 1_800_000_000)
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyyMMddHHmmss"
+
+        for channel in 0 ..< channelCount {
+            for slot in 0 ..< programmesPerChannel {
+                let start = epoch.addingTimeInterval(Double(slot) * 1800)
+                let end = start.addingTimeInterval(1800)
+                let startStamp = formatter.string(from: start)
+                let endStamp = formatter.string(from: end)
+                text += "<programme start=\"\(startStamp) +0000\" stop=\"\(endStamp) +0000\" channel=\"ch\(channel)\">"
+                text += "<title>Programme \(channel)-\(slot)</title>"
+                text += "<desc>A synthetic description for programme \(slot) on channel \(channel).</desc>"
+                text += "</programme>\n"
+            }
+        }
+        text += "</tv>\n"
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    /// An Xtream `get_vod_streams` response body with `count` movies, as `Data`
+    /// ready for `JSONDecoder`. Fields mirror what panels actually send,
+    /// including the string/number ambiguity the DTOs have to absorb.
+    static func xtreamVODStreamsJSON(count: Int) throws -> Data {
+        var generator = SeededGenerator()
+        var items: [String] = []
+        items.reserveCapacity(count)
+        for index in 0 ..< count {
+            // Half the panels send numbers as strings; alternate so the decoder's
+            // lenient paths are exercised too.
+            let rating = index.isMultiple(of: 2) ? "\"7.\(index % 10)\"" : "7.\(index % 10)"
+            let added = 1_700_000_000 + index
+            items.append("""
+            {"num":\(index),"name":"Movie \(index)","stream_type":"movie",\
+            "stream_id":\(100_000 + index),"stream_icon":"https://example.invalid/p/\(index).jpg",\
+            "rating":\(rating),"rating_5based":\(Int.random(in: 0 ... 5, using: &generator)),\
+            "added":"\(added)","category_id":"\(index % 300)","container_extension":"mkv",\
+            "custom_sid":null,"direct_source":""}
+            """)
+        }
+        return Data("[\(items.joined(separator: ","))]".utf8)
+    }
+}
+
+// MARK: - Assertions
+
+extension XCTestCase {
+    /// Fails when a generated fixture is unexpectedly small — a silently broken
+    /// generator would otherwise look like a spectacular speed-up.
+    func assertFixtureIsSubstantial(_ url: URL, minimumBytes: Int, file: StaticString = #filePath, line: UInt = #line) {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        let size = (attributes?[.size] as? Int) ?? 0
+        XCTAssertGreaterThan(
+            size, minimumBytes,
+            "fixture at \(url.lastPathComponent) is only \(size) bytes — the generator is probably broken",
+            file: file, line: line
+        )
+    }
+}

--- a/LumePerformanceTests/PersistenceBenchmarks.swift
+++ b/LumePerformanceTests/PersistenceBenchmarks.swift
@@ -1,0 +1,151 @@
+//
+//  PersistenceBenchmarks.swift
+//  LumePerformanceTests
+//
+//  Tier A, store edition: the SwiftData writes users actually wait on.
+//
+//  Profiling a 600k-entry playlist showed the import — not the download — owning
+//  the multi-minute wait, and that a no-change re-sync costs nearly as much as a
+//  first one (because the upsert lookup runs regardless). Both properties are
+//  pinned here.
+//
+//  These run against an **on-disk** container. An in-memory store bypasses
+//  SQLite, which is precisely the cost being measured.
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import XCTest
+
+final class PersistenceBenchmarks: XCTestCase {
+    /// Matches `ContentSyncManager.batchSize`; the whole point is to reproduce
+    /// the sync's write shape, so it must track that constant.
+    private let batchSize = 2000
+
+    // MARK: - Insert
+
+    /// Cold insert of 20k movies through the sync's context-per-batch pattern.
+    /// Measures wall clock *and* storage: a regression that stops resetting the
+    /// context per batch shows up as memory, one that writes more per row shows
+    /// up as bytes.
+    func testInsert20kMoviesOnDisk() {
+        measureStoreWork(metrics: [XCTClockMetric(), XCTMemoryMetric()]) { container in
+            let playlistId = UUID()
+            insertMovies(count: 20000, playlistId: playlistId, container: container)
+        }
+    }
+
+    /// Re-importing an unchanged catalog. Users hit this on every scheduled sync,
+    /// and it was measured at nearly the cost of a first import — so it gets its
+    /// own baseline rather than being assumed cheap.
+    func testReimport20kUnchangedMovies() throws {
+        let store = try PerfStore.makeOnDiskContainer()
+        defer { PerfStore.destroy(directory: store.directory) }
+        let playlistId = UUID()
+        // Seed outside the measured block: we are timing the *second* pass.
+        insertMovies(count: 20000, playlistId: playlistId, container: store.container)
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            insertMovies(count: 20000, playlistId: playlistId, container: store.container)
+        }
+    }
+
+    /// The guide-ingest write path: `EPGSyncManager` accumulates listings on one
+    /// context and saves every 10k to limit main-context merges. 60k listings is
+    /// a modest real guide.
+    func testInsert60kEPGListings() {
+        measureStoreWork(metrics: [XCTClockMetric(), XCTMemoryMetric()]) { container in
+            let context = ModelContext(container)
+            context.autosaveEnabled = false
+            let epoch = Date(timeIntervalSince1970: 1_800_000_000)
+            var pending = 0
+            for index in 0 ..< 60000 {
+                let start = epoch.addingTimeInterval(Double(index % 300) * 1800)
+                context.insert(EPGListing(
+                    id: "ch\(index / 300)-\(Int(start.timeIntervalSince1970))-\(index)",
+                    channelId: "ch\(index / 300)",
+                    title: "Programme \(index)",
+                    listingDescription: "A synthetic description for programme \(index).",
+                    start: start,
+                    end: start.addingTimeInterval(1800)
+                ))
+                pending += 1
+                // Mirrors EPGSyncManager.saveThreshold.
+                if pending >= 10000 {
+                    try? context.save()
+                    pending = 0
+                }
+            }
+            if pending > 0 {
+                try? context.save()
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Runs `work` against a freshly created on-disk store on every iteration, so
+    /// each pass starts from an empty database and the numbers are comparable.
+    /// Store setup/teardown sit outside the measured region.
+    private func measureStoreWork(
+        metrics: [XCTMetric],
+        _ work: (ModelContainer) -> Void
+    ) {
+        // Manual start/stop is what keeps store creation and deletion — tens of
+        // milliseconds of file I/O each — out of the numbers.
+        let options = XCTMeasureOptions()
+        options.invocationOptions = [.manuallyStart, .manuallyStop]
+        measure(metrics: metrics, options: options) {
+            guard let store = try? PerfStore.makeOnDiskContainer() else {
+                XCTFail("could not create the on-disk store")
+                return
+            }
+            startMeasuring()
+            work(store.container)
+            stopMeasuring()
+            PerfStore.destroy(directory: store.directory)
+        }
+    }
+
+    /// The upsert loop `ContentSyncManager.syncMovies` runs: one fresh,
+    /// autosave-off context per batch, an id-scoped fetch for existing rows, then
+    /// insert-or-update and save.
+    private func insertMovies(count: Int, playlistId: UUID, container: ModelContainer) {
+        for batchStart in stride(from: 0, to: count, by: batchSize) {
+            autoreleasepool {
+                let batchEnd = min(batchStart + batchSize, count)
+                let context = ModelContext(container)
+                context.autosaveEnabled = false
+
+                let ids = (batchStart ..< batchEnd).map { "\(playlistId.uuidString)-movie-\($0)" }
+                var existing: [String: Movie] = [:]
+                existing.reserveCapacity(ids.count)
+                let fetched = (try? context.fetch(
+                    FetchDescriptor<Movie>(predicate: #Predicate { ids.contains($0.id) })
+                )) ?? []
+                for movie in fetched {
+                    existing[movie.id] = movie
+                }
+
+                for index in batchStart ..< batchEnd {
+                    let id = "\(playlistId.uuidString)-movie-\(index)"
+                    let movie: Movie
+                    if let found = existing[id] {
+                        movie = found
+                    } else {
+                        movie = Movie(id: id, streamId: index, name: "")
+                        context.insert(movie)
+                    }
+                    movie.name = "Movie \(index)"
+                    movie.streamIcon = "https://example.invalid/p/\(index).jpg"
+                    movie.rating = Double(index % 10)
+                    movie.added = "\(1_700_000_000 + index)"
+                    movie.containerExtension = "mkv"
+                    movie.categoryId = "\(playlistId.uuidString)-vod-\(index % 300)"
+                }
+                try? context.save()
+            }
+        }
+    }
+}

--- a/LumePerformanceTests/README.md
+++ b/LumePerformanceTests/README.md
@@ -1,0 +1,115 @@
+# LumePerformanceTests
+
+Lume's dedicated performance suite. Separate target, separate scheme, separate
+build configuration — so it never slows a normal `xcodebuild test`, and so the
+numbers mean something.
+
+```bash
+Scripts/run-performance-tests.sh                                  # whole suite
+Scripts/run-performance-tests.sh ParsingBenchmarks                # one suite
+Scripts/run-performance-tests.sh ParsingBenchmarks/testXMLTVDateParsing
+```
+
+## Why a separate configuration
+
+The suite builds under **Benchmark** = Release settings + `ENABLE_TESTABILITY`
+(+ explicit `-O`). This matters more than anything else here: Debug is `-Onone`,
+which makes the parsers several times slower than shipped code and turns every
+measurement into fiction. `ENABLE_TESTABILITY` is what still allows
+`@testable import Lume` against an optimized build.
+
+`Benchmark` was added rather than reusing Release because enabling testability on
+Release would change what ships. Debug, Release and Sideload are untouched.
+
+## The four layers
+
+| Layer | Where | What it catches |
+|---|---|---|
+| Microbenchmarks | `ParsingBenchmarks`, `PersistenceBenchmarks`, `EPGQueryBenchmarks` | Parser / import / query regressions |
+| Signpost metrics | `SignpostBenchmarks` | A named production phase getting slower |
+| Field telemetry | `AppPerformanceMetrics` (MetricKit) in the app | What users actually experience |
+| Player QoE | `PlaybackQoE` in the app | Join time, rebuffering, startup failures |
+
+The last two are not tests — they run in the shipping app and surface in the
+diagnostic report the user can export (Settings → Diagnostics). They are listed
+here because they are the same measurement programme: the tests tell you whether
+a phase regressed on your machine, MetricKit and QoE tell you whether it matters
+in the field.
+
+## Signposts are the load-bearing part
+
+`Lume/Services/Diagnostics/PerformanceSignposts.swift` names every phase we have
+ever had to profile by hand. One `Perf.begin`/`Perf.end` pair buys three things:
+
+1. A Points of Interest lane in Instruments (phase boundaries, not just stacks).
+2. `XCTOSSignpostMetric` measurements of *production* code, by name.
+3. `os_log`-based timing in the field, via the debug log exporter.
+
+The names in `PerfSignpost` are a contract with `SignpostBenchmarks` — rename one
+and its benchmark fails with "no samples" rather than silently measuring nothing.
+`testSignpostNamesAreUnique` guards against two phases colliding on one name.
+
+## Fixtures are generated, never committed
+
+`PerfSupport.swift` writes the m3u playlists, XMLTV guides and Xtream JSON each
+run, from a fixed-seed LCG. A 600k-entry playlist is ~60 MB; the repo carries the
+generator instead (same reasoning as the gitignored `ExampleData/`). Fixed seed
+matters: a fixture that changed between runs would be indistinguishable from a
+regression.
+
+Sizes are a compromise between representativeness and a suite that finishes in a
+few minutes. When chasing a specific regression, raise `entryCount` locally —
+don't commit the raise, or every future baseline shifts.
+
+## Stores are on disk, not in memory
+
+`PerfStore.makeOnDiskContainer()` creates a real store file per iteration. An
+in-memory `ModelContainer` skips SQLite entirely, so it understates import cost
+by roughly an order of magnitude — and import is the phase users wait minutes on.
+(It also hides SQL-generation behaviour outright; a predicate crash we once
+shipped only reproduced on-disk.)
+
+Every configuration sets `cloudKitDatabase: .none`, without exception: the
+catalog's `@Attribute(.unique)` models crash container load when CloudKit
+mirroring is left at `.automatic` on an entitled host.
+
+## Baselines
+
+Xcode stores accepted baselines in
+`Lume.xcodeproj/xcshareddata/xcbaselines/…` keyed by **device model and
+configuration**. To record them:
+
+1. Open the `LumePerformance` scheme in Xcode and run the suite.
+2. In the test report, click the grey diamond next to a measurement → *Accept*.
+3. Commit the resulting `.xcbaseline`.
+
+They can't meaningfully be hand-written — the key includes a hardware hash — so
+this step is manual and per-machine by design.
+
+### What baselines are and aren't good for
+
+Only compare runs from the **same machine, same thermal state, nothing else
+building**. A laptop that just finished a full build is 20–30% slower than a cold
+one. That is why there is no CI gate wired up here: gating pull requests on
+absolute wall clock from a shared runner produces noise, not signal.
+
+Two ways to get a real gate, when it's wanted:
+
+- Pin one physical device to a self-hosted runner and compare against a baseline
+  recorded on that device.
+- Compare machine-independent counters (allocation counts, object counts) rather
+  than time.
+
+Until then, treat the suite as a *tool you run when you touch a hot path* and as
+the place a suspected regression gets confirmed or dismissed.
+
+## Deliberately not covered
+
+- **Scroll / hitch metrics.** `XCTOSSignpostMetric.scrollDecelerationMetric`
+  needs a real device to mean anything, and the worst scroll cost we have
+  (the tvOS focus engine) is tvOS-only while this target excludes tvOS by
+  deployment target. That stays a manual `xctrace` recipe.
+- **Launch time.** Already covered by `LumeUITests.testLaunchPerformance`
+  (`XCTApplicationLaunchMetric`), which belongs with the UI tests.
+- **Network.** No benchmark touches a provider. Download time is the provider's
+  variable, not ours; `M3UDownload` is a signpost so field logs still show it.

--- a/LumePerformanceTests/SignpostBenchmarks.swift
+++ b/LumePerformanceTests/SignpostBenchmarks.swift
@@ -1,0 +1,131 @@
+//
+//  SignpostBenchmarks.swift
+//  LumePerformanceTests
+//
+//  Tier B: measure the app's own named phases rather than a benchmark's
+//  reimplementation of them.
+//
+//  `XCTOSSignpostMetric` reads the `OSSignposter` intervals the app emits (see
+//  `PerformanceSignposts.swift`), so these tests time *production* code paths by
+//  name. They double as a tripwire on the instrumentation itself: rename or drop
+//  a signpost and the matching test fails with "no samples" instead of quietly
+//  measuring nothing.
+//
+//  Treat these as coarse (2× regression) checks, not 5% gates — they include
+//  whatever the phase legitimately does.
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import XCTest
+
+final class SignpostBenchmarks: XCTestCase {
+    private var store: (container: ModelContainer, directory: URL)!
+    private let channelCount = 200
+    private let slotsPerChannel = 48
+    private let epoch = Date(timeIntervalSince1970: 1_800_000_000)
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        store = try PerfStore.makeOnDiskContainer()
+        seedGuide()
+    }
+
+    override func tearDownWithError() throws {
+        if let store {
+            PerfStore.destroy(directory: store.directory)
+        }
+        store = nil
+        try super.tearDownWithError()
+    }
+
+    /// Times the `ChannelEPGLoad` interval emitted from inside
+    /// `ChannelEPGLoader.load` — production instrumentation, measured by name.
+    func testChannelEPGLoadSignpost() {
+        let channelIds = (0 ..< channelCount).map { "ch\($0)" }
+        let now = epoch.addingTimeInterval(Double(slotsPerChannel) * 1800 / 2)
+        let metric = XCTOSSignpostMetric(
+            subsystem: Perf.subsystem,
+            category: Perf.category,
+            name: PerfSignpost.channelEPGLoad.metricName
+        )
+
+        measure(metrics: [metric]) {
+            _ = ChannelEPGLoader.load(
+                container: store.container, channelIds: channelIds, now: now
+            )
+        }
+    }
+
+    /// Same for the guide grid's window fetch.
+    func testGuideWindowLoadSignpost() {
+        let channelIds = (0 ..< channelCount).map { "ch\($0)" }
+        let windowEnd = epoch.addingTimeInterval(Double(slotsPerChannel) * 1800)
+        let metric = XCTOSSignpostMetric(
+            subsystem: Perf.subsystem,
+            category: Perf.category,
+            name: PerfSignpost.guideWindowLoad.metricName
+        )
+
+        measure(metrics: [metric]) {
+            _ = EPGGuideLoader.load(
+                container: store.container,
+                channelIds: channelIds,
+                windowStart: epoch,
+                windowEnd: windowEnd
+            )
+        }
+    }
+
+    // MARK: - Instrumentation integrity
+
+    /// Two milestones sharing a name would silently merge into one metric, so a
+    /// benchmark would measure the wrong thing without ever failing. Cheap guard.
+    func testSignpostNamesAreUnique() {
+        let all: [PerfSignpost] = [
+            .playlistSync, .syncCategories, .syncMovies, .syncSeries, .syncLiveStreams,
+            .m3uDownload, .m3uImport,
+            .epgSourceSync, .epgIngest, .channelEPGLoad, .guideWindowLoad,
+            .homeTrendingLoad, .homeRecommendations,
+            .playerStartup, .playerRebuffer, .playerEngineFallback, .playerStartupFailure
+        ]
+        let names = all.map(\.metricName)
+        XCTAssertEqual(
+            Set(names).count, names.count,
+            "duplicate signpost name: \(names.sorted())"
+        )
+        for name in names {
+            XCTAssertFalse(name.isEmpty, "a signpost has an empty name")
+        }
+    }
+
+    /// The subsystem must match `Logger`'s, so one Instruments filter covers both
+    /// signposts and log messages. Both derive from the bundle id.
+    func testSignpostSubsystemMatchesBundle() {
+        XCTAssertEqual(Perf.subsystem, Bundle.main.bundleIdentifier)
+    }
+
+    // MARK: - Seeding
+
+    private func seedGuide() {
+        let context = ModelContext(store.container)
+        context.autosaveEnabled = false
+        for channel in 0 ..< channelCount {
+            autoreleasepool {
+                for slot in 0 ..< slotsPerChannel {
+                    let start = epoch.addingTimeInterval(Double(slot) * 1800)
+                    context.insert(EPGListing(
+                        id: "ch\(channel)-\(Int(start.timeIntervalSince1970))",
+                        channelId: "ch\(channel)",
+                        title: "Programme \(channel)-\(slot)",
+                        listingDescription: "Synthetic description.",
+                        start: start,
+                        end: start.addingTimeInterval(1800)
+                    ))
+                }
+            }
+        }
+        try? context.save()
+    }
+}

--- a/LumeTests/Services/PlaybackQoETests.swift
+++ b/LumeTests/Services/PlaybackQoETests.swift
@@ -1,0 +1,178 @@
+//
+//  PlaybackQoETests.swift
+//  LumeTests
+//
+//  Correctness of the QoE accounting — the counters that answer "how slow is
+//  startup for real users". Each test uses its own `UserDefaults` suite so these
+//  never race the singleton (or each other) through `UserDefaults.standard`.
+//
+
+import Foundation
+@testable import Lume
+import Testing
+
+@MainActor
+struct PlaybackQoETests {
+    /// A tracker backed by a throwaway suite.
+    private func makeTracker() -> (qoe: PlaybackQoE, suiteName: String) {
+        let suiteName = "PlaybackQoETests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        return (PlaybackQoE(defaults: defaults), suiteName)
+    }
+
+    private func tearDown(_ suiteName: String) {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+
+    @Test
+    func `a completed startup records one session and one join time`() {
+        let (qoe, suite) = makeTracker()
+        defer { tearDown(suite) }
+
+        qoe.beginStartup(engine: .ksPlayer, isLive: true)
+        qoe.noteFirstFrame()
+
+        let stats = qoe.summary.engines[PlayerEngineKind.ksPlayer.rawValue]
+        #expect(stats?.sessions == 1)
+        #expect(stats?.firstFrames == 1)
+        #expect((stats?.lastJoinTime ?? -1) >= 0)
+        #expect(stats?.exitsBeforeVideoStart == 0)
+    }
+
+    @Test
+    func `join time is recorded once even if the engine reports the first frame twice`() {
+        let (qoe, suite) = makeTracker()
+        defer { tearDown(suite) }
+
+        qoe.beginStartup(engine: .avPlayer, isLive: false)
+        qoe.noteFirstFrame()
+        qoe.noteFirstFrame()
+        qoe.noteFirstFrame()
+
+        #expect(qoe.summary.engines[PlayerEngineKind.avPlayer.rawValue]?.firstFrames == 1)
+    }
+
+    @Test
+    func `abandoning a stream before the first frame counts as an exit before video start`() {
+        let (qoe, suite) = makeTracker()
+        defer { tearDown(suite) }
+
+        qoe.beginStartup(engine: .vlcKit, isLive: true)
+        qoe.endSession()
+
+        let stats = qoe.summary.engines[PlayerEngineKind.vlcKit.rawValue]
+        #expect(stats?.exitsBeforeVideoStart == 1)
+        #expect(stats?.firstFrames == 0)
+        #expect(stats?.watchedSeconds == 0)
+    }
+
+    @Test
+    func `stalls before the first frame are join time, not rebuffering`() {
+        let (qoe, suite) = makeTracker()
+        defer { tearDown(suite) }
+
+        qoe.beginStartup(engine: .ksPlayer, isLive: true)
+        // Startup buffering — the spinner before any frame arrives.
+        qoe.noteStallBegan()
+        qoe.noteStallEnded()
+        qoe.noteFirstFrame()
+
+        #expect(qoe.summary.engines[PlayerEngineKind.ksPlayer.rawValue]?.rebuffers == 0)
+    }
+
+    @Test
+    func `a mid-stream stall is counted once it clears`() {
+        let (qoe, suite) = makeTracker()
+        defer { tearDown(suite) }
+
+        qoe.beginStartup(engine: .ksPlayer, isLive: true)
+        qoe.noteFirstFrame()
+        qoe.noteStallBegan()
+        // A repeated "still stalled" signal must not double-count.
+        qoe.noteStallBegan()
+        qoe.noteStallEnded()
+
+        let stats = qoe.summary.engines[PlayerEngineKind.ksPlayer.rawValue]
+        #expect(stats?.rebuffers == 1)
+        #expect((stats?.rebufferSeconds ?? -1) >= 0)
+    }
+
+    @Test
+    func `an unclosed stall is still accounted for when the session ends`() {
+        let (qoe, suite) = makeTracker()
+        defer { tearDown(suite) }
+
+        qoe.beginStartup(engine: .lumeEngine, isLive: true)
+        qoe.noteFirstFrame()
+        qoe.noteStallBegan()
+        qoe.endSession()
+
+        #expect(qoe.summary.engines[PlayerEngineKind.lumeEngine.rawValue]?.rebuffers == 1)
+    }
+
+    @Test
+    func `restarting startup without ending the session closes the previous one`() {
+        let (qoe, suite) = makeTracker()
+        defer { tearDown(suite) }
+
+        // A live-channel zap: the engine begins a new attempt without a teardown.
+        qoe.beginStartup(engine: .ksPlayer, isLive: true)
+        qoe.noteFirstFrame()
+        qoe.beginStartup(engine: .ksPlayer, isLive: true)
+        qoe.noteFirstFrame()
+
+        let stats = qoe.summary.engines[PlayerEngineKind.ksPlayer.rawValue]
+        #expect(stats?.sessions == 2)
+        #expect(stats?.firstFrames == 2)
+    }
+
+    @Test
+    func `startup failures and engine fallbacks are counted separately`() {
+        let (qoe, suite) = makeTracker()
+        defer { tearDown(suite) }
+
+        qoe.beginStartup(engine: .ksPlayer, isLive: true)
+        qoe.noteStartupFailure()
+        qoe.noteEngineFallback(to: .vlcKit)
+
+        #expect(qoe.summary.engines[PlayerEngineKind.ksPlayer.rawValue]?.startupFailures == 1)
+        #expect(qoe.summary.engineFallbacks == 1)
+    }
+
+    @Test
+    func `counters survive a restart through the persisted summary`() throws {
+        let suiteName = "PlaybackQoETests-\(UUID().uuidString)"
+        defer { tearDown(suiteName) }
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+
+        let first = PlaybackQoE(defaults: defaults)
+        first.beginStartup(engine: .ksPlayer, isLive: false)
+        first.noteFirstFrame()
+
+        let second = PlaybackQoE(defaults: defaults)
+        #expect(second.summary.engines[PlayerEngineKind.ksPlayer.rawValue]?.firstFrames == 1)
+    }
+
+    @Test
+    func `rebuffer ratio is nil until something has been watched`() {
+        var stats = EngineQoEStats()
+        #expect(stats.rebufferRatio == nil)
+
+        stats.watchedSeconds = 100
+        stats.rebufferSeconds = 5
+        #expect(stats.rebufferRatio == 0.05)
+    }
+
+    @Test
+    func `reset clears every counter`() {
+        let (qoe, suite) = makeTracker()
+        defer { tearDown(suite) }
+
+        qoe.beginStartup(engine: .ksPlayer, isLive: true)
+        qoe.noteFirstFrame()
+        qoe.reset()
+
+        #expect(qoe.summary.engines.isEmpty)
+        #expect(qoe.summary.totalSessions == 0)
+    }
+}

--- a/Performance.xctestplan
+++ b/Performance.xctestplan
@@ -1,0 +1,27 @@
+{
+  "configurations" : [
+    {
+      "id" : "DE0B10B0-F6B3-4DEF-BDAA-82C7D3DFDBF5",
+      "name" : "Benchmark",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "testExecutionOrdering" : "alphabetical",
+    "testTimeoutsEnabled" : false
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : false,
+      "target" : {
+        "containerPath" : "container:Lume.xcodeproj",
+        "identifier" : "C6BE110000000000000000A6",
+        "name" : "LumePerformanceTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Scripts/run-performance-tests.sh
+++ b/Scripts/run-performance-tests.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# Runs the Lume benchmark suite and prints the measurements.
+#
+# The benchmarks live in their own target/scheme so they never slow down a normal
+# `xcodebuild test`, and they build under the **Benchmark** configuration
+# (Release + ENABLE_TESTABILITY): Debug builds are `-Onone`, which makes parser
+# and import numbers meaningless.
+#
+# Usage:
+#   Scripts/run-performance-tests.sh                       # whole suite
+#   Scripts/run-performance-tests.sh ParsingBenchmarks     # one suite
+#   Scripts/run-performance-tests.sh ParsingBenchmarks/testXMLTVDateParsing
+#
+# Environment:
+#   LUME_PERF_SIM   simulator name or UDID (default: newest available iPhone
+#                   running iOS 26.4 or later — 26.2 fails the deployment target)
+#   LUME_PERF_DD    derived data path (default: /tmp/lume-perf-dd)
+#
+# NOTE ON NUMBERS: results are only comparable against runs on the *same*
+# machine, at the same thermal state, with nothing else building. Committed
+# `.xcbaseline`s are per-device for exactly this reason. For a shared gate, pin
+# one machine or compare allocation counts rather than wall clock.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DERIVED_DATA="${LUME_PERF_DD:-/tmp/lume-perf-dd}"
+LOG_DIR="${DERIVED_DATA}/perf-logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="${LOG_DIR}/perf-$(date +%Y%m%d-%H%M%S).log"
+
+# --- Pick a simulator ------------------------------------------------------
+if [[ -n "${LUME_PERF_SIM:-}" ]]; then
+    DESTINATION="platform=iOS Simulator,name=${LUME_PERF_SIM}"
+    # A UDID works in the `id=` form; detect one by shape.
+    if [[ "$LUME_PERF_SIM" =~ ^[0-9A-Fa-f-]{36}$ ]]; then
+        DESTINATION="platform=iOS Simulator,id=${LUME_PERF_SIM}"
+    fi
+else
+    # The tests deploy to a recent iOS only; a 26.2 simulator fails with a
+    # deployment-target mismatch (exit 65), so resolve a 26.4+ device.
+    UDID=$(xcrun simctl list devices available |
+        awk '/-- iOS 2[6-9]\.[4-9]|-- iOS [3-9][0-9]\./ {ok=1; next} /^-- /{ok=0} ok && /iPhone/ {print; exit}' |
+        sed -E 's/.*\(([0-9A-F-]{36})\).*/\1/')
+    if [[ -z "$UDID" ]]; then
+        echo "error: no iOS 26.4+ iPhone simulator found. Create one, or set LUME_PERF_SIM." >&2
+        exit 1
+    fi
+    DESTINATION="platform=iOS Simulator,id=${UDID}"
+fi
+
+# --- Optional test filter --------------------------------------------------
+FILTER_ARGS=()
+if [[ $# -gt 0 ]]; then
+    FILTER_ARGS=(-only-testing:"LumePerformanceTests/$1")
+    echo "Filter:      LumePerformanceTests/$1"
+fi
+
+echo "Destination: ${DESTINATION}"
+echo "Log:         ${LOG_FILE}"
+echo
+
+set +e
+# `${arr[@]+"${arr[@]}"}` rather than `"${arr[@]}"`: macOS ships bash 3.2, where
+# expanding an empty array under `set -u` is an "unbound variable" error.
+xcodebuild test \
+    -project Lume.xcodeproj \
+    -scheme LumePerformance \
+    -destination "$DESTINATION" \
+    -derivedDataPath "$DERIVED_DATA" \
+    ${FILTER_ARGS[@]+"${FILTER_ARGS[@]}"} \
+    >"$LOG_FILE" 2>&1
+STATUS=$?
+set -e
+
+# --- Report ---------------------------------------------------------------
+echo "=== Measurements ==="
+# One line per metric: test name, metric, average, and the run-to-run spread.
+# A relative standard deviation above ~10% means the number is too noisy to
+# compare — close other apps and re-run before believing a "regression".
+grep -o "Test Case '-\[[^]]*\]' measured \[[^]]*\] average: [0-9.]*, relative standard deviation: [0-9.]*%" "$LOG_FILE" |
+    sed -E "s/Test Case '-\[LumePerformanceTests\.([^ ]+) ([^]]+)\]' measured \[([^]]+)\] average: ([0-9.]+), relative standard deviation: ([0-9.]+)%/\1.\2  \3  avg=\4  rsd=\5%/" ||
+    echo "(no measurements found — see the log)"
+
+echo
+echo "=== Result ==="
+grep -E "^Test Suite '(Selected tests|All tests)' (passed|failed)" "$LOG_FILE" | tail -2 || true
+grep -E "error:|failed \(" "$LOG_FILE" | head -20 || true
+
+if [[ $STATUS -ne 0 ]]; then
+    echo
+    echo "xcodebuild exited $STATUS — full log: $LOG_FILE" >&2
+fi
+exit $STATUS


### PR DESCRIPTION
Every performance problem we have fixed so far — the XMLTV `DateFormatter`, the SwiftData import cost, TTFF, the EPG `@Query` churn — was found by hand-profiling *after* a user complained. This adds the four layers that turn that into a repeatable measurement programme.

## 1. Signposts — the load-bearing part

`Lume/Services/Diagnostics/PerformanceSignposts.swift` names all 17 phases we repeatedly profile in one place. A single `Perf.begin`/`end` pair buys three things:

1. A Points of Interest lane in Instruments (phase boundaries, not just stack samples).
2. `XCTOSSignpostMetric` measurements of **production** code, by name.
3. `os_log`-based timing in the field, via the existing debug log exporter.

Wired into `ContentSyncManager` (whole sync + categories/movies/series/live), M3U download vs import as **separate** intervals, `EPGSyncManager` (per-source + ingest), both off-main EPG loaders, Home trending + recommendations, and player startup.

## 2. Benchmarks — `LumePerformanceTests`

Own target, scheme (`LumePerformance`) and test plan, so a normal `xcodebuild test` never runs them.

```bash
Scripts/run-performance-tests.sh                    # whole suite + measurements
Scripts/run-performance-tests.sh ParsingBenchmarks  # one suite
```

**New `Benchmark` build configuration** = Release settings + `ENABLE_TESTABILITY` + explicit `-O`. This is the part worth reviewing closely: Debug is `-Onone`, which makes parser and import numbers fiction, but `@testable import Lume` needs testability on the app module. Enabling testability on Release would change what ships, so a fourth configuration was added instead. **Debug / Release / Sideload are untouched.**

Other deliberate choices, all documented in `LumePerformanceTests/README.md`:

- **On-disk stores**, not in-memory — in-memory skips SQLite, which is the cost being measured.
- **Fixtures are generated per run** from a fixed-seed LCG, never committed (same reasoning as the gitignored `ExampleData/`). A fixture that changed between runs would be indistinguishable from a regression.
- **No CI gate.** Wall clock from a shared runner is noise, not signal. The README spells out the two ways to get a real gate (pinned self-hosted device, or machine-independent counters) if we ever want one.

## 3. Player QoE

`PlaybackQoE.swift` records what video services actually measure: **join time (TTFF), rebuffer ratio, exits before video start, startup failures, engine fallbacks**. All four engines report from choke points they already had (`hasStartedPlayback` flipping, the startup watchdog arming), so the numbers are directly comparable across KSPlayer / VLCKit / AVPlayer / LumeEngine.

Flushed to `UserDefaults` at session boundaries only — never periodically, which is what used to hitch KSPlayer every few seconds.

## 4. Field telemetry

`AppPerformanceMetrics.swift` subscribes to MetricKit: launch time, hang rate, scroll hitch ratio, memory, disk writes, plus hang/crash diagnostics, with raw payloads archived (and pruned) on disk. Compiled out on tvOS, where MetricKit doesn't exist.

Both QoE and the latest MetricKit summary render into the **exported diagnostic report** rather than a new settings screen — this is developer-facing data, and a localized screen would mean 9-locale churn for it.

## Measured

iPhone 17 Pro simulator, Benchmark configuration. Relative standard deviation is mostly under 2%, tight enough to baseline.

| Benchmark | Result |
|---|---|
| m3u parse, 120k entries | 0.747 s |
| XMLTV parse, 120k programmes | 0.453 s |
| Xtream decode, 50k movies | 0.288 s |
| Insert 20k movies (on disk) | 5.421 s |
| **Re-import 20k _unchanged_ movies** | **5.388 s** |
| Guide window, all 400 channels | 0.783 s |
| Guide window, 30 visible channels | 0.004 s |
| `ChannelEPGLoad` signpost (200 channels) | 0.083 s |

## Two findings, both left unfixed here

1. **A no-change re-import costs the same as a first import** (5.388 s vs 5.421 s). This confirms the earlier profiling note — it is now pinned by a test rather than institutional memory.

2. **`XMLTVDate` silently drops offset-less timestamps.** `20260730130000` (no `±HHMM`, which the XMLTV spec permits) fails both the hand-rolled fast path *and* the `DateFormatter` fallback, and `XMLTVParser.didEndElement` guards on the result — so **every programme from a provider that omits UTC offsets is dropped, with no error logged anywhere**. That guide just reads as empty. The fallback path also measures ~600× slower per call (75 µs vs 0.12 µs). Widening it means choosing a timezone to assume, so it needs a deliberate decision rather than a drive-by fix in a perf PR.

## Also in here

`VLCPlayerCoordinator.logStateChange` moves into the existing `+Diagnostics` file, which exists precisely to keep that file under the 600-line lint cap.

## Verification

- Builds for **iOS, tvOS and macOS**.
- Full benchmark suite passes; `Scripts/run-performance-tests.sh` output is the table above.
- `LumeTests` matches the pre-change baseline exactly: 2 failures, both the known flaky ones (`RecommendationEngineTests` cache test, and `WatchProgressBufferTests` whose failing case moves between runs). Verified by stashing the branch, running `LumeTests` at `main`, and comparing — including a run on a completely fresh derived-data path.
- SwiftFormat + SwiftLint pre-commit hooks pass.

### One thing reviewers should know

During this work I hit a single run where 228 tests failed with `signal trap`. It did **not** reproduce across three subsequent full runs, including one on a fresh derived-data path. Related and pre-existing: `LumeApp.makeCloudContainer()` ends in `fatalError`, so a transient CloudKit-store load failure at launch takes the whole app down — that is the most likely amplifier of whatever that one-off was, and is worth hardening separately.
