### PR TITLE
feat(player): add a per-playlist HLS / MPEG-TS stream format option

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -3377,6 +3377,58 @@
         }
       }
     },
+    "Automatic plays channels at the URL the playlist lists. Choose HLS or MPEG-TS to request that container instead; channels served through another kind of URL are unaffected." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "„Automatisch“ spielt Kanäle über die in der Playlist angegebene URL ab. Wähle HLS oder MPEG-TS, um stattdessen dieses Format anzufordern; Kanäle mit einer anderen Art von URL bleiben unverändert."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«Automático» reproduce los canales con la URL indicada en la lista. Elige HLS o MPEG-TS para solicitar ese contenedor en su lugar; los canales con otro tipo de URL no se ven afectados."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "« Automatique » lit les chaînes à l’URL indiquée dans la playlist. Choisissez HLS ou MPEG-TS pour demander ce conteneur à la place ; les chaînes diffusées via un autre type d’URL ne sont pas concernées."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«Automatico» riproduce i canali all’URL indicato nella playlist. Scegli HLS o MPEG-TS per richiedere invece quel contenitore; i canali distribuiti con un altro tipo di URL non vengono modificati."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「自動」はプレイリストに記載された URL でチャンネルを再生します。HLS または MPEG-TS を選ぶと、そのコンテナで要求します。別の形式の URL で配信されているチャンネルには影響しません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‘자동’은 재생 목록에 기재된 URL로 채널을 재생합니다. HLS 또는 MPEG-TS를 선택하면 해당 컨테이너로 요청합니다. 다른 형태의 URL로 제공되는 채널은 영향을 받지 않습니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«Automático» reproduz os canais no URL indicado na lista. Escolha HLS ou MPEG-TS para pedir esse contentor em vez disso; os canais servidos através de outro tipo de URL não são afetados."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“自动”会使用播放列表中给出的 URL 播放频道。选择 HLS 或 MPEG-TS 可改为请求该封装格式；通过其他类型 URL 提供的频道不受影响。"
+          }
+        }
+      }
+    },
     "Automatic Refresh" : {
       "localizations" : {
         "de" : {
@@ -3425,6 +3477,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动刷新"
+          }
+        }
+      }
+    },
+    "Automatic requests live channels as HLS. Choose MPEG-TS if channels stutter, refuse to start, or drop out — servers often serve one container more reliably than the other." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "„Automatisch“ fordert Live-Kanäle als HLS an. Wähle MPEG-TS, wenn Kanäle stocken, nicht starten oder abbrechen – Server liefern oft eines der beiden Formate zuverlässiger."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«Automático» solicita los canales en directo como HLS. Elige MPEG-TS si los canales se cortan, no arrancan o se interrumpen: los servidores suelen ofrecer un contenedor con más fiabilidad que el otro."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "« Automatique » demande les chaînes en direct en HLS. Choisissez MPEG-TS si les chaînes saccadent, ne démarrent pas ou s’interrompent : les serveurs diffusent souvent l’un des deux conteneurs de manière plus fiable."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«Automatico» richiede i canali live come HLS. Scegli MPEG-TS se i canali scattano, non partono o si interrompono: i server offrono spesso un contenitore in modo più affidabile dell’altro."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「自動」はライブチャンネルを HLS で要求します。映像が途切れる、再生が始まらない、途中で止まる場合は MPEG-TS を選んでください。サーバーによってどちらか一方のコンテナが安定していることがよくあります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‘자동’은 라이브 채널을 HLS로 요청합니다. 채널이 끊기거나 재생이 시작되지 않거나 도중에 멈추면 MPEG-TS를 선택하세요. 서버에 따라 한쪽 컨테이너가 더 안정적인 경우가 많습니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«Automático» pede os canais ao vivo em HLS. Escolha MPEG-TS se os canais engasgarem, não iniciarem ou caírem — os servidores costumam fornecer um dos contentores de forma mais fiável do que o outro."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“自动”会以 HLS 请求直播频道。如果频道卡顿、无法开始播放或中断，请选择 MPEG-TS——服务器往往对其中一种封装格式的支持更稳定。"
           }
         }
       }
@@ -14904,6 +15008,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "直播缓冲"
+          }
+        }
+      }
+    },
+    "Live Stream Format" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Format für Livestreams"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Formato de canales en directo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Format des flux en direct"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Formato dei flussi live"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライブ配信のフォーマット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "라이브 스트림 형식"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Formato de transmissão ao vivo"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直播流格式"
           }
         }
       }

--- a/Lume/Models/Playlist.swift
+++ b/Lume/Models/Playlist.swift
@@ -19,6 +19,15 @@ final class Playlist {
     /// empty, from the playlist's own `url-tvg` header on first sync.
     var epgURL: String?
 
+    /// Container the live streams of this playlist are requested in. Stored as a
+    /// raw string so the attribute stays lightweight-migration safe; existing
+    /// rows default to `automatic`, which keeps whatever the provider hands out
+    /// (HLS for Xtream, the playlist's own URL for m3u). Deliberately *not*
+    /// mirrored to CloudKit — which container a network and decoder cope with is
+    /// a per-device trait, like the per-channel `customOrder`. Access through
+    /// `streamFormat`.
+    var streamFormatRaw: String = PlaylistStreamFormat.automatic.rawValue
+
     /// Stalker portals authenticate by MAC address rather than credentials.
     /// `serverURL` holds the portal URL; this holds the bound MAC (e.g.
     /// `00:1A:79:xx:xx:xx`). `nil` for Xtream / m3u sources.
@@ -72,6 +81,69 @@ enum PlaylistSourceType: String, Codable {
     case stalker
 }
 
+/// The container a playlist's live streams are requested in.
+///
+/// `automatic` is the historical behaviour and stays the default: Xtream builds
+/// HLS URLs, and m3u channels play at exactly the URL the playlist listed. The
+/// two explicit choices exist because providers serve the same channel through
+/// both endpoints and only one of them tends to work well on a given network or
+/// decoder — HLS survives lossy connections, MPEG-TS starts faster and avoids
+/// the repackaging some panels do badly.
+nonisolated enum PlaylistStreamFormat: String, CaseIterable, Identifiable, Codable {
+    case automatic
+    case hls
+    case mpegTS
+
+    var id: String {
+        rawValue
+    }
+
+    var displayName: String {
+        switch self {
+        case .automatic: String(localized: "Automatic")
+        case .hls: "HLS"
+        case .mpegTS: "MPEG-TS"
+        }
+    }
+
+    /// The next choice, wrapping around — tvOS advances the setting in place
+    /// rather than opening a picker.
+    var next: PlaylistStreamFormat {
+        let all = Self.allCases
+        let index = all.firstIndex(of: self) ?? 0
+        return all[(index + 1) % all.count]
+    }
+
+    /// The Xtream path extension this format maps to, or `nil` for `automatic`
+    /// — where the caller keeps its own default.
+    var xtreamFormat: StreamFormat? {
+        switch self {
+        case .automatic: nil
+        case .hls: .m3u8
+        case .mpegTS: .tsStream
+        }
+    }
+
+    /// Rewrites a provider-supplied live URL to this container.
+    ///
+    /// Only URLs whose filename already ends in `.m3u8` or `.ts` are touched —
+    /// those are the two interchangeable Xtream-style live endpoints. Anything
+    /// else (a bare path, an `index.*` segment manifest, a VOD file) is left
+    /// alone rather than guessed at, so a mismatched setting can never break a
+    /// channel that was playing before.
+    func applied(to url: URL) -> URL {
+        guard let target = xtreamFormat?.rawValue,
+              var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let dot = components.path.lastIndex(of: "."),
+              !components.path[dot...].contains("/")
+        else { return url }
+        let current = components.path[components.path.index(after: dot)...].lowercased()
+        guard current == "m3u8" || current == "ts", current != target else { return url }
+        components.path = String(components.path[..<dot]) + "." + target
+        return components.url ?? url
+    }
+}
+
 enum SyncStatus: String, Codable {
     case idle
     case syncing
@@ -87,6 +159,18 @@ extension Playlist {
     var sourceType: PlaylistSourceType {
         get { PlaylistSourceType(rawValue: sourceTypeRaw) ?? .xtream }
         set { sourceTypeRaw = newValue.rawValue }
+    }
+
+    var streamFormat: PlaylistStreamFormat {
+        get { PlaylistStreamFormat(rawValue: streamFormatRaw) ?? .automatic }
+        set { streamFormatRaw = newValue.rawValue }
+    }
+
+    /// Whether the stream container can be chosen for this playlist. Stalker
+    /// portals hand out a fully-formed stream URL per session through
+    /// `create_link`, so there is nothing for us to pick.
+    var supportsStreamFormatChoice: Bool {
+        sourceType != .stalker
     }
 
     /// Whether content from this playlist can be downloaded for offline playback.

--- a/Lume/Services/Network/XtreamClient.swift
+++ b/Lume/Services/Network/XtreamClient.swift
@@ -400,9 +400,18 @@ class XtreamClient: APIClient {
         return URL(string: "\(playlist.serverURL)/series/\(playlist.username)/\(playlist.password)/\(episode.episodeId).\(ext)")
     }
 
-    /// Builds a playback URL for a live stream
-    func buildLiveStreamURL(for stream: LiveStream, playlist: Playlist, format: StreamFormat = .m3u8) -> URL? {
-        URL(string: "\(playlist.serverURL)/live/\(playlist.username)/\(playlist.password)/\(stream.streamId).\(format.rawValue)")
+    /// Builds a playback URL for a live stream. `format` overrides the
+    /// playlist's own container preference; when omitted the playlist decides,
+    /// falling back to HLS.
+    func buildLiveStreamURL(for stream: LiveStream, playlist: Playlist, format: StreamFormat? = nil) -> URL? {
+        let ext = Self.resolvedFormat(format, playlist: playlist).rawValue
+        return URL(string: "\(playlist.serverURL)/live/\(playlist.username)/\(playlist.password)/\(stream.streamId).\(ext)")
+    }
+
+    /// HLS is the fallback because it is what every Xtream URL Lume ever built
+    /// used before the container became configurable.
+    private nonisolated static func resolvedFormat(_ requested: StreamFormat?, playlist: Playlist) -> StreamFormat {
+        requested ?? playlist.streamFormat.xtreamFormat ?? .m3u8
     }
 
     /// `Y-m-d:H-i` is the start format Xtream Codes panels expect in a timeshift
@@ -428,11 +437,12 @@ class XtreamClient: APIClient {
         playlist: Playlist,
         start: Date,
         durationMinutes: Int,
-        format: StreamFormat = .m3u8
+        format: StreamFormat? = nil
     ) -> URL? {
         guard durationMinutes > 0 else { return nil }
+        let ext = Self.resolvedFormat(format, playlist: playlist).rawValue
         let startString = Self.timeshiftStartFormatter.string(from: start)
-        return URL(string: "\(playlist.serverURL)/timeshift/\(playlist.username)/\(playlist.password)/\(durationMinutes)/\(startString)/\(stream.streamId).\(format.rawValue)")
+        return URL(string: "\(playlist.serverURL)/timeshift/\(playlist.username)/\(playlist.password)/\(durationMinutes)/\(startString)/\(stream.streamId).\(ext)")
     }
 }
 

--- a/Lume/Services/Player/PlayableMedia.swift
+++ b/Lume/Services/Player/PlayableMedia.swift
@@ -162,7 +162,10 @@ extension PlayableMedia {
             guard let cmd = stream.directURL, let placeholder = StalkerLink.placeholder(type: .itv, cmd: cmd) else { return nil }
             url = placeholder
         } else {
-            let directURL = stream.directURL.flatMap(URL.init(string:))
+            // An m3u channel plays at the URL the playlist listed; the chosen
+            // container rewrites it only when the provider used one of the two
+            // interchangeable live endpoints. Xtream URLs are built with it.
+            let directURL = stream.directURL.flatMap(URL.init(string:)).map(playlist.streamFormat.applied(to:))
             guard let resolved = directURL ?? client.buildLiveStreamURL(for: stream, playlist: playlist) else { return nil }
             url = resolved
         }

--- a/Lume/Views/Settings/PlaylistDetailView+TV.swift
+++ b/Lume/Views/Settings/PlaylistDetailView+TV.swift
@@ -1,0 +1,217 @@
+//
+//  PlaylistDetailView+TV.swift
+//  Lume
+//
+//  The tvOS layout for a playlist's detail pane: the connection fields, account
+//  info, stream-format and sync sections, and the edit/delete actions. Split out
+//  of PlaylistDetailView to keep that file within the project's line-count cap.
+//
+
+import SwiftUI
+
+#if os(tvOS)
+
+    extension PlaylistDetailView {
+        /// Rendered *inline* inside the Settings detail pane (next to the sidebar),
+        /// not pushed full-screen. A push hides the TabView's header tab bar and
+        /// strands focus once the content scrolls — keeping it in the pane means
+        /// the sidebar and tab bar stay one "Left"/"Up" away at all times. The
+        /// enclosing pane supplies the ScrollView, background, and width framing.
+        var tvBody: some View {
+            VStack(alignment: .leading, spacing: 32) {
+                Text(playlist.name)
+                    .font(.system(size: 34, weight: .bold))
+                    .padding(.horizontal, TVSettingsMetrics.rowHPadding)
+
+                tvServerSection
+                tvAccountSection
+                tvStreamFormatSection
+                tvSyncSection
+                tvActionsSection
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .alert("Delete Playlist", isPresented: $showDeleteConfirmation) {
+                Button("Cancel", role: .cancel) {}
+                Button("Delete", role: .destructive) { deletePlaylist() }
+            } message: {
+                Text("All synced content for this playlist will also be removed.")
+            }
+            .fullScreenCover(isPresented: $showSync) {
+                SyncProgressView(playlist: playlist)
+            }
+            .fullScreenCover(isPresented: $showFullSync) {
+                SyncProgressView(playlist: playlist, full: true)
+            }
+        }
+
+        var tvServerSection: some View {
+            VStack(alignment: .leading, spacing: 8) {
+                TVSettingsSectionLabel(connectionSectionTitle)
+
+                if isEditing {
+                    VStack(spacing: 18) {
+                        TVSettingsField(title: "Name", placeholder: "Name", text: $editName, contentType: .name)
+                        TVSettingsField(title: serverURLFieldTitle, placeholder: serverURLFieldTitle, text: $editServerURL, contentType: .URL)
+                        if isM3U {
+                            TVSettingsField(title: "EPG URL (optional)", placeholder: "EPG URL", text: $editEPGURL, contentType: .URL)
+                        } else if isStalker {
+                            TVSettingsField(title: "MAC Address", placeholder: "00:1A:79:xx:xx:xx", text: $editMacAddress, contentType: nil)
+                            TVSettingsField(title: "Username (optional)", placeholder: "Username", text: $editUsername, contentType: .username)
+                            TVSettingsField(title: "Password (optional)", placeholder: "Password", text: $editPassword, isSecure: true, contentType: .password)
+                        } else {
+                            TVSettingsField(title: "Username", placeholder: "Username", text: $editUsername, contentType: .username)
+                            TVSettingsField(title: "Password", placeholder: "Password", text: $editPassword, isSecure: true, contentType: .password)
+                        }
+                    }
+                } else {
+                    VStack(spacing: 2) {
+                        TVSettingsValueRow("Name", value: playlist.name)
+                        TVSettingsValueRow(isStalker ? "Portal URL" : "URL") {
+                            Text(playlist.serverURL)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                        if isM3U {
+                            TVSettingsValueRow("EPG URL") {
+                                Text(playlist.epgURL ?? String(localized: "None"))
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+                        } else if isStalker {
+                            TVSettingsValueRow("MAC Address", value: playlist.macAddress ?? "")
+                            if !playlist.username.isEmpty {
+                                TVSettingsValueRow("Username", value: playlist.username)
+                            }
+                        } else {
+                            TVSettingsValueRow("Username", value: playlist.username)
+                            TVSettingsValueRow("Password") { Text("••••••••") }
+                        }
+                        TVSettingsValueRow("Added") { Text(playlist.addedAt, style: .date) }
+                    }
+                }
+            }
+        }
+
+        @ViewBuilder
+        var tvAccountSection: some View {
+            if let status = playlist.userStatus {
+                VStack(alignment: .leading, spacing: 8) {
+                    TVSettingsSectionLabel("Account")
+
+                    VStack(spacing: 2) {
+                        TVSettingsValueRow("Status", value: status)
+                        if let expDate = playlist.expDate {
+                            TVSettingsValueRow("Expires") {
+                                Text(formattedExpiry(expDate))
+                                    .foregroundStyle(isExpired(expDate) ? .red : .secondary)
+                            }
+                        }
+                        if let maxConn = playlist.maxConnections {
+                            TVSettingsValueRow("Max Connections", value: maxConn)
+                        }
+                        if let activeConn = playlist.activeConnections {
+                            TVSettingsValueRow("Active Connections", value: activeConn)
+                        }
+                    }
+                }
+            }
+        }
+
+        @ViewBuilder
+        var tvStreamFormatSection: some View {
+            if playlist.supportsStreamFormatChoice {
+                VStack(alignment: .leading, spacing: 8) {
+                    TVSettingsSectionLabel("Playback")
+
+                    TVOptionCycleRow(
+                        title: "Live Stream Format",
+                        valueLabel: playlist.streamFormat.displayName
+                    ) {
+                        playlist.streamFormat = playlist.streamFormat.next
+                    }
+
+                    Text(streamFormatFooter)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, TVSettingsMetrics.rowHPadding)
+                        .padding(.top, 4)
+                }
+            }
+        }
+
+        var tvSyncSection: some View {
+            VStack(alignment: .leading, spacing: 8) {
+                TVSettingsSectionLabel("Sync")
+
+                VStack(spacing: 2) {
+                    Button {
+                        playlist.syncEnabled.toggle()
+                    } label: {
+                        HStack(spacing: 16) {
+                            Text("Sync Enabled")
+                            Spacer(minLength: 0)
+                            Text(playlist.syncEnabled ? "On" : "Off")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .buttonStyle(TVSettingsRowButtonStyle())
+
+                    if playlist.syncStatus == .syncing {
+                        TVSettingsValueRow("Status") {
+                            HStack(spacing: 8) {
+                                ProgressView()
+                                Text("Syncing")
+                            }
+                        }
+                    }
+
+                    if let lastSync = playlist.lastSyncDate {
+                        TVSettingsValueRow("Last Synced") {
+                            Text(lastSync, style: .relative)
+                        }
+                    }
+
+                    Button("Sync Now") { showSync = true }
+                        .buttonStyle(TVSettingsRowButtonStyle())
+                        .disabled(playlist.syncStatus == .syncing)
+
+                    if isStalker {
+                        Button("Download Full Catalog") { showFullSync = true }
+                            .buttonStyle(TVSettingsRowButtonStyle())
+                            .disabled(playlist.syncStatus == .syncing)
+                    }
+                }
+
+                if isStalker {
+                    Text("""
+                    Movies and series load as you browse — nothing is prefetched. \
+                    Download the full catalog to make everything available offline and \
+                    searchable at once; this can take a while on large portals.
+                    """)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, TVSettingsMetrics.rowHPadding)
+                    .padding(.top, 4)
+                }
+            }
+        }
+
+        var tvActionsSection: some View {
+            VStack(spacing: 2) {
+                if isEditing {
+                    Button("Done") { saveChanges() }
+                        .buttonStyle(TVSettingsRowButtonStyle())
+                    Button("Cancel") { cancelEditing() }
+                        .buttonStyle(TVSettingsRowButtonStyle())
+                } else {
+                    Button("Edit Playlist") { startEditing() }
+                        .buttonStyle(TVSettingsRowButtonStyle())
+                    Button("Delete Playlist") { showDeleteConfirmation = true }
+                        .buttonStyle(TVSettingsRowButtonStyle(isDestructive: true))
+                }
+            }
+            .padding(.top, 12)
+        }
+    }
+
+#endif

--- a/Lume/Views/Settings/PlaylistDetailView.swift
+++ b/Lume/Views/Settings/PlaylistDetailView.swift
@@ -13,29 +13,29 @@ struct PlaylistDetailView: View {
     /// pops it.
     var onClose: (() -> Void)?
 
-    @State private var isEditing = false
-    @State private var editName = ""
-    @State private var editServerURL = ""
-    @State private var editUsername = ""
-    @State private var editPassword = ""
-    @State private var editEPGURL = ""
-    @State private var editMacAddress = ""
-    @State private var showDeleteConfirmation = false
-    @State private var showSync = false
+    @State var isEditing = false
+    @State var editName = ""
+    @State var editServerURL = ""
+    @State var editUsername = ""
+    @State var editPassword = ""
+    @State var editEPGURL = ""
+    @State var editMacAddress = ""
+    @State var showDeleteConfirmation = false
+    @State var showSync = false
     /// Presents the full-catalog download (Stalker only). Kept separate from
     /// `showSync` so the two sheets carry different `full` flags.
-    @State private var showFullSync = false
+    @State var showFullSync = false
 
-    private var isM3U: Bool {
+    var isM3U: Bool {
         playlist.sourceType == .m3u
     }
 
-    private var isStalker: Bool {
+    var isStalker: Bool {
         playlist.sourceType == .stalker
     }
 
     /// The localized section heading for the connection fields.
-    private var connectionSectionTitle: LocalizedStringKey {
+    var connectionSectionTitle: LocalizedStringKey {
         switch playlist.sourceType {
         case .xtream: "Server"
         case .m3u: "M3U Playlist"
@@ -76,6 +76,10 @@ struct PlaylistDetailView: View {
                             LabeledContent("Active Connections", value: activeConn)
                         }
                     }
+                }
+
+                if playlist.supportsStreamFormatChoice {
+                    streamFormatSection
                 }
 
                 syncSection
@@ -208,6 +212,22 @@ struct PlaylistDetailView: View {
             }
         }
 
+        // MARK: - Stream Format Section
+
+        private var streamFormatSection: some View {
+            Section {
+                Picker("Live Stream Format", selection: $playlist.streamFormat) {
+                    ForEach(PlaylistStreamFormat.allCases) { format in
+                        Text(verbatim: format.displayName).tag(format)
+                    }
+                }
+            } header: {
+                Text("Playback")
+            } footer: {
+                Text(streamFormatFooter)
+            }
+        }
+
         // MARK: - Sync Section
 
         private var syncSection: some View {
@@ -262,202 +282,28 @@ struct PlaylistDetailView: View {
         }
     #endif
 
+    /// Explains the stream-format choice. m3u playlists carry their own URLs, so
+    /// the wording there is about rewriting them rather than picking a default.
+    var streamFormatFooter: LocalizedStringKey {
+        isM3U
+            ? "Automatic plays channels at the URL the playlist lists. Choose HLS or MPEG-TS to request that container instead; channels served through another kind of URL are unaffected."
+            : "Automatic requests live channels as HLS. Choose MPEG-TS if channels stutter, refuse to start, or drop out — servers often serve one container more reliably than the other."
+    }
+
     /// Field label for the primary URL, shared across the iOS/macOS and tvOS
     /// layouts — its wording depends on the playlist's source type.
-    private var serverURLFieldTitle: LocalizedStringKey {
+    var serverURLFieldTitle: LocalizedStringKey {
         switch playlist.sourceType {
         case .xtream: "Server URL"
         case .m3u: "Playlist URL"
         case .stalker: "Portal URL"
         }
     }
-
-    // MARK: - tvOS layout
-
-    #if os(tvOS)
-        /// Rendered *inline* inside the Settings detail pane (next to the sidebar),
-        /// not pushed full-screen. A push hides the TabView's header tab bar and
-        /// strands focus once the content scrolls — keeping it in the pane means
-        /// the sidebar and tab bar stay one "Left"/"Up" away at all times. The
-        /// enclosing pane supplies the ScrollView, background, and width framing.
-        private var tvBody: some View {
-            VStack(alignment: .leading, spacing: 32) {
-                Text(playlist.name)
-                    .font(.system(size: 34, weight: .bold))
-                    .padding(.horizontal, TVSettingsMetrics.rowHPadding)
-
-                tvServerSection
-                tvAccountSection
-                tvSyncSection
-                tvActionsSection
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .alert("Delete Playlist", isPresented: $showDeleteConfirmation) {
-                Button("Cancel", role: .cancel) {}
-                Button("Delete", role: .destructive) { deletePlaylist() }
-            } message: {
-                Text("All synced content for this playlist will also be removed.")
-            }
-            .fullScreenCover(isPresented: $showSync) {
-                SyncProgressView(playlist: playlist)
-            }
-            .fullScreenCover(isPresented: $showFullSync) {
-                SyncProgressView(playlist: playlist, full: true)
-            }
-        }
-
-        private var tvServerSection: some View {
-            VStack(alignment: .leading, spacing: 8) {
-                TVSettingsSectionLabel(connectionSectionTitle)
-
-                if isEditing {
-                    VStack(spacing: 18) {
-                        TVSettingsField(title: "Name", placeholder: "Name", text: $editName, contentType: .name)
-                        TVSettingsField(title: serverURLFieldTitle, placeholder: serverURLFieldTitle, text: $editServerURL, contentType: .URL)
-                        if isM3U {
-                            TVSettingsField(title: "EPG URL (optional)", placeholder: "EPG URL", text: $editEPGURL, contentType: .URL)
-                        } else if isStalker {
-                            TVSettingsField(title: "MAC Address", placeholder: "00:1A:79:xx:xx:xx", text: $editMacAddress, contentType: nil)
-                            TVSettingsField(title: "Username (optional)", placeholder: "Username", text: $editUsername, contentType: .username)
-                            TVSettingsField(title: "Password (optional)", placeholder: "Password", text: $editPassword, isSecure: true, contentType: .password)
-                        } else {
-                            TVSettingsField(title: "Username", placeholder: "Username", text: $editUsername, contentType: .username)
-                            TVSettingsField(title: "Password", placeholder: "Password", text: $editPassword, isSecure: true, contentType: .password)
-                        }
-                    }
-                } else {
-                    VStack(spacing: 2) {
-                        TVSettingsValueRow("Name", value: playlist.name)
-                        TVSettingsValueRow(isStalker ? "Portal URL" : "URL") {
-                            Text(playlist.serverURL)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                        }
-                        if isM3U {
-                            TVSettingsValueRow("EPG URL") {
-                                Text(playlist.epgURL ?? String(localized: "None"))
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                            }
-                        } else if isStalker {
-                            TVSettingsValueRow("MAC Address", value: playlist.macAddress ?? "")
-                            if !playlist.username.isEmpty {
-                                TVSettingsValueRow("Username", value: playlist.username)
-                            }
-                        } else {
-                            TVSettingsValueRow("Username", value: playlist.username)
-                            TVSettingsValueRow("Password") { Text("••••••••") }
-                        }
-                        TVSettingsValueRow("Added") { Text(playlist.addedAt, style: .date) }
-                    }
-                }
-            }
-        }
-
-        @ViewBuilder
-        private var tvAccountSection: some View {
-            if let status = playlist.userStatus {
-                VStack(alignment: .leading, spacing: 8) {
-                    TVSettingsSectionLabel("Account")
-
-                    VStack(spacing: 2) {
-                        TVSettingsValueRow("Status", value: status)
-                        if let expDate = playlist.expDate {
-                            TVSettingsValueRow("Expires") {
-                                Text(formattedExpiry(expDate))
-                                    .foregroundStyle(isExpired(expDate) ? .red : .secondary)
-                            }
-                        }
-                        if let maxConn = playlist.maxConnections {
-                            TVSettingsValueRow("Max Connections", value: maxConn)
-                        }
-                        if let activeConn = playlist.activeConnections {
-                            TVSettingsValueRow("Active Connections", value: activeConn)
-                        }
-                    }
-                }
-            }
-        }
-
-        private var tvSyncSection: some View {
-            VStack(alignment: .leading, spacing: 8) {
-                TVSettingsSectionLabel("Sync")
-
-                VStack(spacing: 2) {
-                    Button {
-                        playlist.syncEnabled.toggle()
-                    } label: {
-                        HStack(spacing: 16) {
-                            Text("Sync Enabled")
-                            Spacer(minLength: 0)
-                            Text(playlist.syncEnabled ? "On" : "Off")
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .buttonStyle(TVSettingsRowButtonStyle())
-
-                    if playlist.syncStatus == .syncing {
-                        TVSettingsValueRow("Status") {
-                            HStack(spacing: 8) {
-                                ProgressView()
-                                Text("Syncing")
-                            }
-                        }
-                    }
-
-                    if let lastSync = playlist.lastSyncDate {
-                        TVSettingsValueRow("Last Synced") {
-                            Text(lastSync, style: .relative)
-                        }
-                    }
-
-                    Button("Sync Now") { showSync = true }
-                        .buttonStyle(TVSettingsRowButtonStyle())
-                        .disabled(playlist.syncStatus == .syncing)
-
-                    if isStalker {
-                        Button("Download Full Catalog") { showFullSync = true }
-                            .buttonStyle(TVSettingsRowButtonStyle())
-                            .disabled(playlist.syncStatus == .syncing)
-                    }
-                }
-
-                if isStalker {
-                    Text("""
-                    Movies and series load as you browse — nothing is prefetched. \
-                    Download the full catalog to make everything available offline and \
-                    searchable at once; this can take a while on large portals.
-                    """)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, TVSettingsMetrics.rowHPadding)
-                    .padding(.top, 4)
-                }
-            }
-        }
-
-        private var tvActionsSection: some View {
-            VStack(spacing: 2) {
-                if isEditing {
-                    Button("Done") { saveChanges() }
-                        .buttonStyle(TVSettingsRowButtonStyle())
-                    Button("Cancel") { cancelEditing() }
-                        .buttonStyle(TVSettingsRowButtonStyle())
-                } else {
-                    Button("Edit Playlist") { startEditing() }
-                        .buttonStyle(TVSettingsRowButtonStyle())
-                    Button("Delete Playlist") { showDeleteConfirmation = true }
-                        .buttonStyle(TVSettingsRowButtonStyle(isDestructive: true))
-                }
-            }
-            .padding(.top, 12)
-        }
-    #endif
 }
 
 // MARK: - Actions
 
-private extension PlaylistDetailView {
+extension PlaylistDetailView {
     func startEditing() {
         editName = playlist.name
         editServerURL = playlist.serverURL
@@ -514,7 +360,7 @@ private extension PlaylistDetailView {
 
 // MARK: - Helpers
 
-private extension PlaylistDetailView {
+extension PlaylistDetailView {
     func formattedExpiry(_ raw: String) -> String {
         if let timestamp = TimeInterval(raw) {
             let date = Date(timeIntervalSince1970: timestamp)

--- a/LumeTests/Models/PlaylistStreamFormatTests.swift
+++ b/LumeTests/Models/PlaylistStreamFormatTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+@testable import Lume
+import Testing
+
+/// The per-playlist HLS / MPEG-TS choice: how it maps onto built Xtream URLs
+/// and how it rewrites the direct URLs an m3u playlist carries.
+struct PlaylistStreamFormatTests {
+    private func makeClient() -> XtreamClient {
+        XtreamClient(configuration: XtreamClient.Configuration(
+            serverURL: "http://example.com:8080",
+            username: "testuser",
+            password: "testpass",
+            timeout: 30
+        ))
+    }
+
+    private func makePlaylist(format: PlaylistStreamFormat = .automatic) -> Playlist {
+        let playlist = Playlist(
+            name: "Test",
+            serverURL: "http://example.com:8080",
+            username: "testuser",
+            password: "testpass"
+        )
+        playlist.streamFormat = format
+        return playlist
+    }
+
+    // MARK: - Defaults
+
+    @Test func `defaults to automatic`() {
+        #expect(makePlaylist().streamFormat == .automatic)
+        #expect(PlaylistStreamFormat.automatic.xtreamFormat == nil)
+    }
+
+    @Test func `raw values are migration stable`() {
+        #expect(PlaylistStreamFormat.automatic.rawValue == "automatic")
+        #expect(PlaylistStreamFormat.hls.rawValue == "hls")
+        #expect(PlaylistStreamFormat.mpegTS.rawValue == "mpegTS")
+    }
+
+    @Test func `unknown raw value falls back to automatic`() {
+        let playlist = makePlaylist()
+        playlist.streamFormatRaw = "quicktime"
+        #expect(playlist.streamFormat == .automatic)
+    }
+
+    @Test func `next wraps through every case`() {
+        #expect(PlaylistStreamFormat.automatic.next == .hls)
+        #expect(PlaylistStreamFormat.hls.next == .mpegTS)
+        #expect(PlaylistStreamFormat.mpegTS.next == .automatic)
+    }
+
+    @Test func `stalker portals cannot choose a container`() {
+        let stalker = Playlist(name: "Portal", portalURL: "http://portal.example", macAddress: "00:1A:79:00:00:01")
+        #expect(!stalker.supportsStreamFormatChoice)
+        #expect(makePlaylist().supportsStreamFormatChoice)
+    }
+
+    // MARK: - Xtream live URLs
+
+    @Test func `automatic keeps the historical HLS live URL`() {
+        let stream = LiveStream(id: "l-1", streamId: 555, name: "Test Channel")
+        let url = makeClient().buildLiveStreamURL(for: stream, playlist: makePlaylist())
+        #expect(url?.absoluteString == "http://example.com:8080/live/testuser/testpass/555.m3u8")
+    }
+
+    @Test func `MPEGTS playlist builds a ts live URL`() {
+        let stream = LiveStream(id: "l-2", streamId: 555, name: "Test Channel")
+        let url = makeClient().buildLiveStreamURL(for: stream, playlist: makePlaylist(format: .mpegTS))
+        #expect(url?.absoluteString == "http://example.com:8080/live/testuser/testpass/555.ts")
+    }
+
+    @Test func `HLS playlist builds an m3u8 live URL`() {
+        let stream = LiveStream(id: "l-3", streamId: 555, name: "Test Channel")
+        let url = makeClient().buildLiveStreamURL(for: stream, playlist: makePlaylist(format: .hls))
+        #expect(url?.absoluteString == "http://example.com:8080/live/testuser/testpass/555.m3u8")
+    }
+
+    @Test func `explicit format argument overrides the playlist`() {
+        let stream = LiveStream(id: "l-4", streamId: 555, name: "Test Channel")
+        let url = makeClient().buildLiveStreamURL(for: stream, playlist: makePlaylist(format: .mpegTS), format: .m3u8)
+        #expect(url?.absoluteString == "http://example.com:8080/live/testuser/testpass/555.m3u8")
+    }
+
+    // MARK: - Xtream catch-up URLs
+
+    @Test func `catchup follows the playlist container`() throws {
+        let stream = LiveStream(id: "l-5", streamId: 777, name: "Catchup Channel")
+        let url = try #require(makeClient().buildCatchupURL(
+            for: stream,
+            playlist: makePlaylist(format: .mpegTS),
+            start: Date(timeIntervalSince1970: 1_700_000_000),
+            durationMinutes: 90
+        ))
+        #expect(url.absoluteString.hasSuffix("/777.ts"))
+    }
+
+    // MARK: - m3u direct URL rewriting
+
+    @Test func `automatic leaves an m3u URL untouched`() throws {
+        let url = try #require(URL(string: "http://host/live/user/pass/1.ts"))
+        #expect(PlaylistStreamFormat.automatic.applied(to: url) == url)
+    }
+
+    @Test func `rewrites between the two live containers`() throws {
+        let hlsURL = try #require(URL(string: "http://host/live/user/pass/1.m3u8"))
+        let tsURL = try #require(URL(string: "http://host/live/user/pass/1.ts"))
+        #expect(PlaylistStreamFormat.mpegTS.applied(to: hlsURL) == tsURL)
+        #expect(PlaylistStreamFormat.hls.applied(to: tsURL) == hlsURL)
+        #expect(PlaylistStreamFormat.hls.applied(to: hlsURL) == hlsURL)
+    }
+
+    @Test func `preserves the query when rewriting`() {
+        let url = URL(string: "http://host/live/user/pass/1.m3u8?token=abc")
+        let rewritten = url.map(PlaylistStreamFormat.mpegTS.applied(to:))
+        #expect(rewritten?.absoluteString == "http://host/live/user/pass/1.ts?token=abc")
+    }
+
+    @Test func `leaves URLs that use neither container alone`() throws {
+        // A bare path, a segment manifest and a VOD file must all survive
+        // untouched — guessing at them would break channels that played before.
+        for raw in [
+            "http://host/live/user/pass/1",
+            "http://host/channel/42/index.mpeg",
+            "http://host/movie/user/pass/1.mkv",
+            "http://host"
+        ] {
+            let url = try #require(URL(string: raw))
+            #expect(PlaylistStreamFormat.mpegTS.applied(to: url) == url)
+            #expect(PlaylistStreamFormat.hls.applied(to: url) == url)
+        }
+    }
+
+    @Test func `only the filename extension is considered`() throws {
+        // The dot lives in a directory component, not the filename.
+        let url = try #require(URL(string: "http://host/v1.2/live/1"))
+        #expect(PlaylistStreamFormat.hls.applied(to: url) == url)
+    }
+
+    // MARK: - PlayableMedia
+
+    @Test func `m3u channel plays through the chosen container`() throws {
+        let playlist = Playlist(name: "M3U", m3uURL: "http://host/list.m3u")
+        playlist.streamFormat = .mpegTS
+        let stream = LiveStream(id: "l-6", streamId: 1, name: "Channel")
+        stream.directURL = "http://host/live/user/pass/1.m3u8"
+        let media = try #require(PlayableMedia.from(stream: stream, playlist: playlist))
+        #expect(media.url.absoluteString == "http://host/live/user/pass/1.ts")
+    }
+
+    @Test func `m3u channel keeps its URL on automatic`() throws {
+        let playlist = Playlist(name: "M3U", m3uURL: "http://host/list.m3u")
+        let stream = LiveStream(id: "l-7", streamId: 1, name: "Channel")
+        stream.directURL = "http://host/live/user/pass/1.ts"
+        let media = try #require(PlayableMedia.from(stream: stream, playlist: playlist))
+        #expect(media.url.absoluteString == "http://host/live/user/pass/1.ts")
+    }
+}


### PR DESCRIPTION
## Summary
Providers commonly serve the same live channel through two interchangeable endpoints — an HLS manifest (`.m3u8`) and a raw MPEG-TS stream (`.ts`) — and only one of them tends to work well on a given network or decoder. Lume always requested HLS, so a channel that only plays reliably as MPEG-TS had no way to be fixed from the app. Each playlist now has a **Playback → Live Stream Format** setting with **Automatic** / **HLS** / **MPEG-TS**.

**Automatic is the default and preserves today's behaviour exactly**: Xtream playlists build HLS URLs, and m3u channels play at precisely the URL the playlist listed. Nothing changes for an existing install unless the user opts in.

## Implementation
`PlaylistStreamFormat` (in `Models/Playlist.swift`) is stored on `Playlist` as `streamFormatRaw` with an `automatic` default, so the schema change is lightweight-migration safe. It feeds two paths:

- **Xtream** — `buildLiveStreamURL` / `buildCatchupURL` take `format: StreamFormat? = nil` and resolve it from the playlist, falling back to HLS. Callers that pass a format explicitly still win.
- **m3u** — `PlaylistStreamFormat.applied(to:)` rewrites the channel's stored URL, but *only* when its filename already ends in `.m3u8` or `.ts`. A bare path, an `index.*` segment manifest or a VOD file is left untouched, so a mismatched setting can never break a channel that was playing before. Query strings survive the rewrite (`URLComponents`, not `appendingPathExtension`).

Stalker portals hand out a fully-formed per-session URL via `create_link`, so the row is hidden for them (`supportsStreamFormatChoice`).

The setting is deliberately **not** mirrored to CloudKit: which container a network and decoder cope with is a per-device trait, matching the existing precedent for per-channel `customOrder`. That also keeps the CloudKit schema untouched.

`PlaylistDetailView` was over SwiftLint's `file_length` / `type_body_length` caps once the section was added (it was already at 564/383 of 600/400), so the tvOS layout moved to `PlaylistDetailView+TV.swift`, following the existing `SettingsView+TVPlayer.swift` pattern. That accounts for most of the diff in that file — the tvOS code itself is unchanged apart from the new section, which uses the existing `TVOptionCycleRow`.

## Testing
- [x] Acceptance criteria met
- [x] Builds clean (XcodeBuildMCP `build_sim`, plus `xcodebuild` for tvOS 26.5 — the extracted file is tvOS-only)
- [x] Tests pass — 41/41 across `PlaylistStreamFormatTests`, `XtreamClientURLTests`, `XtreamErrorTests` (iPhone 17 Pro Max / iOS 26.4)
- [x] SwiftLint clean (strict, via the vendored plugin; pre-commit hooks green)
- [x] Tests added — 17 new tests in `LumeTests/Models/PlaylistStreamFormatTests.swift` covering the automatic default, raw-value stability, Xtream live + catch-up URLs, the m3u rewrite (including the leave-alone cases and query preservation) and `PlayableMedia`
- [x] UI verified on simulator — section renders and the picker persists the choice, checked in both dark and light appearance

## Platforms
- [x] iOS / iPadOS
- [ ] tvOS
- [ ] macOS
- [ ] visionOS
<!-- iOS verified interactively; tvOS verified to compile only. macOS/visionOS share the iOS form layout. -->