### PR TITLE
fix(sync): surface the real cause of a CloudKit partialFailure

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -12817,6 +12817,58 @@
         }
       }
     },
+    "iCloud is busy. Sync will retry automatically." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud ist ausgelastet. Die Synchronisierung wird automatisch wiederholt."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud está ocupado. La sincronización se reintentará automáticamente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud est occupé. La synchronisation sera relancée automatiquement."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud è occupato. La sincronizzazione verrà ritentata automaticamente."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloudが混雑しています。同期は自動的に再試行されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud가 사용 중입니다. 동기화를 자동으로 다시 시도합니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O iCloud está ocupado. A sincronização será tentada novamente automaticamente."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 繁忙。将自动重试同步。"
+          }
+        }
+      }
+    },
     "iCloud is restricted on this device (e.g. by Screen Time or a profile)." : {
       "localizations" : {
         "de" : {
@@ -12917,6 +12969,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "iCloud暂时不可用。同步将自动恢复。"
+          }
+        }
+      }
+    },
+    "iCloud rejected some changes. Export a diagnostic report for details." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud hat einige Änderungen abgelehnt. Exportiere einen Diagnosebericht für Details."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud rechazó algunos cambios. Exporta un informe de diagnóstico para ver los detalles."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud a refusé certaines modifications. Exportez un rapport de diagnostic pour en savoir plus."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud ha rifiutato alcune modifiche. Esporta un report diagnostico per i dettagli."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloudが一部の変更を拒否しました。詳細は診断レポートを書き出してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud가 일부 변경을 거부했습니다. 자세한 내용은 진단 보고서를 내보내세요."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O iCloud rejeitou algumas alterações. Exporte um relatório de diagnóstico para ver os detalhes."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 拒绝了部分更改。请导出诊断报告以查看详情。"
           }
         }
       }
@@ -18831,6 +18935,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无频道"
+          }
+        }
+      }
+    },
+    "No connection to iCloud. Sync resumes when you’re back online." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Verbindung zu iCloud. Die Synchronisierung wird fortgesetzt, sobald du wieder online bist."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin conexión con iCloud. La sincronización se reanudará cuando vuelvas a estar en línea."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune connexion à iCloud. La synchronisation reprendra dès que vous serez de nouveau en ligne."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna connessione a iCloud. La sincronizzazione riprende quando torni online."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloudに接続できません。オンラインに戻ると同期が再開されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud에 연결할 수 없습니다. 다시 온라인 상태가 되면 동기화가 재개됩니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sem ligação ao iCloud. A sincronização é retomada quando voltar a estar online."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法连接到 iCloud。恢复联网后将继续同步。"
           }
         }
       }
@@ -26953,6 +27109,58 @@
         }
       }
     },
+    "Sign in to iCloud to resume syncing." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melde dich bei iCloud an, um die Synchronisierung fortzusetzen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicia sesión en iCloud para reanudar la sincronización."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connectez-vous à iCloud pour reprendre la synchronisation."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accedi a iCloud per riprendere la sincronizzazione."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同期を再開するにはiCloudにサインインしてください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "동기화를 재개하려면 iCloud에 로그인하세요."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicie sessão no iCloud para retomar a sincronização."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请登录 iCloud 以继续同步。"
+          }
+        }
+      }
+    },
     "Skip back 15 seconds" : {
       "comment" : "A button that skips back 15 seconds.",
       "isCommentAutoGenerated" : true,
@@ -29517,6 +29725,58 @@
         }
       }
     },
+    "The same item changed on another device. Sync merges it on the next pass." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dasselbe Element wurde auf einem anderen Gerät geändert. Die Synchronisierung führt es beim nächsten Durchlauf zusammen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El mismo elemento cambió en otro dispositivo. La sincronización lo combinará en la siguiente pasada."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le même élément a été modifié sur un autre appareil. La synchronisation le fusionnera au prochain passage."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lo stesso elemento è stato modificato su un altro dispositivo. La sincronizzazione lo unirà al passaggio successivo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同じ項目が別のデバイスで変更されました。次回の同期で統合されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "같은 항목이 다른 기기에서 변경되었습니다. 다음 동기화에서 병합됩니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O mesmo item foi alterado noutro dispositivo. A sincronização vai uni-lo na próxima passagem."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同一项目已在其他设备上更改。下次同步时将合并。"
+          }
+        }
+      }
+    },
     "The TV guide refreshes automatically in the background at this interval." : {
       "localizations" : {
         "de" : {
@@ -29825,6 +30085,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近观看的频道列表将被清除。收藏和频道本身不受影响。"
+          }
+        }
+      }
+    },
+    "This iCloud account isn’t permitted to sync." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser iCloud-Account darf nicht synchronisieren."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta cuenta de iCloud no tiene permiso para sincronizar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce compte iCloud n’est pas autorisé à synchroniser."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo account iCloud non è autorizzato a sincronizzare."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このiCloudアカウントは同期を許可されていません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 iCloud 계정은 동기화할 수 없습니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta conta iCloud não tem permissão para sincronizar."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此 iCloud 账户不允许同步。"
           }
         }
       }
@@ -33016,6 +33328,110 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "您的凭据存储在此设备本地。"
+          }
+        }
+      }
+    },
+    "Your iCloud account is temporarily unavailable. Sync resumes automatically." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dein iCloud-Account ist vorübergehend nicht verfügbar. Die Synchronisierung wird automatisch fortgesetzt."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu cuenta de iCloud no está disponible temporalmente. La sincronización se reanudará automáticamente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre compte iCloud est temporairement indisponible. La synchronisation reprendra automatiquement."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il tuo account iCloud non è temporaneamente disponibile. La sincronizzazione riprende automaticamente."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloudアカウントを一時的に利用できません。同期は自動的に再開されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 계정을 일시적으로 사용할 수 없습니다. 동기화는 자동으로 재개됩니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A sua conta iCloud está temporariamente indisponível. A sincronização é retomada automaticamente."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的 iCloud 账户暂时不可用。同步将自动恢复。"
+          }
+        }
+      }
+    },
+    "Your iCloud storage is full. Free up space or upgrade your plan to resume syncing." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dein iCloud-Speicher ist voll. Gib Speicher frei oder erweitere deinen Plan, um die Synchronisierung fortzusetzen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu almacenamiento de iCloud está lleno. Libera espacio o amplía tu plan para reanudar la sincronización."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre stockage iCloud est saturé. Libérez de l’espace ou changez de forfait pour reprendre la synchronisation."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lo spazio su iCloud è esaurito. Libera spazio o passa a un piano superiore per riprendere la sincronizzazione."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloudストレージが満杯です。空き容量を作るかプランをアップグレードすると同期が再開されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 저장 공간이 가득 찼습니다. 공간을 확보하거나 요금제를 업그레이드하면 동기화가 다시 시작됩니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O seu armazenamento do iCloud está cheio. Liberte espaço ou faça upgrade do plano para retomar a sincronização."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 存储空间已满。请释放空间或升级方案以恢复同步。"
           }
         }
       }

--- a/Lume/Services/Sync/CloudSync/CloudSyncCoordinator.swift
+++ b/Lume/Services/Sync/CloudSync/CloudSyncCoordinator.swift
@@ -358,44 +358,49 @@ final class CloudSyncCoordinator {
     /// detail to `Logger.sync`.
     ///
     /// A CloudKit `partialFailure` — the opaque "CKErrorDomain error 2" that
-    /// reaches the user — hides the real cause inside `partialErrorsByItemID`;
-    /// `localizedDescription` on its own just repeats "error 2". Unwrapping the
-    /// per-record errors lets the log (and the settings screen) name what
-    /// actually failed — most often a record type that isn't in the deployed
-    /// CloudKit schema yet (e.g. a build pointed at an environment whose schema
-    /// was never deployed: every record is rejected and the batch reports
-    /// `partialFailure`).
+    /// reaches the user — usually hides the real cause inside
+    /// `partialErrorsByItemID`; `localizedDescription` on its own just repeats
+    /// "error 2". Unwrapping the per-record errors lets the log (and the settings
+    /// screen) name what actually failed — most often a record type that isn't in
+    /// the deployed CloudKit schema yet (e.g. a build pointed at an environment
+    /// whose schema was never deployed: every record is rejected and the batch
+    /// reports `partialFailure`).
+    ///
+    /// When that dictionary is *empty* the failure is above the record level —
+    /// account, zone, or quota — and there is nothing to unwrap, so
+    /// `CloudSyncErrorDescription` carries the diagnosis instead: the log gets
+    /// the domain, code, `CKError` case name and the whole underlying-error
+    /// chain, and the settings row gets a mapped sentence rather than an error
+    /// number (#156).
     private nonisolated static func describe(
         _ error: Error?,
         eventType: NSPersistentCloudKitContainer.EventType
     ) -> String? {
         guard let error else { return nil }
         let phase = eventName(eventType)
-
-        // Usually the CKError directly; occasionally a Cocoa error wrapping it.
-        let ckError = (error as? CKError)
-            ?? ((error as NSError).userInfo[NSUnderlyingErrorKey] as? Error)
-            .flatMap { $0 as? CKError }
+        let ckError = CloudSyncErrorDescription.ckError(in: error)
 
         if let ckError, ckError.code == .partialFailure,
            let perItem = ckError.partialErrorsByItemID, !perItem.isEmpty
         {
             for (itemID, itemError) in perItem {
-                // LogRedaction.describe, not String(reflecting:): conflict
+                // CloudSyncErrorDescription, not String(reflecting:): conflict
                 // errors can dump the whole CKRecord, and synced-playlist
                 // records carry server URLs and account credentials.
                 Logger.sync.error(
-                    "CloudKit \(phase, privacy: .public) rejected \(String(describing: itemID), privacy: .public): \(LogRedaction.describe(itemError), privacy: .public)"
+                    "CloudKit \(phase, privacy: .public) rejected \(String(describing: itemID), privacy: .public): \(CloudSyncErrorDescription.logDetail(for: itemError), privacy: .public)"
                 )
             }
             // Records usually all fail identically; collapse to the distinct
             // underlying messages so the UI shows the cause, not "error 2".
-            let messages = Set(perItem.values.map { ($0 as NSError).localizedDescription })
+            let messages = Set(perItem.values.map { CloudSyncErrorDescription.message(for: $0) })
             return messages.sorted().joined(separator: "; ")
         }
 
-        Logger.sync.error("CloudKit \(phase, privacy: .public) failed: \(LogRedaction.describe(error), privacy: .public)")
-        return error.localizedDescription
+        Logger.sync.error(
+            "CloudKit \(phase, privacy: .public) failed: \(CloudSyncErrorDescription.logDetail(for: error), privacy: .public)"
+        )
+        return CloudSyncErrorDescription.message(for: error)
     }
 
     private nonisolated static func eventName(_ type: NSPersistentCloudKitContainer.EventType) -> String {

--- a/Lume/Services/Sync/CloudSync/CloudSyncErrorDescription.swift
+++ b/Lume/Services/Sync/CloudSync/CloudSyncErrorDescription.swift
@@ -1,0 +1,159 @@
+//
+//  CloudSyncErrorDescription.swift
+//  Lume
+//
+//  Renders a CloudKit sync error twice: once for `Logger.sync` (domain, code,
+//  CKError case name, and the whole `NSUnderlyingErrorKey` chain) and once for
+//  the iCloud row in settings (a human sentence naming the cause).
+//
+//  `localizedDescription` alone is not enough for either. For
+//  `CKError.partialFailure` it reads "The operation couldn't be completed.
+//  (CKErrorDomain error 2.)", which makes a per-record rejection, a quota
+//  problem, and a zone-level failure indistinguishable after the fact — that
+//  ambiguity is what sent #155 chasing a CloudKit schema that turned out to be
+//  in sync.
+//
+//  Everything here is bound for `privacy: .public` log interpolation and lands
+//  verbatim in user-exported diagnostics, so messages pass through
+//  `LogRedaction` and `userInfo` is never rendered: CloudKit conflict errors
+//  carry whole `CKRecord`s, and a synced playlist record holds the server URL
+//  and account credentials.
+//
+
+import CloudKit
+import Foundation
+
+nonisolated enum CloudSyncErrorDescription {
+    /// The first `CKError` reachable from `error` through the underlying-error
+    /// chain. The error on an `NSPersistentCloudKitContainer` event is usually
+    /// the `CKError` itself, but it also arrives wrapped in a Cocoa error —
+    /// sometimes more than one level deep, which a single `userInfo` lookup
+    /// misses.
+    static func ckError(in error: Error) -> CKError? {
+        for link in chain(from: error) {
+            if let ckError = link as? CKError {
+                return ckError
+            }
+        }
+        return nil
+    }
+
+    /// Diagnostic rendering for the log: every link of the underlying-error
+    /// chain as `domain code (ckCase): message`, newest first.
+    static func logDetail(for error: Error) -> String {
+        chain(from: error).map(detail(for:)).joined(separator: " ← ")
+    }
+
+    /// The cause as shown in the iCloud settings row. Known `CKError` codes get
+    /// a human sentence; anything else keeps the system wording but gains the
+    /// `CKError` case name, so even an unmapped failure is identifiable from a
+    /// screenshot instead of reading as a bare number.
+    static func message(for error: Error) -> String {
+        guard let ckError = ckError(in: error) else { return error.localizedDescription }
+        if let mapped = mapped(ckError.code) {
+            return mapped
+        }
+        return "\(ckError.localizedDescription) (\(codeName(ckError.code)))"
+    }
+
+    // MARK: - Chain
+
+    /// Bounded so a self-referential `NSUnderlyingErrorKey` can't spin.
+    private static let maxChainDepth = 4
+
+    private static func chain(from error: Error) -> [Error] {
+        var links: [Error] = []
+        var current: Error? = error
+        while let link = current, links.count < maxChainDepth {
+            links.append(link)
+            current = (link as NSError).userInfo[NSUnderlyingErrorKey] as? Error
+        }
+        return links
+    }
+
+    private static func detail(for error: Error) -> String {
+        let nsError = error as NSError
+        var detail = "\(nsError.domain) \(nsError.code)"
+        if let ckError = error as? CKError {
+            detail += " (\(codeName(ckError.code)))"
+            if ckError.code == .partialFailure, ckError.partialErrorsByItemID?.isEmpty ?? true {
+                // The emptiness *is* the diagnostic. A rejected record always
+                // populates the dictionary, so an empty one rules out the
+                // record types and points at the account, zone, or quota (#155).
+                detail += " [no per-record errors]"
+            }
+        }
+        return "\(detail): \(LogRedaction.scrubURLs(in: nsError.localizedDescription))"
+    }
+
+    private static func codeName(_ code: CKError.Code) -> String {
+        codeNames[code.rawValue] ?? "CKErrorCode \(code.rawValue)"
+    }
+
+    /// `CKError.Code` is an imported `NS_ENUM`, so `String(describing:)` renders
+    /// `CKErrorCode(rawValue: 25)` — the bare number this type exists to
+    /// translate. Keyed by `rawValue` rather than by the code so the table stays
+    /// a plain `Sendable` literal.
+    private static let codeNames: [Int: String] = [
+        1: "internalError",
+        2: "partialFailure",
+        3: "networkUnavailable",
+        4: "networkFailure",
+        5: "badContainer",
+        6: "serviceUnavailable",
+        7: "requestRateLimited",
+        8: "missingEntitlement",
+        9: "notAuthenticated",
+        10: "permissionFailure",
+        11: "unknownItem",
+        12: "invalidArguments",
+        14: "serverRecordChanged",
+        15: "serverRejectedRequest",
+        16: "assetFileNotFound",
+        17: "assetFileModified",
+        18: "incompatibleVersion",
+        19: "constraintViolation",
+        20: "operationCancelled",
+        21: "changeTokenExpired",
+        22: "batchRequestFailed",
+        23: "zoneBusy",
+        24: "badDatabase",
+        25: "quotaExceeded",
+        26: "zoneNotFound",
+        27: "limitExceeded",
+        28: "userDeletedZone",
+        29: "tooManyParticipants",
+        30: "alreadyShared",
+        31: "referenceViolation",
+        32: "managedAccountRestricted",
+        33: "participantMayNeedVerification",
+        34: "serverResponseLost",
+        35: "assetNotAvailable",
+        36: "accountTemporarilyUnavailable"
+    ]
+
+    // MARK: - User-facing mapping
+
+    private static func mapped(_ code: CKError.Code) -> String? {
+        switch code {
+        case .quotaExceeded:
+            String(localized: "Your iCloud storage is full. Free up space or upgrade your plan to resume syncing.")
+        case .networkUnavailable, .networkFailure:
+            String(localized: "No connection to iCloud. Sync resumes when you’re back online.")
+        case .notAuthenticated:
+            String(localized: "Sign in to iCloud to resume syncing.")
+        case .accountTemporarilyUnavailable:
+            String(localized: "Your iCloud account is temporarily unavailable. Sync resumes automatically.")
+        case .managedAccountRestricted, .permissionFailure:
+            String(localized: "This iCloud account isn’t permitted to sync.")
+        case .zoneBusy, .requestRateLimited, .serviceUnavailable:
+            String(localized: "iCloud is busy. Sync will retry automatically.")
+        case .serverRecordChanged:
+            String(localized: "The same item changed on another device. Sync merges it on the next pass.")
+        case .partialFailure:
+            String(localized: "iCloud rejected some changes. Export a diagnostic report for details.")
+        default:
+            nil
+        }
+    }
+}

--- a/LumeTests/Services/CloudSyncErrorDescriptionTests.swift
+++ b/LumeTests/Services/CloudSyncErrorDescriptionTests.swift
@@ -1,0 +1,175 @@
+//
+//  CloudSyncErrorDescriptionTests.swift
+//  LumeTests
+//
+//  Guards the CloudKit error renderer: a `partialFailure` with no per-record
+//  errors must still name its domain, code and underlying chain in the log, and
+//  the settings row must show a cause rather than "CKErrorDomain error 2" (#156)
+//  — without letting the added detail carry playlist credentials into an
+//  exported diagnostic report.
+//
+
+import CloudKit
+import Foundation
+@testable import Lume
+import Testing
+
+struct CloudSyncErrorDescriptionTests {
+    // MARK: - Fixtures
+
+    private func ckError(
+        _ code: CKError.Code,
+        message: String = "The operation couldn’t be completed.",
+        underlying: Error? = nil,
+        partialErrors: [CKRecord.ID: Error]? = nil
+    ) -> Error {
+        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: message]
+        if let underlying {
+            userInfo[NSUnderlyingErrorKey] = underlying as NSError
+        }
+        if let partialErrors {
+            userInfo[CKPartialErrorsByItemIDKey] = partialErrors
+        }
+        return NSError(domain: CKErrorDomain, code: code.rawValue, userInfo: userInfo)
+    }
+
+    // MARK: - Log detail
+
+    @Test func `log detail names domain code and CKError case`() {
+        let detail = CloudSyncErrorDescription.logDetail(for: ckError(.quotaExceeded, message: "Quota exceeded"))
+        #expect(detail == "CKErrorDomain \(CKError.Code.quotaExceeded.rawValue) (quotaExceeded): Quota exceeded")
+    }
+
+    @Test func `code names line up with the real CKError values`() {
+        // The name table is keyed by raw value, so a mis-keyed row would silently
+        // mislabel a code — exactly the confusion this is meant to end.
+        let expected: [(CKError.Code, String)] = [
+            (.internalError, "internalError"),
+            (.partialFailure, "partialFailure"),
+            (.networkUnavailable, "networkUnavailable"),
+            (.networkFailure, "networkFailure"),
+            (.serviceUnavailable, "serviceUnavailable"),
+            (.requestRateLimited, "requestRateLimited"),
+            (.notAuthenticated, "notAuthenticated"),
+            (.permissionFailure, "permissionFailure"),
+            (.serverRecordChanged, "serverRecordChanged"),
+            (.changeTokenExpired, "changeTokenExpired"),
+            (.zoneBusy, "zoneBusy"),
+            (.quotaExceeded, "quotaExceeded"),
+            (.zoneNotFound, "zoneNotFound"),
+            (.limitExceeded, "limitExceeded"),
+            (.userDeletedZone, "userDeletedZone"),
+            (.managedAccountRestricted, "managedAccountRestricted"),
+            (.accountTemporarilyUnavailable, "accountTemporarilyUnavailable")
+        ]
+        for (code, name) in expected {
+            let detail = CloudSyncErrorDescription.logDetail(for: ckError(code, message: "x"))
+            #expect(detail.contains("(\(name))"), "code \(code.rawValue) rendered as \(detail)")
+        }
+    }
+
+    @Test func `log detail flags a partial failure with no per record errors`() {
+        // The motivating case: nothing to unwrap, so the emptiness itself has to
+        // reach the log — it rules out a per-record rejection.
+        let detail = CloudSyncErrorDescription.logDetail(for: ckError(.partialFailure, message: "Failed to modify some records"))
+        #expect(detail == "CKErrorDomain 2 (partialFailure) [no per-record errors]: Failed to modify some records")
+    }
+
+    @Test func `log detail does not flag a partial failure that has per record errors`() {
+        let error = ckError(
+            .partialFailure,
+            message: "Failed to modify some records",
+            partialErrors: [CKRecord.ID(recordName: "abc"): ckError(.serverRecordChanged, message: "Conflict")]
+        )
+        #expect(!CloudSyncErrorDescription.logDetail(for: error).contains("no per-record errors"))
+    }
+
+    @Test func `log detail walks the underlying error chain`() {
+        let root = NSError(domain: "NSPOSIXErrorDomain", code: 50, userInfo: [NSLocalizedDescriptionKey: "Network is down"])
+        let middle = NSError(
+            domain: NSCocoaErrorDomain,
+            code: 4097,
+            userInfo: [NSLocalizedDescriptionKey: "Connection interrupted", NSUnderlyingErrorKey: root]
+        )
+        let detail = CloudSyncErrorDescription.logDetail(for: ckError(.partialFailure, underlying: middle))
+        #expect(detail.contains("CKErrorDomain 2 (partialFailure)"))
+        #expect(detail.contains("NSCocoaErrorDomain 4097: Connection interrupted"))
+        #expect(detail.contains("NSPOSIXErrorDomain 50: Network is down"))
+    }
+
+    @Test func `log detail scrubs credentials out of every link`() {
+        let root = NSError(
+            domain: "TestDomain",
+            code: 7,
+            userInfo: [NSLocalizedDescriptionKey: "rejected http://iptv.example.com/live/myuser/mypass/1.ts"]
+        )
+        let detail = CloudSyncErrorDescription.logDetail(
+            for: ckError(.partialFailure, message: "push to https://portal.example.com/c/?mac=00:1A:79:AA failed", underlying: root)
+        )
+        #expect(!detail.contains("myuser"))
+        #expect(!detail.contains("mypass"))
+        #expect(!detail.contains("00:1A:79:AA"))
+        #expect(detail.contains("http://<redacted>"))
+        #expect(detail.contains("https://<redacted>"))
+    }
+
+    @Test func `log detail caps a pathologically deep chain`() {
+        var error = NSError(domain: "TestDomain", code: 0, userInfo: [NSLocalizedDescriptionKey: "root"])
+        for depth in 1 ... 6 {
+            error = NSError(
+                domain: "TestDomain",
+                code: depth,
+                userInfo: [NSLocalizedDescriptionKey: "level \(depth)", NSUnderlyingErrorKey: error]
+            )
+        }
+        #expect(CloudSyncErrorDescription.logDetail(for: error).components(separatedBy: " ← ").count == 4)
+    }
+
+    // MARK: - CKError extraction
+
+    @Test func `finds a CKError wrapped two levels deep`() {
+        let inner = ckError(.zoneBusy)
+        let middle = NSError(domain: NSCocoaErrorDomain, code: 134_400, userInfo: [NSUnderlyingErrorKey: inner as NSError])
+        let outer = NSError(domain: NSCocoaErrorDomain, code: 4097, userInfo: [NSUnderlyingErrorKey: middle])
+        #expect(CloudSyncErrorDescription.ckError(in: outer)?.code == .zoneBusy)
+    }
+
+    @Test func `reports no CKError when the chain has none`() {
+        let error = NSError(domain: NSCocoaErrorDomain, code: 4097, userInfo: [:])
+        #expect(CloudSyncErrorDescription.ckError(in: error) == nil)
+    }
+
+    // MARK: - User-facing message
+
+    @Test func `maps the common CKError codes to a cause`() {
+        let mapped: [CKError.Code] = [
+            .quotaExceeded, .networkUnavailable, .networkFailure, .notAuthenticated,
+            .zoneBusy, .serverRecordChanged, .partialFailure
+        ]
+        for code in mapped {
+            let message = CloudSyncErrorDescription.message(for: ckError(code))
+            #expect(!message.contains("CKErrorDomain"), "\(code) still surfaced the raw domain")
+            #expect(!message.contains("\(code.rawValue)"), "\(code) still surfaced the raw code")
+            #expect(message.count > 20, "\(code) produced no explanatory text")
+        }
+    }
+
+    @Test func `maps a CKError reached only through the underlying chain`() {
+        let wrapped = NSError(
+            domain: NSCocoaErrorDomain,
+            code: 4097,
+            userInfo: [NSUnderlyingErrorKey: ckError(.quotaExceeded) as NSError]
+        )
+        #expect(CloudSyncErrorDescription.message(for: wrapped) == CloudSyncErrorDescription.message(for: ckError(.quotaExceeded)))
+    }
+
+    @Test func `an unmapped CKError still names its case`() {
+        let message = CloudSyncErrorDescription.message(for: ckError(.internalError, message: "Something went wrong."))
+        #expect(message == "Something went wrong. (internalError)")
+    }
+
+    @Test func `a non CloudKit error keeps its own description`() {
+        let error = NSError(domain: "TestDomain", code: 3, userInfo: [NSLocalizedDescriptionKey: "Local save failed"])
+        #expect(CloudSyncErrorDescription.message(for: error) == "Local save failed")
+    }
+}


### PR DESCRIPTION
## Summary
A CloudKit `partialFailure` whose `partialErrorsByItemID` is empty — a zone-, account- or quota-level failure, or a `CKError` reached only through `NSUnderlyingErrorKey` — fell through `CloudSyncCoordinator.describe(_:eventType:)` to `error.localizedDescription`. For `CKError 2` that is just "The operation couldn't be completed. (CKErrorDomain error 2.)", so neither the log nor the iCloud row in Settings recorded the domain, the numeric code, or the underlying-error chain, and a per-record rejection was indistinguishable from an account problem after the fact. That ambiguity is what sent #155 chasing a Production CloudKit schema that turned out to be identical to Development.

## Implementation
New `CloudSyncErrorDescription` renders a sync error two ways. `logDetail(for:)` walks the `NSUnderlyingErrorKey` chain (depth-capped at 4 so a self-referential error can't spin) and prints each link as `domain code (ckCase): message`, explicitly flagging `[no per-record errors]` on an empty `partialFailure` — the emptiness is itself the diagnostic, since a rejected record always populates that dictionary. `message(for:)` maps the common `CKError` codes (`quotaExceeded`, `networkUnavailable`/`networkFailure`, `notAuthenticated`, `accountTemporarilyUnavailable`, `managedAccountRestricted`/`permissionFailure`, `zoneBusy`/`requestRateLimited`/`serviceUnavailable`, `serverRecordChanged`, `partialFailure`) to a localized sentence for the settings row, and appends the `CKError` case name to anything unmapped so no path surfaces a bare number. The `CKError` lookup now searches the whole chain instead of one `userInfo` level.

Redaction is unchanged: every message still goes through `LogRedaction`, and `userInfo` is never rendered — CloudKit conflict errors can carry whole `CKRecord`s, and a synced playlist record holds the server URL and credentials. `CKError.Code` is an imported `NS_ENUM`, so `String(describing:)` yields `CKErrorCode(rawValue: 25)` rather than a case name; the names come from an explicit raw-value table, with a test pinning it against the real enum constants.

## Testing
- [x] Acceptance criteria met
- [x] Builds clean (XcodeBuildMCP `build_sim`, iPhone 17 Pro Max / iOS 26.4)
- [x] Tests pass (13 new + 25 existing CloudSync tests, iOS 26.4 sim)
- [x] SwiftLint clean
- [x] Tests added — `LumeTests/Services/CloudSyncErrorDescriptionTests.swift` covers the empty-`partialFailure` flag, the chain walk and its depth cap, the code-name table against the real `CKError` constants, credential scrubbing across every link, and each mapped/unmapped message path
- [ ] UI verified on simulator — n/a: the settings row only renders this text on a real CloudKit failure (quota, zone, account), which can't be induced on a simulator; the mapping is covered by unit tests instead

## Platforms
- [x] iOS / iPadOS
- [ ] tvOS
- [ ] macOS
- [ ] visionOS
<!-- Platform-independent service code; built and tested on the iOS simulator. -->

## Related
Closes #156
Context for #155 (closed as not reproducible) — with this logging, that report would have been resolved from the log line alone.