### PR TITLE
fix(macos): give TV Guide sources a way to be deleted

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -7515,6 +7515,58 @@
         }
       }
     },
+    "Delete this guide source" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Programmquelle löschen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar esta fuente de guía"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer cette source du guide"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina questa sorgente della guida"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この番組表ソースを削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 편성표 소스 삭제"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apagar esta fonte de guia"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除此电视指南源"
+          }
+        }
+      }
+    },
     "Describe the problem here. The diagnostic log is attached.\n\n" : {
       "localizations" : {
         "de" : {

--- a/Lume/Views/Settings/EPGSettingsView.swift
+++ b/Lume/Views/Settings/EPGSettingsView.swift
@@ -88,12 +88,7 @@ struct EPGSettingsView: View {
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(sources) { source in
-                        EPGSourceRow(source: source)
-                            .swipeActions(edge: .trailing) {
-                                if source.isManual {
-                                    Button("Delete", role: .destructive) { delete(source) }
-                                }
-                            }
+                        sourceRow(source)
                     }
                 }
 
@@ -106,6 +101,32 @@ struct EPGSettingsView: View {
                 Text("Sources")
             } footer: {
                 Text("Guide data is matched to channels across all your playlists.")
+            }
+        }
+
+        /// One source row, with a delete affordance only when the source is
+        /// deletable at all. Playlist-linked sources are regenerated from their
+        /// playlist on every reconcile, so offering to delete one would just
+        /// show it coming back.
+        ///
+        /// Manual sources carry three, because no single one covers every
+        /// platform: swipe is the iOS idiom but does nothing on macOS (AppKit
+        /// list rows have no swipe gesture), which left a custom XMLTV feed
+        /// added on a Mac with no way to remove it at all. macOS gets a visible
+        /// trash button — a context menu alone is about as discoverable as the
+        /// swipe was — and the context menu comes along for both platforms.
+        @ViewBuilder
+        func sourceRow(_ source: EPGSource) -> some View {
+            if source.isManual {
+                EPGSourceRow(source: source, onDelete: { delete(source) })
+                    .swipeActions(edge: .trailing) {
+                        Button("Delete", role: .destructive) { delete(source) }
+                    }
+                    .contextMenu {
+                        Button("Delete", role: .destructive) { delete(source) }
+                    }
+            } else {
+                EPGSourceRow(source: source)
             }
         }
 
@@ -141,8 +162,30 @@ struct EPGSettingsView: View {
 
     private struct EPGSourceRow: View {
         @Bindable var source: EPGSource
+        /// Non-nil only for deletable (manual) sources. Drives the macOS trash
+        /// button; the swipe action and context menu are applied by the caller.
+        var onDelete: (() -> Void)?
 
         var body: some View {
+            #if os(macOS)
+                HStack(spacing: 12) {
+                    toggle
+                    if let onDelete {
+                        Button(role: .destructive, action: onDelete) {
+                            Image(systemName: "trash")
+                        }
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(.red)
+                        .help("Delete this guide source")
+                        .accessibilityLabel(Text("Delete \(source.name)"))
+                    }
+                }
+            #else
+                toggle
+            #endif
+        }
+
+        private var toggle: some View {
             Toggle(isOn: $source.isEnabled) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(source.name)


### PR DESCRIPTION
## The problem

Add a custom XMLTV guide source on a Mac and there is no way to remove it from that Mac.

`EPGSettingsView` has three platform paths, and macOS falls through the gap between them:

| Platform | Delete affordance |
|---|---|
| tvOS | An explicit Delete button in each manual source's row |
| iOS | Swipe-to-delete |
| macOS | **Shares the iOS path** — so swipe only |

`.swipeActions` compiles on macOS and does nothing: AppKit-backed list rows have no swipe gesture. There was no context menu on the row either, so nothing invoked it. The `delete(_:)` action itself was fine — it simply had no trigger on one platform.

The only workaround was to delete the source on an iPhone, iPad or Apple TV and let it sync back, which is not much of a workaround for someone who only uses the Mac app.

## The fix

Manual sources now get a visible trash button on macOS, plus a context menu on both platforms. Swipe stays as the iOS idiom.

The button leads rather than the context menu because a right-click-only action is close to as undiscoverable as the swipe was — and an inline button is what tvOS has done all along, so the three platforms now agree. The context menu is a cheap addition on top and gives iOS a second route as a side effect.

The row's delete affordance is now driven by whether the source is deletable at all, rather than each call site re-checking:

```swift
@ViewBuilder
func sourceRow(_ source: EPGSource) -> some View {
    if source.isManual {
        EPGSourceRow(source: source, onDelete: { delete(source) })
            .swipeActions(edge: .trailing) { … }
            .contextMenu { … }
    } else {
        EPGSourceRow(source: source)
    }
}
```

Playlist-linked sources deliberately still offer nothing. They are regenerated from their playlist on every reconcile (`regenerateLinkedEPGSources`), so a delete would only show them reappearing — which is why the original code gated on `isManual`, and that gate is preserved.

## Test plan

This is a SwiftUI affordance with no unit-testable logic — the delete path it triggers is unchanged and already worked everywhere it could be reached. Verified by building every affected platform, since the change is platform-conditional and a single-platform build would not compile it:

- **macOS build: succeeds** (the platform being fixed)
- iOS Simulator build: succeeds
- tvOS Simulator build: succeeds
- SwiftFormat clean; SwiftLint `--strict` clean

Full `LumeTests` run for regressions: **37 failures with this change, 38 on `main` without it** — i.e. no regressions. Those failures are pre-existing and unrelated (`DTODecodingTests` and friends load JSON fixtures that aren't checked into the repo; the count drifts run to run, which points at shared state under parallel execution).

## Manual check worth doing on review

Settings › TV Guide on a Mac, with at least one custom XMLTV source and one playlist-linked source: the custom one should show a trash button and delete on click; the playlist-linked one should show neither a button nor a Delete item in its context menu.

Independent of #160, #161 and #162 — different file, any merge order.
