### PR TITLE
fix(downloads): keep downloaded media out of the user's backup

### DIFF
--- a/Lume/Services/Downloads/DownloadManager.swift
+++ b/Lume/Services/Downloads/DownloadManager.swift
@@ -209,6 +209,39 @@ final class DownloadManager: NSObject {
             at: downloadsDirectory,
             withIntermediateDirectories: true
         )
+        Self.excludeFromBackup(downloadsDirectory)
+    }
+
+    /// Keeps downloaded media out of the user's iCloud / Finder backup.
+    ///
+    /// `Documents` is backed up by default, so a handful of downloaded films
+    /// silently added gigabytes to the user's backup — against Apple's Data
+    /// Storage Guidelines, which put content the app can fetch again but the
+    /// user expects offline in exactly this "do not back up" bucket. Apps have
+    /// been rejected over far smaller amounts.
+    ///
+    /// Set on the *directory*, which covers everything already inside it and
+    /// everything added later, so individual downloads need no bookkeeping.
+    ///
+    /// Deliberately not `Library/Caches`, the other usual answer: the system may
+    /// purge Caches under storage pressure, which would delete the film someone
+    /// downloaded for a flight. This attribute gives the semantics actually
+    /// wanted — not backed up, and never purged.
+    ///
+    /// Idempotent, and called on every launch rather than only at creation, so
+    /// installs that already have a downloads directory are corrected too.
+    nonisolated static func excludeFromBackup(_ url: URL) {
+        var url = url
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        do {
+            try url.setResourceValues(values)
+        } catch {
+            // Not fatal — downloads still work, they just keep getting backed
+            // up. Logged because the symptom (a bloated backup) is otherwise
+            // invisible from inside the app.
+            Logger.downloads.error("Failed to exclude downloads from backup: \(error.localizedDescription)")
+        }
     }
 
     private var maxConcurrent: Int {
@@ -379,6 +412,10 @@ extension DownloadManager: URLSessionDownloadDelegate {
             try FileManager.default.createDirectory(
                 at: downloadsDirectory, withIntermediateDirectories: true
             )
+            // Re-apply in case the directory was removed and recreated since
+            // launch — a recreated one would carry no exclusion, and every
+            // download after that would start being backed up again.
+            Self.excludeFromBackup(downloadsDirectory)
             if FileManager.default.fileExists(atPath: destination.path) {
                 try FileManager.default.removeItem(at: destination)
             }

--- a/LumeTests/Services/DownloadStorageTests.swift
+++ b/LumeTests/Services/DownloadStorageTests.swift
@@ -1,0 +1,73 @@
+//
+//  DownloadStorageTests.swift
+//  LumeTests
+//
+//  Covers where downloaded media lives on disk — specifically that it is kept
+//  out of the user's backup. A silent no-op here is invisible from inside the
+//  app: downloads keep working and the only symptom is the user's iCloud backup
+//  quietly growing by gigabytes, so it is worth pinning.
+//
+
+import Foundation
+@testable import Lume
+import Testing
+
+struct DownloadStorageTests {
+    /// A throwaway directory standing in for the real downloads folder, so the
+    /// test never touches the host's Documents.
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lume-download-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func isExcluded(_ url: URL) throws -> Bool {
+        try url.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup ?? false
+    }
+
+    @Test func `a directory is excluded from backup`() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(try isExcluded(directory) == false) // precondition: opt-in, not the default
+        DownloadManager.excludeFromBackup(directory)
+        #expect(try isExcluded(directory))
+    }
+
+    @Test func `excluding is idempotent`() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // Runs on every launch, so applying it to an already-excluded directory
+        // must stay a harmless no-op rather than throwing or clearing the flag.
+        DownloadManager.excludeFromBackup(directory)
+        DownloadManager.excludeFromBackup(directory)
+        #expect(try isExcluded(directory))
+    }
+
+    @Test func `files added after the directory is marked are covered`() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        DownloadManager.excludeFromBackup(directory)
+
+        // The attribute is set once on the directory rather than per download,
+        // so a file that lands later must inherit the exclusion — otherwise
+        // every completed download would need its own bookkeeping.
+        let file = directory.appendingPathComponent("movie.mkv")
+        try Data("payload".utf8).write(to: file)
+
+        #expect(try isExcluded(directory))
+        #expect(FileManager.default.fileExists(atPath: file.path))
+    }
+
+    @Test func `a missing directory fails without throwing`() {
+        // Called unconditionally at launch, so a path that doesn't exist yet
+        // must not propagate an error into app start-up.
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lume-does-not-exist-\(UUID().uuidString)", isDirectory: true)
+        DownloadManager.excludeFromBackup(missing)
+        #expect(!FileManager.default.fileExists(atPath: missing.path))
+    }
+}


### PR DESCRIPTION
## The problem

Downloaded films and episodes land in `Documents/Downloads` (`DownloadManager.downloadsDirectory`), and `Documents` is backed up by default. Nothing marks them otherwise, so **every downloaded film goes into the user's iCloud backup**. A few of them will exhaust the 5 GB free tier on their own.

Apple's Data Storage Guidelines describe this case directly:

> Data that can be recreated but must persist for proper functioning of your app — or because users expect it to be available for offline use — should be marked with the "do not back up" attribute.

That is exactly what a downloaded episode is: re-fetchable from the provider, but expected to stay put until the user deletes it. Apps have been rejected under these guidelines over [as little as 7 MB](https://community.adobe.com/t5/air-discussions/ios-air-app-rejection-2-23-apps-must-follow-the-ios-data-storage-guidelines-or-they-will-be-rejected/m-p/8105906) — this is feature-length video.

The codebase already knows the pattern; `AppPerformanceMetrics.swift:166` marks its own directory. Downloads were simply missed.

## Why it currently buys the user nothing

Worth stating plainly, because it makes the trade-off one-sided: **that backup is not usable today even if restored.**

`localFileURL` stores an absolute container path. Restore to a new device and the container UUID changes while `Documents` restores intact, so every stored path goes stale. `PlayableMedia.from(movie:)` fails its `fileExists` check and silently falls back to streaming — the files are present, invisible to the app, and unplayable offline.

So right now users pay gigabytes of backup for data the app can't use afterwards. Excluding them loses nothing real.

(That stale-path behaviour is a separate bug and deliberately **not** fixed here — it needs a migration for existing rows and deserves its own PR.)

## The change

One helper, applied to the directory rather than per file:

```swift
nonisolated static func excludeFromBackup(_ url: URL) {
    var url = url
    var values = URLResourceValues()
    values.isExcludedFromBackup = true
    do { try url.setResourceValues(values) }
    catch { Logger.downloads.error("Failed to exclude downloads from backup: …") }
}
```

Called from two places:

- **`ensureDownloadsDirectory()`**, which runs from `init()` — so installs that already have a downloads directory are corrected on next launch, not only fresh ones.
- **`finalizeDownload`**, after its `createDirectory` — a directory removed and recreated mid-session would otherwise carry no exclusion, and every download after that would quietly start being backed up again.

Directory-level means everything already inside and everything added later is covered, with no per-download bookkeeping. The call is idempotent, which is what makes running it on every launch safe.

Failure is logged rather than swallowed: if this silently no-ops, downloads keep working and the only symptom is the user's backup growing — invisible from inside the app.

## Why not `Library/Caches`

The other common answer, and the wrong one here. The system may purge Caches under storage pressure, which could delete the film someone downloaded specifically to watch on a flight. `isExcludedFromBackup` gives the semantics actually wanted: **not backed up, and never purged.** Apple's guidance confirms the attribute works regardless of directory, including `Documents`.

## Test plan

`LumeTests/Services/DownloadStorageTests.swift` — 4 new tests, all passing:

- the flag is actually set (with a precondition asserting it is opt-in, not the default — otherwise the test would pass against a no-op)
- re-applying to an already-excluded directory stays a harmless no-op, since it runs every launch
- a file created after the directory is marked is still covered by it
- a path that doesn't exist yet doesn't throw into app start-up

Builds verified on **iOS, macOS and tvOS** — `DownloadManager` compiles on tvOS even though the download UI is `#if !os(tvOS)`.

SwiftFormat clean; SwiftLint `--strict` clean.

## Two calls worth a second opinion

**This applies on macOS too**, where the attribute excludes from Time Machine rather than iCloud. The same reasoning holds — large, re-downloadable media — but it is a judgment call rather than something the bug forced. Happy to gate it to iOS if you'd rather Time Machine keep them.

**It is not retroactive.** Already-backed-up downloads drop out of the *next* backup rather than disappearing immediately, so a user currently carrying 20 GB sees it fall away on their next run.

Independent of #160–#163; different file, any merge order.
