### PR TITLE
fix(tvos): honour category locks in the channel browser, list and guide

### DIFF
--- a/Lume/Views/LiveTV/EPG/EPGGuideView.swift
+++ b/Lume/Views/LiveTV/EPG/EPGGuideView.swift
@@ -25,6 +25,11 @@ struct EPGGuideView: View {
     let onDidClaimFocus: () -> Void
 
     @Environment(\.modelContext) private var modelContext
+    /// The guide is a channel list like any other, so it owes the viewer the same
+    /// parental filtering. It matters most in the Favorites and Recently Watched
+    /// scopes, which span categories: a channel favorited before its category was
+    /// locked would otherwise stay reachable — and playable — from the guide.
+    @Environment(\.contentRestriction) private var restriction
     @Query private var streams: [LiveStream]
 
     private let timeline: EPGTimeline
@@ -72,7 +77,7 @@ struct EPGGuideView: View {
     }
 
     private var scopedStreams: [LiveStream] {
-        LiveChannelQuery.scoped(streams, scope: scope, playlistPrefix: playlistPrefix)
+        LiveChannelQuery.scoped(streams, scope: scope, playlistPrefix: playlistPrefix, restriction: restriction)
     }
 
     var body: some View {

--- a/Lume/Views/LiveTV/LiveTVSection.swift
+++ b/Lume/Views/LiveTV/LiveTVSection.swift
@@ -158,13 +158,35 @@ enum LiveChannelQuery {
         playlistPrefix: String,
         restriction: ContentRestriction
     ) -> [LiveStream] {
-        let inPlaylist: [LiveStream] = switch scope {
+        switch scope {
         case .category:
-            streams
+            streams.excludingRestricted(restriction)
         case .favorites, .recentlyWatched:
-            streams.filter { $0.id.hasPrefix(playlistPrefix) }
+            streams.filter { isVisible($0, playlistPrefix: playlistPrefix, restriction: restriction) }
         }
-        return inPlaylist.excludingRestricted(restriction)
+    }
+
+    /// Whether any of `streams` survives the filtering `scoped` applies to the
+    /// virtual collections. Short-circuits, so the Live TV rail can decide
+    /// whether to offer Favorites / Recently Watched without materialising the
+    /// list — and shares `isVisible` with `scoped`, so the rail can never offer
+    /// a section whose list then renders empty.
+    static func containsVisible(
+        _ streams: some Sequence<LiveStream>,
+        playlistPrefix: String,
+        restriction: ContentRestriction
+    ) -> Bool {
+        streams.contains { isVisible($0, playlistPrefix: playlistPrefix, restriction: restriction) }
+    }
+
+    /// The per-channel test the virtual collections apply: in the active
+    /// playlist, and not in a category locked away from this viewer.
+    private static func isVisible(
+        _ stream: LiveStream,
+        playlistPrefix: String,
+        restriction: ContentRestriction
+    ) -> Bool {
+        stream.id.hasPrefix(playlistPrefix) && !restriction.hides(categoryID: stream.categoryId)
     }
 
     /// The live categories of the active playlist this viewer may see: scoped by
@@ -181,7 +203,8 @@ enum LiveChannelQuery {
         restriction: ContentRestriction
     ) -> [Category] {
         categories.filter {
-            $0.id.hasPrefix(playlistPrefix) && !$0.isHidden && !restriction.hides(categoryID: $0.id)
+            $0.type == .live && $0.id.hasPrefix(playlistPrefix)
+                && !$0.isHidden && !restriction.hides(categoryID: $0.id)
         }
     }
 }

--- a/Lume/Views/LiveTV/LiveTVSection.swift
+++ b/Lume/Views/LiveTV/LiveTVSection.swift
@@ -137,16 +137,51 @@ enum LiveChannelQuery {
         }
     }
 
-    /// Scopes a query's results to the active playlist. Category queries are
-    /// already isolated (category ids are playlist-prefixed), but the virtual
-    /// collections span every playlist, so they're filtered in-memory by the
-    /// shared id prefix — the same approach used throughout the app.
-    static func scoped(_ streams: [LiveStream], scope: LiveChannelScope, playlistPrefix: String) -> [LiveStream] {
-        switch scope {
+    /// Scopes a query's results to the active playlist *and* to what the current
+    /// viewer is allowed to see. Category queries are already isolated (category
+    /// ids are playlist-prefixed), but the virtual collections span every
+    /// playlist, so they're filtered in-memory by the shared id prefix — the same
+    /// approach used throughout the app.
+    ///
+    /// `restriction` is required rather than defaulted on purpose. Every channel
+    /// list in the app funnels through here, so making the compiler demand it at
+    /// each call site is what stops one surface from quietly shipping without the
+    /// parental filter — which is exactly how the tvOS list and the in-player
+    /// browser came to show a child channels from locked categories.
+    ///
+    /// The virtual collections need it most: Favorites and Recently Watched cut
+    /// across categories, so a channel favorited before its category was locked
+    /// would otherwise keep surfacing.
+    static func scoped(
+        _ streams: [LiveStream],
+        scope: LiveChannelScope,
+        playlistPrefix: String,
+        restriction: ContentRestriction
+    ) -> [LiveStream] {
+        let inPlaylist: [LiveStream] = switch scope {
         case .category:
             streams
         case .favorites, .recentlyWatched:
             streams.filter { $0.id.hasPrefix(playlistPrefix) }
+        }
+        return inPlaylist.excludingRestricted(restriction)
+    }
+
+    /// The live categories of the active playlist this viewer may see: scoped by
+    /// playlist prefix, minus the ones hidden in Content Management, minus the
+    /// ones locked away from a child profile.
+    ///
+    /// Shared by the Live TV rail and the in-player channel browser so the two
+    /// cannot disagree about what a category rail contains — the browser used to
+    /// drop only `isHidden`, which put locked categories one remote press away
+    /// from a child mid-playback.
+    static func visibleCategories(
+        _ categories: [Category],
+        playlistPrefix: String,
+        restriction: ContentRestriction
+    ) -> [Category] {
+        categories.filter {
+            $0.id.hasPrefix(playlistPrefix) && !$0.isHidden && !restriction.hides(categoryID: $0.id)
         }
     }
 }

--- a/Lume/Views/LiveTV/LiveTVTVComponents.swift
+++ b/Lume/Views/LiveTV/LiveTVTVComponents.swift
@@ -18,6 +18,10 @@
         let playlistPrefix: String
         let onPlay: (LiveStream) -> Void
         @Environment(\.modelContext) private var modelContext
+        /// Drops channels in categories locked away from a child profile — the
+        /// iOS list has always done this; this one didn't, so Favorites and
+        /// Recently Watched still surfaced them here.
+        @Environment(\.contentRestriction) private var restriction
         @Query private var streams: [LiveStream]
         /// Now/next EPG for the visible channels, resolved in one off-main fetch
         /// (see `ChannelEPGSnapshot`) instead of a per-row `@Query`.
@@ -38,7 +42,7 @@
         }
 
         private var scopedStreams: [LiveStream] {
-            LiveChannelQuery.scoped(streams, scope: scope, playlistPrefix: playlistPrefix)
+            LiveChannelQuery.scoped(streams, scope: scope, playlistPrefix: playlistPrefix, restriction: restriction)
         }
 
         var body: some View {

--- a/Lume/Views/LiveTV/LiveTVView.swift
+++ b/Lume/Views/LiveTV/LiveTVView.swift
@@ -279,15 +279,15 @@ struct LiveTVView: View {
     /// Channels in restricted categories are excluded while a child profile is
     /// active, so those collections never surface restricted content.
     private var hasFavorites: Bool {
-        !playlistPrefix.isEmpty && favoriteStreams.contains {
-            $0.id.hasPrefix(playlistPrefix) && !restriction.hides(categoryID: $0.categoryId)
-        }
+        !playlistPrefix.isEmpty && LiveChannelQuery.containsVisible(
+            favoriteStreams, playlistPrefix: playlistPrefix, restriction: restriction
+        )
     }
 
     private var hasRecents: Bool {
-        !playlistPrefix.isEmpty && recentStreams.contains {
-            $0.id.hasPrefix(playlistPrefix) && !restriction.hides(categoryID: $0.categoryId)
-        }
+        !playlistPrefix.isEmpty && LiveChannelQuery.containsVisible(
+            recentStreams, playlistPrefix: playlistPrefix, restriction: restriction
+        )
     }
 
     /// The rail's entries: the virtual collections (when non-empty) pinned above

--- a/Lume/Views/LiveTV/LiveTVView.swift
+++ b/Lume/Views/LiveTV/LiveTVView.swift
@@ -271,7 +271,7 @@ struct LiveTVView: View {
     private var sortedCategories: [Category] {
         guard let playlistId = activePlaylist?.id else { return [] }
         let prefix = "\(playlistId.uuidString)-"
-        return categorySort.sort(categories.filter { $0.id.hasPrefix(prefix) && !restriction.hides(categoryID: $0.id) })
+        return categorySort.sort(LiveChannelQuery.visibleCategories(categories, playlistPrefix: prefix, restriction: restriction))
     }
 
     /// Whether the active playlist has any favorited / recently-watched channels,
@@ -520,8 +520,7 @@ struct ChannelsList: View {
     }
 
     private var scopedStreams: [LiveStream] {
-        LiveChannelQuery.scoped(streams, scope: scope, playlistPrefix: playlistPrefix)
-            .excludingRestricted(restriction)
+        LiveChannelQuery.scoped(streams, scope: scope, playlistPrefix: playlistPrefix, restriction: restriction)
     }
 
     /// Clears a channel's watch timestamp so it drops out of the Recently

--- a/Lume/Views/Player/TVChannelBrowserOverlay.swift
+++ b/Lume/Views/Player/TVChannelBrowserOverlay.swift
@@ -28,6 +28,12 @@
         let onClose: () -> Void
 
         @Environment(\.modelContext) private var modelContext
+        /// Keeps the browser honest about parental restrictions. It reaches here
+        /// because the player is a `fullScreenCover` presented from inside
+        /// `MainTabView`'s hierarchy, which is where the value is injected.
+        /// Without it a child could press left mid-playback and tune straight
+        /// into a locked category.
+        @Environment(\.contentRestriction) private var restriction
         /// The same sort choices the Live TV browse screen uses, so the browser
         /// mirrors the order the viewer knows from the channel list.
         @AppStorage(SortStorageKey.liveCategories)
@@ -337,7 +343,11 @@
                 predicate: #Predicate { $0.typeRaw == "live" && $0.isHidden == false }
             )
             let categories = categorySort.sort(
-                ((try? modelContext.fetch(descriptor)) ?? []).filter { $0.id.hasPrefix(playlistPrefix) }
+                LiveChannelQuery.visibleCategories(
+                    (try? modelContext.fetch(descriptor)) ?? [],
+                    playlistPrefix: playlistPrefix,
+                    restriction: restriction
+                )
             )
 
             var rail: [LiveTVSection] = []
@@ -367,7 +377,7 @@
             let sort = ContentSortOption(rawValue: contentSortRaw) ?? .playlist
             let descriptor = LiveChannelQuery.descriptor(for: scope, sort: sort)
             let fetched = (try? modelContext.fetch(descriptor)) ?? []
-            return LiveChannelQuery.scoped(fetched, scope: scope, playlistPrefix: playlistPrefix)
+            return LiveChannelQuery.scoped(fetched, scope: scope, playlistPrefix: playlistPrefix, restriction: restriction)
         }
 
         /// Swap the channel column to another section's channels. Debounced a

--- a/Lume/Views/Player/TVPlayerContent.swift
+++ b/Lume/Views/Player/TVPlayerContent.swift
@@ -63,12 +63,25 @@
         /// into models for the in-player "Recent" rail. Order follows
         /// `LiveChannelHistory`; channels that no longer resolve (e.g. removed in
         /// a sync) are simply dropped.
-        static func recentChannels(in context: ModelContext, defaults: UserDefaults = .standard) -> [LiveStream] {
+        ///
+        /// `restriction` is required, like `LiveChannelQuery.scoped`'s: this rail
+        /// is a channel list the viewer can tune from, and history cuts across
+        /// categories, so a channel watched *before* its category was locked
+        /// would otherwise stay one tab away for a child mid-playback. Hidden
+        /// channels drop out for the same reason every other channel query
+        /// filters them.
+        static func recentChannels(
+            in context: ModelContext,
+            restriction: ContentRestriction,
+            defaults: UserDefaults = .standard
+        ) -> [LiveStream] {
             let ids = LiveChannelHistory.recentChannelIds(defaults: defaults)
             guard !ids.isEmpty else { return [] }
-            let descriptor = FetchDescriptor<LiveStream>(predicate: #Predicate { ids.contains($0.id) })
-            let byId = Dictionary(((try? context.fetch(descriptor)) ?? []).map { ($0.id, $0) },
-                                  uniquingKeysWith: { first, _ in first })
+            let descriptor = FetchDescriptor<LiveStream>(
+                predicate: #Predicate { ids.contains($0.id) && $0.isHidden == false }
+            )
+            let visible = ((try? context.fetch(descriptor)) ?? []).excludingRestricted(restriction)
+            let byId = Dictionary(visible.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
             return ids.compactMap { byId[$0] }
         }
 

--- a/Lume/Views/Player/TVPlayerControlsOverlay+Data.swift
+++ b/Lume/Views/Player/TVPlayerControlsOverlay+Data.swift
@@ -49,7 +49,7 @@
                 let now = Date()
                 epgNow = listings.first { $0.start <= now && now < $0.end }
                 epgNext = listings.first { $0.start > now }
-                recentChannels = TVPlayerContent.recentChannels(in: modelContext)
+                recentChannels = TVPlayerContent.recentChannels(in: modelContext, restriction: restriction)
                 recentNowTitles = TVPlayerContent.nowProgrammeTitles(for: recentChannels, in: modelContext)
             }
         }

--- a/Lume/Views/Player/TVPlayerControlsOverlay.swift
+++ b/Lume/Views/Player/TVPlayerControlsOverlay.swift
@@ -41,6 +41,11 @@
         /// `internal` (not `private`) so the derived-data extension in
         /// `TVPlayerControlsOverlay+Data.swift` can read this view's state.
         @Environment(\.modelContext) var modelContext
+        /// Parental filter for the Recent channels rail. That rail is a channel
+        /// list the viewer can tune from, so it owes the same filtering the Live
+        /// TV lists do — a channel watched before its category was locked must
+        /// not stay one tab away.
+        @Environment(\.contentRestriction) var restriction
 
         // Resolved SwiftData backing for the active stream.
         @State var episode: Episode?

--- a/LumeTests/Services/LiveChannelQueryTests.swift
+++ b/LumeTests/Services/LiveChannelQueryTests.swift
@@ -11,25 +11,14 @@
 
 import Foundation
 @testable import Lume
-import SwiftData
 import Testing
 
 @MainActor
 struct LiveChannelQueryTests {
-    /// An in-memory catalog so the models under test are real `LiveStream` /
-    /// `Category` instances rather than stand-ins — the helpers read `id`,
-    /// `categoryId` and `isHidden` off the models themselves.
-    private func makeContainer() throws -> ModelContainer {
-        let schema = Schema([
-            Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
-            Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self
-        ])
-        return try ModelContainer(
-            for: schema,
-            configurations: ModelConfiguration(schema: schema, isStoredInMemoryOnly: true, cloudKitDatabase: .none)
-        )
-    }
-
+    /// Real `LiveStream` / `Category` instances rather than stand-ins — the
+    /// helpers read `id`, `categoryId`, `type` and `isHidden` off the models
+    /// themselves. No `ModelContainer`: both helpers are pure functions over the
+    /// array they're handed, so inserting and saving would only add cost.
     private func stream(_ suffix: String, playlist: UUID, category: String?) -> LiveStream {
         LiveStream(id: "\(playlist.uuidString)-live-\(suffix)", streamId: 1, name: "Ch \(suffix)", categoryId: category)
     }
@@ -96,63 +85,54 @@ struct LiveChannelQueryTests {
     @Test func `category scope is not playlist-filtered but is still restriction-filtered`() {
         let pid = UUID()
         let locked = "\(pid.uuidString)-live-locked"
-        let streams = [stream("1", playlist: pid, category: locked)]
+        let streams = [
+            stream("1", playlist: pid, category: locked),
+            stream("2", playlist: pid, category: "\(pid.uuidString)-live-open")
+        ]
         let restriction = ContentRestriction(isActive: true, restrictedCategoryIDs: [locked])
 
-        // Category ids are already playlist-prefixed, so the scope skips the
-        // prefix filter — but a locked category must still never render.
+        // A prefix no stream matches: category ids are already playlist-prefixed,
+        // so the scope must skip the prefix filter entirely (an empty prefix
+        // would pass `hasPrefix` either way and prove nothing) — while a locked
+        // category still never renders.
         let kept = LiveChannelQuery.scoped(
-            streams, scope: .category(locked), playlistPrefix: "", restriction: restriction
+            streams, scope: .category(locked), playlistPrefix: "\(UUID().uuidString)-", restriction: restriction
         )
-        #expect(kept.isEmpty)
+        #expect(kept.map(\.name) == ["Ch 2"])
     }
 
     // MARK: - visibleCategories
 
-    @Test func `visible categories drop hidden, locked and other playlists`() throws {
-        let container = try makeContainer()
-        let ctx = container.mainContext
+    @Test func `visible categories drop hidden, locked, other playlists and other types`() {
         let playlist = Playlist(name: "Mine", serverURL: "http://x", username: "u", password: "p")
-        ctx.insert(playlist)
         let prefix = "\(playlist.id.uuidString)-"
 
         let open = Lume.Category(apiId: "1", name: "News", parentId: 0, type: .live, playlist: playlist)
         let hidden = Lume.Category(apiId: "2", name: "Shopping", parentId: 0, type: .live, playlist: playlist)
         hidden.isHidden = true
         let locked = Lume.Category(apiId: "3", name: "Adults", parentId: 0, type: .live, playlist: playlist)
-        locked.isRestricted = true
+        // A VOD category of the same playlist shares the prefix, so only the
+        // type check keeps it out of a *live* rail.
+        let movies = Lume.Category(apiId: "4", name: "Action", parentId: 0, type: .vod, playlist: playlist)
 
         let otherPlaylist = Playlist(name: "Theirs", serverURL: "http://y", username: "u", password: "p")
-        ctx.insert(otherPlaylist)
         let foreign = Lume.Category(apiId: "1", name: "News", parentId: 0, type: .live, playlist: otherPlaylist)
-        for category in [open, hidden, locked, foreign] {
-            ctx.insert(category)
-        }
-        try ctx.save()
 
         let restriction = ContentRestriction(isActive: true, restrictedCategoryIDs: [locked.id])
         let visible = LiveChannelQuery.visibleCategories(
-            [open, hidden, locked, foreign], playlistPrefix: prefix, restriction: restriction
+            [open, hidden, locked, movies, foreign], playlistPrefix: prefix, restriction: restriction
         )
 
         #expect(visible.map(\.id) == [open.id])
     }
 
-    @Test func `a parent profile still sees a locked category but never a hidden one`() throws {
-        let container = try makeContainer()
-        let ctx = container.mainContext
+    @Test func `a parent profile still sees a locked category but never a hidden one`() {
         let playlist = Playlist(name: "Mine", serverURL: "http://x", username: "u", password: "p")
-        ctx.insert(playlist)
         let prefix = "\(playlist.id.uuidString)-"
 
         let hidden = Lume.Category(apiId: "2", name: "Shopping", parentId: 0, type: .live, playlist: playlist)
         hidden.isHidden = true
         let locked = Lume.Category(apiId: "3", name: "Adults", parentId: 0, type: .live, playlist: playlist)
-        locked.isRestricted = true
-        for category in [hidden, locked] {
-            ctx.insert(category)
-        }
-        try ctx.save()
 
         // Hiding is a viewer-agnostic Content Management choice; locking only
         // applies to a child profile. The two must not be conflated.
@@ -160,5 +140,20 @@ struct LiveChannelQueryTests {
         let visible = LiveChannelQuery.visibleCategories([hidden, locked], playlistPrefix: prefix, restriction: restriction)
 
         #expect(visible.map(\.id) == [locked.id])
+    }
+
+    // MARK: - containsVisible
+
+    @Test func `rail gating agrees with what the list will render`() {
+        let pid = UUID()
+        let prefix = "\(pid.uuidString)-"
+        let locked = "\(pid.uuidString)-live-locked"
+        let streams = [stream("1", playlist: pid, category: locked)]
+        let restriction = ContentRestriction(isActive: true, restrictedCategoryIDs: [locked])
+
+        // The rail must not offer Favorites when every favorite would be
+        // filtered out of the list it opens.
+        #expect(LiveChannelQuery.containsVisible(streams, playlistPrefix: prefix, restriction: restriction) == false)
+        #expect(LiveChannelQuery.containsVisible(streams, playlistPrefix: prefix, restriction: ContentRestriction()))
     }
 }

--- a/LumeTests/Services/LiveChannelQueryTests.swift
+++ b/LumeTests/Services/LiveChannelQueryTests.swift
@@ -1,0 +1,164 @@
+//
+//  LiveChannelQueryTests.swift
+//  LumeTests
+//
+//  Covers the shared scoping helpers every Live TV channel list and category
+//  rail funnels through. The parental filter lives here rather than in each
+//  view precisely so it can be tested once and cannot be forgotten by a new
+//  surface — the tvOS channel list, the in-player browser and the EPG guide all
+//  shipped without it while the iOS list had it.
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+@MainActor
+struct LiveChannelQueryTests {
+    /// An in-memory catalog so the models under test are real `LiveStream` /
+    /// `Category` instances rather than stand-ins — the helpers read `id`,
+    /// `categoryId` and `isHidden` off the models themselves.
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([
+            Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
+            Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self
+        ])
+        return try ModelContainer(
+            for: schema,
+            configurations: ModelConfiguration(schema: schema, isStoredInMemoryOnly: true, cloudKitDatabase: .none)
+        )
+    }
+
+    private func stream(_ suffix: String, playlist: UUID, category: String?) -> LiveStream {
+        LiveStream(id: "\(playlist.uuidString)-live-\(suffix)", streamId: 1, name: "Ch \(suffix)", categoryId: category)
+    }
+
+    // MARK: - scoped
+
+    @Test func `favorites scope drops channels in a locked category`() {
+        let pid = UUID()
+        let prefix = "\(pid.uuidString)-"
+        let locked = "\(pid.uuidString)-live-locked"
+        let streams = [
+            stream("1", playlist: pid, category: locked),
+            stream("2", playlist: pid, category: "\(pid.uuidString)-live-open")
+        ]
+        let restriction = ContentRestriction(isActive: true, restrictedCategoryIDs: [locked])
+
+        let kept = LiveChannelQuery.scoped(streams, scope: .favorites, playlistPrefix: prefix, restriction: restriction)
+
+        // A channel favorited *before* its category was locked is exactly the
+        // case the virtual collections leak, since they cut across categories.
+        #expect(kept.map(\.name) == ["Ch 2"])
+    }
+
+    @Test func `recently watched scope drops channels in a locked category`() {
+        let pid = UUID()
+        let prefix = "\(pid.uuidString)-"
+        let locked = "\(pid.uuidString)-live-locked"
+        let streams = [stream("1", playlist: pid, category: locked)]
+        let restriction = ContentRestriction(isActive: true, restrictedCategoryIDs: [locked])
+
+        let kept = LiveChannelQuery.scoped(streams, scope: .recentlyWatched, playlistPrefix: prefix, restriction: restriction)
+        #expect(kept.isEmpty)
+    }
+
+    @Test func `a parent profile keeps every channel`() {
+        let pid = UUID()
+        let prefix = "\(pid.uuidString)-"
+        let locked = "\(pid.uuidString)-live-locked"
+        let streams = [
+            stream("1", playlist: pid, category: locked),
+            stream("2", playlist: pid, category: "\(pid.uuidString)-live-open")
+        ]
+        // isActive false — restriction applies only while a child profile is on.
+        let restriction = ContentRestriction(isActive: false, restrictedCategoryIDs: [locked])
+
+        let kept = LiveChannelQuery.scoped(streams, scope: .favorites, playlistPrefix: prefix, restriction: restriction)
+        #expect(kept.count == 2)
+    }
+
+    @Test func `virtual scopes still isolate the active playlist`() {
+        let mine = UUID()
+        let other = UUID()
+        let streams = [
+            stream("1", playlist: mine, category: nil),
+            stream("2", playlist: other, category: nil)
+        ]
+
+        let kept = LiveChannelQuery.scoped(
+            streams, scope: .favorites, playlistPrefix: "\(mine.uuidString)-", restriction: ContentRestriction()
+        )
+        #expect(kept.map(\.name) == ["Ch 1"])
+    }
+
+    @Test func `category scope is not playlist-filtered but is still restriction-filtered`() {
+        let pid = UUID()
+        let locked = "\(pid.uuidString)-live-locked"
+        let streams = [stream("1", playlist: pid, category: locked)]
+        let restriction = ContentRestriction(isActive: true, restrictedCategoryIDs: [locked])
+
+        // Category ids are already playlist-prefixed, so the scope skips the
+        // prefix filter — but a locked category must still never render.
+        let kept = LiveChannelQuery.scoped(
+            streams, scope: .category(locked), playlistPrefix: "", restriction: restriction
+        )
+        #expect(kept.isEmpty)
+    }
+
+    // MARK: - visibleCategories
+
+    @Test func `visible categories drop hidden, locked and other playlists`() throws {
+        let container = try makeContainer()
+        let ctx = container.mainContext
+        let playlist = Playlist(name: "Mine", serverURL: "http://x", username: "u", password: "p")
+        ctx.insert(playlist)
+        let prefix = "\(playlist.id.uuidString)-"
+
+        let open = Lume.Category(apiId: "1", name: "News", parentId: 0, type: .live, playlist: playlist)
+        let hidden = Lume.Category(apiId: "2", name: "Shopping", parentId: 0, type: .live, playlist: playlist)
+        hidden.isHidden = true
+        let locked = Lume.Category(apiId: "3", name: "Adults", parentId: 0, type: .live, playlist: playlist)
+        locked.isRestricted = true
+
+        let otherPlaylist = Playlist(name: "Theirs", serverURL: "http://y", username: "u", password: "p")
+        ctx.insert(otherPlaylist)
+        let foreign = Lume.Category(apiId: "1", name: "News", parentId: 0, type: .live, playlist: otherPlaylist)
+        for category in [open, hidden, locked, foreign] {
+            ctx.insert(category)
+        }
+        try ctx.save()
+
+        let restriction = ContentRestriction(isActive: true, restrictedCategoryIDs: [locked.id])
+        let visible = LiveChannelQuery.visibleCategories(
+            [open, hidden, locked, foreign], playlistPrefix: prefix, restriction: restriction
+        )
+
+        #expect(visible.map(\.id) == [open.id])
+    }
+
+    @Test func `a parent profile still sees a locked category but never a hidden one`() throws {
+        let container = try makeContainer()
+        let ctx = container.mainContext
+        let playlist = Playlist(name: "Mine", serverURL: "http://x", username: "u", password: "p")
+        ctx.insert(playlist)
+        let prefix = "\(playlist.id.uuidString)-"
+
+        let hidden = Lume.Category(apiId: "2", name: "Shopping", parentId: 0, type: .live, playlist: playlist)
+        hidden.isHidden = true
+        let locked = Lume.Category(apiId: "3", name: "Adults", parentId: 0, type: .live, playlist: playlist)
+        locked.isRestricted = true
+        for category in [hidden, locked] {
+            ctx.insert(category)
+        }
+        try ctx.save()
+
+        // Hiding is a viewer-agnostic Content Management choice; locking only
+        // applies to a child profile. The two must not be conflated.
+        let restriction = ContentRestriction(isActive: false, restrictedCategoryIDs: [locked.id])
+        let visible = LiveChannelQuery.visibleCategories([hidden, locked], playlistPrefix: prefix, restriction: restriction)
+
+        #expect(visible.map(\.id) == [locked.id])
+    }
+}


### PR DESCRIPTION
## The problem

Locking a category in Content Management hides it from the Live TV screen. It did not hide it from three other places a viewer can reach channels from, so on a child profile the lock was largely decorative.

**The in-player channel browser (tvOS)** — `TVChannelBrowserOverlay.swift` built its category rail like this:

```swift
let descriptor = FetchDescriptor<Category>(
    predicate: #Predicate { $0.typeRaw == "live" && $0.isHidden == false }
)
```

`isHidden` only. `LiveTVView` has always done both:

```swift
categories.filter { $0.id.hasPrefix(prefix) && !restriction.hides(categoryID: $0.id) }
```

The file contained no reference to `contentRestriction` at all, despite its own header claiming it shows "the same sections the Live TV screen shows". So: a child watching any live channel presses left on the Siri Remote, sees the locked category sitting in the rail, and tunes into it without ever leaving the player. Its channel fetch was unfiltered too.

**The tvOS channel list** — `LiveTVTVComponents.swift` and its iOS twin in `LiveTVView.swift` are near-identical: same properties, same `init`, same `scopedStreams`. One line differed. The iOS copy ends with `.excludingRestricted(restriction)`; the tvOS copy doesn't have it, and had no `@Environment(\.contentRestriction)` to call it with.

**The EPG guide** — `EPGGuideView.swift`, same omission, and this one is cross-platform, so it leaks on iOS and macOS too.

The Favorites and Recently Watched collections are what make the last two reachable in practice. They cut across categories, so a channel favorited or watched *before* a parent locked its category keeps surfacing in them afterwards.

## The fix

Patching three call sites would have left the fourth to be found later — which is exactly the history here. Instead the filter moves into the two helpers every channel list and category rail already funnels through, with `restriction` as a **required** parameter:

```swift
static func scoped(_ streams: [LiveStream], scope: LiveChannelScope,
                   playlistPrefix: String, restriction: ContentRestriction) -> [LiveStream]

static func visibleCategories(_ categories: [Category],
                              playlistPrefix: String, restriction: ContentRestriction) -> [Category]
```

Not defaulted, deliberately. A new channel surface now cannot compile without deciding what the viewer is allowed to see.

That paid for itself immediately: `EPGGuideView` was not on my list when I started. The compiler surfaced it as a fourth unfiltered call site the moment the parameter became required.

`LiveTVView` keeps identical behaviour and gets slightly shorter — its inline category filter and its separate `.excludingRestricted` call are now the shared helpers.

## A distinction the helper preserves

`visibleCategories` drops hidden categories for everyone but drops locked ones only while a child profile is active. Hiding is a viewer-agnostic Content Management choice; locking is a parental rule that a parent is by definition already past. Conflating them would have made locked categories vanish from the parent's own browse, which is not what the toggle means. There's a test pinning it.

## Test plan

`LumeTests/Services/LiveChannelQueryTests.swift` — 7 new tests, all passing:

- `scoped`: Favorites and Recently Watched both drop channels from a locked category; a parent profile keeps everything; virtual scopes still isolate the active playlist; the category scope skips the prefix filter but is still restriction-filtered
- `visibleCategories`: drops hidden, locked and other-playlist categories; and for a parent profile, still drops hidden but keeps locked

Existing `ContentRestrictionTests` — 6/6 still pass.

Verified on **both** platforms, which matters here: two of the three fixes live inside `#if os(tvOS)`, so an iOS build alone never compiles them.

- iOS Simulator build: succeeds
- tvOS Simulator build: succeeds
- SwiftFormat clean; SwiftLint `--strict` clean on every changed file

One pre-existing note: `LiveTVView.swift` trips SwiftLint's 600-line `file_length` rule. It was already over at 638 lines before this change; this brings it to 637. Not addressed here — splitting it is its own change.

## Scope

Channel surfaces only. `LiveChannelNavigator` — the up/down channel surfing resolver — also ignores both `isHidden` and restrictions, so hidden channels remain in the surf order. It's a static resolver called from four engine views and needs restriction state threaded through, so it's a separate change; happy to follow up.

Independent of #160. That one makes locks *arrive* on the Apple TV; this one makes the Apple TV *honour* them. Both are needed for the feature to hold on tvOS, and they touch no common files.

Refs #11
