### PR TITLE
feat(player): add deinterlacing options for the Lume Engine

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -2738,6 +2738,58 @@
         }
       }
     },
+    "Always" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Immer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siempre"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toujours"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sempre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常に"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "항상"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sempre"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "始终"
+          }
+        }
+      }
+    },
     "Analyze Duration" : {
       "localizations" : {
         "de" : {
@@ -3527,6 +3579,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动"
+          }
+        }
+      }
+    },
+    "Automatic filters only streams that report interlaced frames; choose Always for providers that don't. Doubling the frame rate smooths motion at a higher cost. " : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatisch filtert nur Streams, die Interlaced-Bilder melden; wähle Immer für Anbieter, die das nicht tun. Eine verdoppelte Bildrate glättet Bewegungen bei höherem Aufwand. "
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automático solo filtra las transmisiones que informan de fotogramas entrelazados; elige Siempre para los proveedores que no lo hacen. Duplicar la frecuencia de imagen suaviza el movimiento con más coste. "
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatique ne filtre que les flux qui signalent des images entrelacées ; choisissez Toujours pour ceux qui ne le font pas. Doubler la fréquence d'images lisse le mouvement, à un coût plus élevé. "
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatico filtra solo i flussi che segnalano fotogrammi interlacciati; scegli Sempre per i provider che non lo fanno. Raddoppiare la frequenza dei fotogrammi rende il movimento più fluido a costo maggiore. "
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「自動」はインターレースフレームを報告するストリームのみを処理します。報告しないプロバイダーには「常に」を選んでください。フレームレートを2倍にすると動きは滑らかになりますが、負荷は高くなります。 "
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'자동'은 인터레이스 프레임을 보고하는 스트림만 처리하며, 보고하지 않는 제공자에는 '항상'을 선택하세요. 프레임 속도를 2배로 하면 움직임이 부드러워지지만 부하가 커집니다. "
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automático filtra apenas as transmissões que informam quadros entrelaçados; escolha Sempre para provedores que não informam. Dobrar a taxa de quadros suaviza o movimento a um custo maior. "
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“自动”仅处理报告隔行帧的流；对于不报告的服务商，请选择“始终”。将帧率翻倍可让画面更流畅，但开销更大。 "
           }
         }
       }
@@ -7357,6 +7461,58 @@
         }
       }
     },
+    "Deinterlace" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deinterlacing"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desentrelazado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désentrelacement"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deinterlacciamento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インターレース解除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "디인터레이스"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desentrelaçamento"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去隔行"
+          }
+        }
+      }
+    },
     "Deinterlace Mode" : {
       "comment" : "A label displayed above a picker for selecting the deinterlace mode.",
       "isCommentAutoGenerated" : true,
@@ -7459,6 +7615,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "去隔行视频"
+          }
+        }
+      }
+    },
+    "Deinterlacing removes the combing interlaced broadcasts — most live sport — show on motion, without giving up hardware decoding. " : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deinterlacing entfernt die Kammartefakte, die Interlaced-Sendungen – die meisten Live-Sportübertragungen – bei Bewegung zeigen, ohne die Hardware-Dekodierung aufzugeben. "
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El desentrelazado elimina el efecto peine que las emisiones entrelazadas —la mayoría del deporte en directo— muestran en movimiento, sin renunciar a la decodificación por hardware. "
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le désentrelacement supprime le peignage que les diffusions entrelacées — la plupart des sports en direct — montrent sur les mouvements, sans renoncer au décodage matériel. "
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il deinterlacciamento elimina l'effetto pettine che le trasmissioni interlacciate — la maggior parte dello sport in diretta — mostrano in movimento, senza rinunciare alla decodifica hardware. "
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インターレース解除は、インターレース放送（ライブスポーツの多く）が動きで見せる櫛状のノイズを、ハードウェアデコードを手放すことなく取り除きます。 "
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "디인터레이스는 인터레이스 방송(대부분의 라이브 스포츠)이 움직임에서 보이는 빗살 무늬를 하드웨어 디코딩을 포기하지 않고 제거합니다. "
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O desentrelaçamento remove o efeito de pente que as transmissões entrelaçadas — a maior parte dos esportes ao vivo — mostram em movimento, sem abrir mão da decodificação por hardware. "
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去隔行可消除隔行扫描节目（大多数体育直播）在运动时出现的锯齿状条纹，同时不必放弃硬件解码。 "
           }
         }
       }
@@ -8292,6 +8500,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "完成"
+          }
+        }
+      }
+    },
+    "Doubled" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verdoppelt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplicada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doublée"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raddoppiata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2倍"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2배"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duplicada"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "翻倍"
           }
         }
       }
@@ -12079,6 +12339,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "强制高级版"
+          }
+        }
+      }
+    },
+    "Frame Rate" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildrate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frecuencia de imagen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fréquence d'images"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frequenza fotogrammi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フレームレート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "프레임 속도"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taxa de Quadros"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帧率"
           }
         }
       }
@@ -21859,6 +22171,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "OpenSubtitles 返回了意外的响应。"
+          }
+        }
+      }
+    },
+    "Original" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Original"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Original"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Originale"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Originale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "元のまま"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "원본"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Original"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原始"
           }
         }
       }

--- a/Lume/Services/Player/PlayerEngineOptions.swift
+++ b/Lume/Services/Player/PlayerEngineOptions.swift
@@ -174,6 +174,55 @@ enum KSMaxBufferPreset {
 
 // MARK: - Lume Engine choices
 
+/// When the Lume Engine runs its deinterlacer. Unlike VLCKit's toggle, leaving
+/// this on costs nothing for progressive streams and does not give up hardware
+/// decoding for interlaced ones — the engine downloads VideoToolbox frames and
+/// filters them, rather than falling back to a software decoder.
+enum LumeDeinterlaceMode: String, CaseIterable, Identifiable {
+    /// Show fields woven, as the stream carries them.
+    case off
+    /// Filter once the decoder reports interlaced frames.
+    case auto
+    /// Filter regardless of what the stream claims — for IPTV transcoders that
+    /// ship interlaced content without flagging it.
+    case always
+
+    static let defaultValue: LumeDeinterlaceMode = .auto
+
+    var id: String {
+        rawValue
+    }
+
+    var label: String {
+        switch self {
+        case .off: String(localized: "Off")
+        case .auto: String(localized: "Automatic")
+        case .always: String(localized: "Always")
+        }
+    }
+}
+
+/// How many frames the Lume Engine's deinterlacer emits per interlaced frame.
+enum LumeDeinterlaceRate: String, CaseIterable, Identifiable {
+    /// One frame per field: 1080i50 becomes 1080p50.
+    case field
+    /// One frame per input frame: 1080i50 becomes 1080p25.
+    case frame
+
+    static let defaultValue: LumeDeinterlaceRate = .field
+
+    var id: String {
+        rawValue
+    }
+
+    var label: String {
+        switch self {
+        case .field: String(localized: "Doubled")
+        case .frame: String(localized: "Original")
+        }
+    }
+}
+
 /// Buffer-target presets (milliseconds of decoded media held before playback
 /// starts or resumes) offered for the Lume Engine's live and on-demand streams.
 enum LumeBufferPreset {
@@ -382,6 +431,8 @@ struct KSPlayerOptions {
 /// builds its `PlayerConfiguration`.
 struct LumeEngineOptions {
     var hardwareDecode: Bool
+    var deinterlaceMode: LumeDeinterlaceMode
+    var deinterlaceRate: LumeDeinterlaceRate
     var httpReconnect: Bool
     /// Buffer targets before starting/resuming playback, in milliseconds.
     var liveBuffer: Int
@@ -401,8 +452,12 @@ struct LumeEngineOptions {
         let ioTimeout = LumeIOTimeout(rawValue: defaults.integer(PlayerSettings.Lume.ioTimeoutKey, default: LumeIOTimeout.defaultValue.rawValue)) ?? .defaultValue
         let probeSize = LumeProbeSize(rawValue: defaults.integer(PlayerSettings.Lume.probeSizeKey, default: LumeProbeSize.auto.rawValue)) ?? .auto
         let analyzeDuration = LumeAnalyzeDuration(rawValue: defaults.integer(PlayerSettings.Lume.analyzeDurationKey, default: LumeAnalyzeDuration.auto.rawValue)) ?? .auto
+        let deinterlaceMode = LumeDeinterlaceMode(rawValue: defaults.string(forKey: PlayerSettings.Lume.deinterlaceModeKey) ?? "") ?? .defaultValue
+        let deinterlaceRate = LumeDeinterlaceRate(rawValue: defaults.string(forKey: PlayerSettings.Lume.deinterlaceRateKey) ?? "") ?? .defaultValue
         return LumeEngineOptions(
             hardwareDecode: defaults.bool(PlayerSettings.Lume.hardwareDecodeKey, default: PlayerSettings.Lume.hardwareDecodeDefault),
+            deinterlaceMode: deinterlaceMode,
+            deinterlaceRate: deinterlaceRate,
             httpReconnect: defaults.bool(PlayerSettings.Lume.httpReconnectKey, default: PlayerSettings.Lume.httpReconnectDefault),
             liveBuffer: defaults.integer(PlayerSettings.Lume.liveBufferKey, default: PlayerSettings.Lume.liveBufferDefault),
             vodBuffer: defaults.integer(PlayerSettings.Lume.vodBufferKey, default: PlayerSettings.Lume.vodBufferDefault),

--- a/Lume/Services/Player/PlayerSettings.swift
+++ b/Lume/Services/Player/PlayerSettings.swift
@@ -296,6 +296,8 @@ enum PlayerSettings {
     /// everything else.
     enum Lume {
         static let hardwareDecodeKey = "player.lume.hardwareDecode"
+        static let deinterlaceModeKey = "player.lume.deinterlaceMode"
+        static let deinterlaceRateKey = "player.lume.deinterlaceRate"
         static let httpReconnectKey = "player.lume.httpReconnect"
         static let liveBufferKey = "player.lume.liveBuffer"
         static let vodBufferKey = "player.lume.vodBuffer"
@@ -324,7 +326,8 @@ enum PlayerSettings {
         /// values so each `@AppStorage` binding reverts to its default.
         static var allKeys: [String] {
             [
-                hardwareDecodeKey, httpReconnectKey, liveBufferKey, vodBufferKey,
+                hardwareDecodeKey, deinterlaceModeKey, deinterlaceRateKey,
+                httpReconnectKey, liveBufferKey, vodBufferKey,
                 videoQueueDepthKey, audioQueueDepthKey, stallThresholdKey,
                 ioTimeoutKey, probeSizeKey, analyzeDurationKey
             ]

--- a/Lume/Views/Player/LumeEngineCoordinator.swift
+++ b/Lume/Views/Player/LumeEngineCoordinator.swift
@@ -20,7 +20,9 @@ final class SubtitleCueModel: ObservableObject {
     /// Assigns only on an actual change, so an unchanged cue repeated across
     /// ticks doesn't invalidate the leaf ten times a second.
     func update(_ newText: String?) {
-        if text != newText { text = newText }
+        if text != newText {
+            text = newText
+        }
     }
 }
 
@@ -261,7 +263,9 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
         let session = session
         let index = id.flatMap(Int32.init)
         Task { await session?.selectSubtitleTrack(index) }
-        if id == nil { subtitleCues.update(nil) }
+        if id == nil {
+            subtitleCues.update(nil)
+        }
         if let info = mediaInfo {
             publishTracks(info: info)
         }
@@ -281,6 +285,7 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
             configuration.startPosition = media.startTime
         }
         configuration.hardwareDecode = options.hardwareDecode ? .videoToolbox : .software
+        configuration.deinterlace = Self.deinterlacing(for: options)
         configuration.bufferTarget = Double(media.isLive ? options.liveBuffer : options.vodBuffer) / 1000
         configuration.videoQueueDepth = options.videoQueueDepth
         configuration.audioQueueDepth = options.audioQueueDepth
@@ -297,6 +302,22 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
             configuration.demuxer.maxAnalyzeDuration = analyzeDuration
         }
         return configuration
+    }
+
+    /// Translates the stored deinterlace choices into the engine's policy.
+    /// Kept out of `makeConfiguration` so it stays a pure mapping between two
+    /// vocabularies — Lume's settings on one side, the engine's on the other.
+    private static func deinterlacing(for options: LumeEngineOptions) -> VideoDecoder.Deinterlacing {
+        let mode: VideoDecoder.Deinterlacing.Mode = switch options.deinterlaceMode {
+        case .off: .off
+        case .auto: .auto
+        case .always: .always
+        }
+        let rate: VideoDecoder.Deinterlacing.Rate = switch options.deinterlaceRate {
+        case .field: .field
+        case .frame: .frame
+        }
+        return VideoDecoder.Deinterlacing(mode: mode, rate: rate)
     }
 
     private func handle(event: PlayerEvent) {
@@ -403,7 +424,9 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
     }
 
     private func trackLabel(_ track: TrackInfo, fallback: String) -> String {
-        if let title = track.title, !title.isEmpty { return title }
+        if let title = track.title, !title.isEmpty {
+            return title
+        }
         if let language = track.language, !language.isEmpty {
             return Locale.current.localizedString(forLanguageCode: language) ?? language
         }
@@ -446,7 +469,9 @@ extension LumeEngineCoordinator: ExternalSubtitleLoading {
     /// the menu rather than left selected but silent.
     private func loadExternalSubtitleFile(_ subtitle: ExternalSubtitle) {
         subtitleCues.update(nil)
-        if let info = mediaInfo { publishTracks(info: info) }
+        if let info = mediaInfo {
+            publishTracks(info: info)
+        }
         let session = session
         Task {
             do {
@@ -455,7 +480,9 @@ extension LumeEngineCoordinator: ExternalSubtitleLoading {
                 Logger.player.error("LumeEngine could not load external subtitles: \(LogRedaction.describe(error), privacy: .public)")
                 self.externalSubtitle = nil
                 self.selectedSubtitleID = nil
-                if let info = self.mediaInfo { self.publishTracks(info: info) }
+                if let info = self.mediaInfo {
+                    self.publishTracks(info: info)
+                }
             }
         }
     }

--- a/Lume/Views/Settings/LumeEngineSettingsViews.swift
+++ b/Lume/Views/Settings/LumeEngineSettingsViews.swift
@@ -1,0 +1,208 @@
+//
+//  LumeEngineSettingsViews.swift
+//  Lume
+//
+//  The Lume Engine's option surface in Settings, split out of
+//  `PlayerEngineSettingsViews.swift` so the shared file stays under the
+//  file-length limit. Same two presentations as the other engines: a grouped
+//  `Form` section for iOS/macOS and the flat Apple-TV-style detail block for
+//  tvOS.
+//
+//  Every control is backed directly by `@AppStorage`, read back by the
+//  coordinator through `LumeEngineOptions` the next time a stream starts.
+//
+
+import SwiftUI
+
+// MARK: - iOS / macOS form
+
+#if !os(tvOS)
+
+    /// Lume Engine options as a grouped `Form` section.
+    struct LumeEngineSettingsForm: View {
+        @AppStorage(PlayerSettings.Lume.hardwareDecodeKey) private var hardwareDecode = PlayerSettings.Lume.hardwareDecodeDefault
+        @AppStorage(PlayerSettings.Lume.deinterlaceModeKey) private var deinterlaceMode = LumeDeinterlaceMode.defaultValue.rawValue
+        @AppStorage(PlayerSettings.Lume.deinterlaceRateKey) private var deinterlaceRate = LumeDeinterlaceRate.defaultValue.rawValue
+        @AppStorage(PlayerSettings.Lume.httpReconnectKey) private var httpReconnect = PlayerSettings.Lume.httpReconnectDefault
+        @AppStorage(PlayerSettings.Lume.liveBufferKey) private var liveBuffer = PlayerSettings.Lume.liveBufferDefault
+        @AppStorage(PlayerSettings.Lume.vodBufferKey) private var vodBuffer = PlayerSettings.Lume.vodBufferDefault
+        @AppStorage(PlayerSettings.Lume.videoQueueDepthKey) private var videoQueueDepth = PlayerSettings.Lume.videoQueueDepthDefault
+        @AppStorage(PlayerSettings.Lume.audioQueueDepthKey) private var audioQueueDepth = PlayerSettings.Lume.audioQueueDepthDefault
+        @AppStorage(PlayerSettings.Lume.stallThresholdKey) private var stallThreshold = PlayerSettings.Lume.stallThresholdDefault
+        @AppStorage(PlayerSettings.Lume.ioTimeoutKey) private var ioTimeout = LumeIOTimeout.defaultValue.rawValue
+        @AppStorage(PlayerSettings.Lume.probeSizeKey) private var probeSize = LumeProbeSize.auto.rawValue
+        @AppStorage(PlayerSettings.Lume.analyzeDurationKey) private var analyzeDuration = LumeAnalyzeDuration.auto.rawValue
+
+        @State private var showResetConfirmation = false
+
+        var body: some View {
+            Section {
+                Toggle("Hardware Decoding", isOn: $hardwareDecode)
+
+                Picker("Deinterlace", selection: $deinterlaceMode) {
+                    ForEach(LumeDeinterlaceMode.allCases) { Text($0.label).tag($0.rawValue) }
+                }
+                if deinterlaceMode != LumeDeinterlaceMode.off.rawValue {
+                    Picker("Frame Rate", selection: $deinterlaceRate) {
+                        ForEach(LumeDeinterlaceRate.allCases) { Text($0.label).tag($0.rawValue) }
+                    }
+                }
+
+                Picker("Video Queue Depth", selection: $videoQueueDepth) {
+                    ForEach(LumeVideoQueuePreset.values, id: \.self) { Text(LumeVideoQueuePreset.label($0)).tag($0) }
+                }
+                Picker("Audio Queue Depth", selection: $audioQueueDepth) {
+                    ForEach(LumeAudioQueuePreset.values, id: \.self) { Text(LumeAudioQueuePreset.label($0)).tag($0) }
+                }
+
+                Toggle("HTTP Reconnect", isOn: $httpReconnect)
+
+                Picker("Live Buffer", selection: $liveBuffer) {
+                    ForEach(LumeBufferPreset.values, id: \.self) { Text(LumeBufferPreset.label($0)).tag($0) }
+                }
+                Picker("On-Demand Buffer", selection: $vodBuffer) {
+                    ForEach(LumeBufferPreset.values, id: \.self) { Text(LumeBufferPreset.label($0)).tag($0) }
+                }
+
+                Picker("Stall Detection", selection: $stallThreshold) {
+                    ForEach(LumeStallThresholdPreset.values, id: \.self) { Text(LumeStallThresholdPreset.label($0)).tag($0) }
+                }
+                Picker("Network Timeout", selection: $ioTimeout) {
+                    ForEach(LumeIOTimeout.allCases) { Text($0.label).tag($0.rawValue) }
+                }
+
+                Picker("Probe Size", selection: $probeSize) {
+                    ForEach(LumeProbeSize.allCases) { Text($0.label).tag($0.rawValue) }
+                }
+                Picker("Analyze Duration", selection: $analyzeDuration) {
+                    ForEach(LumeAnalyzeDuration.allCases) { Text($0.label).tag($0.rawValue) }
+                }
+            } footer: {
+                Text("Deinterlacing removes the combing interlaced broadcasts — most live sport — show on motion, without giving up hardware decoding. ")
+                    + Text("Automatic filters only streams that report interlaced frames; choose Always for providers that don't. Doubling the frame rate smooths motion at a higher cost. ")
+                    + Text("The buffers set how much decoded media is held before playback starts or resumes — raise them if high-bitrate 4K streams stutter. ")
+                    + Text("Queue depths trade memory for smoothness: decoded 4K video frames are large, so raise the video queue cautiously. Applied the next time playback starts.")
+            }
+
+            Section {
+                Button("Restore Defaults", role: .destructive) {
+                    showResetConfirmation = true
+                }
+            }
+            .confirmationDialog(
+                "Restore the default Lume Engine options?",
+                isPresented: $showResetConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Restore Defaults", role: .destructive) {
+                    PlayerSettings.Lume.resetToDefaults()
+                }
+                Button("Cancel", role: .cancel) {}
+            }
+        }
+    }
+
+    /// Dedicated screen wrapping the Lume Engine options, pushed from the Player
+    /// settings section so every engine's options are reachable regardless of
+    /// the priority order.
+    struct LumeEngineSettingsScreen: View {
+        var body: some View {
+            Form {
+                LumeEngineSettingsForm()
+            }
+            .platformNavigationTitle("Lume Engine Options")
+        }
+    }
+
+#endif
+
+// MARK: - tvOS detail
+
+#if os(tvOS)
+
+    /// Lume Engine options for the tvOS settings detail pane.
+    struct LumeEngineSettingsTVDetail: View {
+        @AppStorage(PlayerSettings.Lume.hardwareDecodeKey) private var hardwareDecode = PlayerSettings.Lume.hardwareDecodeDefault
+        @AppStorage(PlayerSettings.Lume.deinterlaceModeKey) private var deinterlaceMode = LumeDeinterlaceMode.defaultValue.rawValue
+        @AppStorage(PlayerSettings.Lume.deinterlaceRateKey) private var deinterlaceRate = LumeDeinterlaceRate.defaultValue.rawValue
+        @AppStorage(PlayerSettings.Lume.httpReconnectKey) private var httpReconnect = PlayerSettings.Lume.httpReconnectDefault
+        @AppStorage(PlayerSettings.Lume.liveBufferKey) private var liveBuffer = PlayerSettings.Lume.liveBufferDefault
+        @AppStorage(PlayerSettings.Lume.vodBufferKey) private var vodBuffer = PlayerSettings.Lume.vodBufferDefault
+        @AppStorage(PlayerSettings.Lume.videoQueueDepthKey) private var videoQueueDepth = PlayerSettings.Lume.videoQueueDepthDefault
+        @AppStorage(PlayerSettings.Lume.audioQueueDepthKey) private var audioQueueDepth = PlayerSettings.Lume.audioQueueDepthDefault
+        @AppStorage(PlayerSettings.Lume.stallThresholdKey) private var stallThreshold = PlayerSettings.Lume.stallThresholdDefault
+        @AppStorage(PlayerSettings.Lume.ioTimeoutKey) private var ioTimeout = LumeIOTimeout.defaultValue.rawValue
+        @AppStorage(PlayerSettings.Lume.probeSizeKey) private var probeSize = LumeProbeSize.auto.rawValue
+        @AppStorage(PlayerSettings.Lume.analyzeDurationKey) private var analyzeDuration = LumeAnalyzeDuration.auto.rawValue
+
+        @State private var showResetConfirmation = false
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 28) {
+                VStack(alignment: .leading, spacing: 8) {
+                    TVSettingsSectionLabel("Lume Engine — Decoding")
+                    TVOptionToggleRow(title: "Hardware Decoding", isOn: $hardwareDecode)
+                    TVOptionCycleRow(
+                        title: "Deinterlace",
+                        valueLabel: (LumeDeinterlaceMode(rawValue: deinterlaceMode) ?? .defaultValue).label
+                    ) { deinterlaceMode = PlayerOptionCycle.next(deinterlaceMode, in: LumeDeinterlaceMode.self) }
+                    if deinterlaceMode != LumeDeinterlaceMode.off.rawValue {
+                        TVOptionCycleRow(
+                            title: "Frame Rate",
+                            valueLabel: (LumeDeinterlaceRate(rawValue: deinterlaceRate) ?? .defaultValue).label
+                        ) { deinterlaceRate = PlayerOptionCycle.next(deinterlaceRate, in: LumeDeinterlaceRate.self) }
+                    }
+                    TVOptionCycleRow(title: "Video Queue Depth", valueLabel: LumeVideoQueuePreset.label(videoQueueDepth)) {
+                        videoQueueDepth = PlayerOptionCycle.next(videoQueueDepth, in: LumeVideoQueuePreset.values)
+                    }
+                    TVOptionCycleRow(title: "Audio Queue Depth", valueLabel: LumeAudioQueuePreset.label(audioQueueDepth)) {
+                        audioQueueDepth = PlayerOptionCycle.next(audioQueueDepth, in: LumeAudioQueuePreset.values)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    TVSettingsSectionLabel("Lume Engine — Network & Buffering")
+                    TVOptionToggleRow(title: "HTTP Reconnect", isOn: $httpReconnect)
+                    TVOptionCycleRow(title: "Live Buffer", valueLabel: LumeBufferPreset.label(liveBuffer)) {
+                        liveBuffer = PlayerOptionCycle.next(liveBuffer, in: LumeBufferPreset.values)
+                    }
+                    TVOptionCycleRow(title: "On-Demand Buffer", valueLabel: LumeBufferPreset.label(vodBuffer)) {
+                        vodBuffer = PlayerOptionCycle.next(vodBuffer, in: LumeBufferPreset.values)
+                    }
+                    TVOptionCycleRow(title: "Stall Detection", valueLabel: LumeStallThresholdPreset.label(stallThreshold)) {
+                        stallThreshold = PlayerOptionCycle.next(stallThreshold, in: LumeStallThresholdPreset.values)
+                    }
+                    TVOptionCycleRow(
+                        title: "Network Timeout",
+                        valueLabel: (LumeIOTimeout(rawValue: ioTimeout) ?? .defaultValue).label
+                    ) { ioTimeout = PlayerOptionCycle.next(ioTimeout, in: LumeIOTimeout.self) }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    TVSettingsSectionLabel("Lume Engine — Stream Analysis")
+                    TVOptionCycleRow(
+                        title: "Probe Size",
+                        valueLabel: (LumeProbeSize(rawValue: probeSize) ?? .auto).label
+                    ) { probeSize = PlayerOptionCycle.next(probeSize, in: LumeProbeSize.self) }
+                    TVOptionCycleRow(
+                        title: "Analyze Duration",
+                        valueLabel: (LumeAnalyzeDuration(rawValue: analyzeDuration) ?? .auto).label
+                    ) { analyzeDuration = PlayerOptionCycle.next(analyzeDuration, in: LumeAnalyzeDuration.self) }
+                }
+
+                TVOptionResetRow(title: "Restore Defaults") { showResetConfirmation = true }
+            }
+            .confirmationDialog(
+                "Restore the default Lume Engine options?",
+                isPresented: $showResetConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Restore Defaults", role: .destructive) {
+                    PlayerSettings.Lume.resetToDefaults()
+                }
+                Button("Cancel", role: .cancel) {}
+            }
+        }
+    }
+
+#endif

--- a/Lume/Views/Settings/PlayerEngineSettingsViews.swift
+++ b/Lume/Views/Settings/PlayerEngineSettingsViews.swift
@@ -7,6 +7,10 @@
 //  priority order. Two presentations share this file: grouped `Form` sections
 //  for iOS/macOS, and the flat Apple-TV-style detail blocks for tvOS.
 //
+//  The Lume Engine's own surfaces live in `LumeEngineSettingsViews.swift` —
+//  this file was at the file-length limit — but the shared `TVOption*` rows and
+//  `PlayerOptionCycle` they use are still defined here.
+//
 //  Every control is backed directly by `@AppStorage`, so changes persist
 //  immediately and are read back by the engines via `VLCPlayerOptions` /
 //  `KSPlayerOptions` the next time a stream starts.
@@ -183,89 +187,6 @@ import SwiftUI
                 KSEngineSettingsForm()
             }
             .platformNavigationTitle("KSPlayer Options")
-        }
-    }
-
-    /// Lume Engine options as a grouped `Form` section.
-    struct LumeEngineSettingsForm: View {
-        @AppStorage(PlayerSettings.Lume.hardwareDecodeKey) private var hardwareDecode = PlayerSettings.Lume.hardwareDecodeDefault
-        @AppStorage(PlayerSettings.Lume.httpReconnectKey) private var httpReconnect = PlayerSettings.Lume.httpReconnectDefault
-        @AppStorage(PlayerSettings.Lume.liveBufferKey) private var liveBuffer = PlayerSettings.Lume.liveBufferDefault
-        @AppStorage(PlayerSettings.Lume.vodBufferKey) private var vodBuffer = PlayerSettings.Lume.vodBufferDefault
-        @AppStorage(PlayerSettings.Lume.videoQueueDepthKey) private var videoQueueDepth = PlayerSettings.Lume.videoQueueDepthDefault
-        @AppStorage(PlayerSettings.Lume.audioQueueDepthKey) private var audioQueueDepth = PlayerSettings.Lume.audioQueueDepthDefault
-        @AppStorage(PlayerSettings.Lume.stallThresholdKey) private var stallThreshold = PlayerSettings.Lume.stallThresholdDefault
-        @AppStorage(PlayerSettings.Lume.ioTimeoutKey) private var ioTimeout = LumeIOTimeout.defaultValue.rawValue
-        @AppStorage(PlayerSettings.Lume.probeSizeKey) private var probeSize = LumeProbeSize.auto.rawValue
-        @AppStorage(PlayerSettings.Lume.analyzeDurationKey) private var analyzeDuration = LumeAnalyzeDuration.auto.rawValue
-
-        @State private var showResetConfirmation = false
-
-        var body: some View {
-            Section {
-                Toggle("Hardware Decoding", isOn: $hardwareDecode)
-
-                Picker("Video Queue Depth", selection: $videoQueueDepth) {
-                    ForEach(LumeVideoQueuePreset.values, id: \.self) { Text(LumeVideoQueuePreset.label($0)).tag($0) }
-                }
-                Picker("Audio Queue Depth", selection: $audioQueueDepth) {
-                    ForEach(LumeAudioQueuePreset.values, id: \.self) { Text(LumeAudioQueuePreset.label($0)).tag($0) }
-                }
-
-                Toggle("HTTP Reconnect", isOn: $httpReconnect)
-
-                Picker("Live Buffer", selection: $liveBuffer) {
-                    ForEach(LumeBufferPreset.values, id: \.self) { Text(LumeBufferPreset.label($0)).tag($0) }
-                }
-                Picker("On-Demand Buffer", selection: $vodBuffer) {
-                    ForEach(LumeBufferPreset.values, id: \.self) { Text(LumeBufferPreset.label($0)).tag($0) }
-                }
-
-                Picker("Stall Detection", selection: $stallThreshold) {
-                    ForEach(LumeStallThresholdPreset.values, id: \.self) { Text(LumeStallThresholdPreset.label($0)).tag($0) }
-                }
-                Picker("Network Timeout", selection: $ioTimeout) {
-                    ForEach(LumeIOTimeout.allCases) { Text($0.label).tag($0.rawValue) }
-                }
-
-                Picker("Probe Size", selection: $probeSize) {
-                    ForEach(LumeProbeSize.allCases) { Text($0.label).tag($0.rawValue) }
-                }
-                Picker("Analyze Duration", selection: $analyzeDuration) {
-                    ForEach(LumeAnalyzeDuration.allCases) { Text($0.label).tag($0.rawValue) }
-                }
-            } footer: {
-                Text("The buffers set how much decoded media is held before playback starts or resumes — raise them if high-bitrate 4K streams stutter. ")
-                    + Text("Queue depths trade memory for smoothness: decoded 4K video frames are large, so raise the video queue cautiously. Applied the next time playback starts.")
-            }
-
-            Section {
-                Button("Restore Defaults", role: .destructive) {
-                    showResetConfirmation = true
-                }
-            }
-            .confirmationDialog(
-                "Restore the default Lume Engine options?",
-                isPresented: $showResetConfirmation,
-                titleVisibility: .visible
-            ) {
-                Button("Restore Defaults", role: .destructive) {
-                    PlayerSettings.Lume.resetToDefaults()
-                }
-                Button("Cancel", role: .cancel) {}
-            }
-        }
-    }
-
-    /// Dedicated screen wrapping the Lume Engine options, pushed from the Player
-    /// settings section so every engine's options are reachable regardless of
-    /// the priority order.
-    struct LumeEngineSettingsScreen: View {
-        var body: some View {
-            Form {
-                LumeEngineSettingsForm()
-            }
-            .platformNavigationTitle("Lume Engine Options")
         }
     }
 
@@ -457,79 +378,6 @@ import SwiftUI
             ) {
                 Button("Restore Defaults", role: .destructive) {
                     PlayerSettings.KSPlayer.resetToDefaults()
-                }
-                Button("Cancel", role: .cancel) {}
-            }
-        }
-    }
-
-    /// Lume Engine options for the tvOS settings detail pane.
-    struct LumeEngineSettingsTVDetail: View {
-        @AppStorage(PlayerSettings.Lume.hardwareDecodeKey) private var hardwareDecode = PlayerSettings.Lume.hardwareDecodeDefault
-        @AppStorage(PlayerSettings.Lume.httpReconnectKey) private var httpReconnect = PlayerSettings.Lume.httpReconnectDefault
-        @AppStorage(PlayerSettings.Lume.liveBufferKey) private var liveBuffer = PlayerSettings.Lume.liveBufferDefault
-        @AppStorage(PlayerSettings.Lume.vodBufferKey) private var vodBuffer = PlayerSettings.Lume.vodBufferDefault
-        @AppStorage(PlayerSettings.Lume.videoQueueDepthKey) private var videoQueueDepth = PlayerSettings.Lume.videoQueueDepthDefault
-        @AppStorage(PlayerSettings.Lume.audioQueueDepthKey) private var audioQueueDepth = PlayerSettings.Lume.audioQueueDepthDefault
-        @AppStorage(PlayerSettings.Lume.stallThresholdKey) private var stallThreshold = PlayerSettings.Lume.stallThresholdDefault
-        @AppStorage(PlayerSettings.Lume.ioTimeoutKey) private var ioTimeout = LumeIOTimeout.defaultValue.rawValue
-        @AppStorage(PlayerSettings.Lume.probeSizeKey) private var probeSize = LumeProbeSize.auto.rawValue
-        @AppStorage(PlayerSettings.Lume.analyzeDurationKey) private var analyzeDuration = LumeAnalyzeDuration.auto.rawValue
-
-        @State private var showResetConfirmation = false
-
-        var body: some View {
-            VStack(alignment: .leading, spacing: 28) {
-                VStack(alignment: .leading, spacing: 8) {
-                    TVSettingsSectionLabel("Lume Engine — Decoding")
-                    TVOptionToggleRow(title: "Hardware Decoding", isOn: $hardwareDecode)
-                    TVOptionCycleRow(title: "Video Queue Depth", valueLabel: LumeVideoQueuePreset.label(videoQueueDepth)) {
-                        videoQueueDepth = PlayerOptionCycle.next(videoQueueDepth, in: LumeVideoQueuePreset.values)
-                    }
-                    TVOptionCycleRow(title: "Audio Queue Depth", valueLabel: LumeAudioQueuePreset.label(audioQueueDepth)) {
-                        audioQueueDepth = PlayerOptionCycle.next(audioQueueDepth, in: LumeAudioQueuePreset.values)
-                    }
-                }
-
-                VStack(alignment: .leading, spacing: 8) {
-                    TVSettingsSectionLabel("Lume Engine — Network & Buffering")
-                    TVOptionToggleRow(title: "HTTP Reconnect", isOn: $httpReconnect)
-                    TVOptionCycleRow(title: "Live Buffer", valueLabel: LumeBufferPreset.label(liveBuffer)) {
-                        liveBuffer = PlayerOptionCycle.next(liveBuffer, in: LumeBufferPreset.values)
-                    }
-                    TVOptionCycleRow(title: "On-Demand Buffer", valueLabel: LumeBufferPreset.label(vodBuffer)) {
-                        vodBuffer = PlayerOptionCycle.next(vodBuffer, in: LumeBufferPreset.values)
-                    }
-                    TVOptionCycleRow(title: "Stall Detection", valueLabel: LumeStallThresholdPreset.label(stallThreshold)) {
-                        stallThreshold = PlayerOptionCycle.next(stallThreshold, in: LumeStallThresholdPreset.values)
-                    }
-                    TVOptionCycleRow(
-                        title: "Network Timeout",
-                        valueLabel: (LumeIOTimeout(rawValue: ioTimeout) ?? .defaultValue).label
-                    ) { ioTimeout = PlayerOptionCycle.next(ioTimeout, in: LumeIOTimeout.self) }
-                }
-
-                VStack(alignment: .leading, spacing: 8) {
-                    TVSettingsSectionLabel("Lume Engine — Stream Analysis")
-                    TVOptionCycleRow(
-                        title: "Probe Size",
-                        valueLabel: (LumeProbeSize(rawValue: probeSize) ?? .auto).label
-                    ) { probeSize = PlayerOptionCycle.next(probeSize, in: LumeProbeSize.self) }
-                    TVOptionCycleRow(
-                        title: "Analyze Duration",
-                        valueLabel: (LumeAnalyzeDuration(rawValue: analyzeDuration) ?? .auto).label
-                    ) { analyzeDuration = PlayerOptionCycle.next(analyzeDuration, in: LumeAnalyzeDuration.self) }
-                }
-
-                TVOptionResetRow(title: "Restore Defaults") { showResetConfirmation = true }
-            }
-            .confirmationDialog(
-                "Restore the default Lume Engine options?",
-                isPresented: $showResetConfirmation,
-                titleVisibility: .visible
-            ) {
-                Button("Restore Defaults", role: .destructive) {
-                    PlayerSettings.Lume.resetToDefaults()
                 }
                 Button("Cancel", role: .cancel) {}
             }

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ available on the platform).
 | **VLCKit** | VLCKit 4 (libVLC) | Maximum compatibility | Virtually any format/codec, hardware-accelerated 4K HDR, Picture in Picture, broadest IPTV support |
 | **KSPlayer** | FFmpeg (FFmpegKit) | Wide IPTV support | Handles most formats common in IPTV streams; configurable decoder (FFmpeg / VideoToolbox) |
 | **AVPlayer** | AVFoundation | HLS & MP4 | Native Apple player with **custom unified overlay** matching the other engines |
-| **Lume Engine** *(beta)* | [LumeEngine](https://github.com/bilipp/LumeEngine) (FFmpeg 8) | Long-running IPTV streams | Our own engine, built from scratch for stability on live streams: Apple-owned A/V sync, supervised pipelines, MPEG-TS wraparound handled at the demux boundary |
+| **Lume Engine** *(beta)* | [LumeEngine](https://github.com/bilipp/LumeEngine) (FFmpeg 8) | Long-running IPTV streams | Our own engine, built from scratch for stability on live streams: Apple-owned A/V sync, supervised pipelines, MPEG-TS wraparound handled at the demux boundary, deinterlacing that keeps hardware decoding |
 
 **Lume Engine** is opt-in: it sits at the *end* of the priority list until you move it
 up in **Settings**, so it is never silently promoted while it is in beta. It is


### PR DESCRIPTION
## Summary
Interlaced broadcasts — which is most European live sport on IPTV — were shown with their fields woven into one frame, so anything moving between the two fields combed. This adds a **Deinterlace** setting (Off / Automatic / Always) and a **Frame Rate** setting (Doubled / Original) to Settings → Lume Engine Options, defaulting to Automatic + Doubled so a 1080i50 match plays as 1080p50 without anyone touching a setting.

The engine-side work lives in the sibling repo [`bilipp/LumeEngine`](https://github.com/bilipp/LumeEngine) (bwdif filter graph, `VideoDecoder.Deinterlacing`, covered by 5 new tests there) and is now on its `main` as `0525392`. Lume resolves LumeEngine as a local path package, so pull that sibling checkout before building this branch.

## Implementation
Two new `@AppStorage` keys under `PlayerSettings.Lume`, surfaced as `LumeDeinterlaceMode` / `LumeDeinterlaceRate` in `PlayerEngineOptions.swift` and mapped onto `PlayerConfiguration.deinterlace` by `LumeEngineCoordinator.deinterlacing(for:)`, re-read on every configure/reload like the other engine options.

Deliberately *not* reusing the existing `PlayerSettings.deinterlaceKey`: despite the generic name it is VLC's legacy top-level key and is listed in `VLC.allKeys`, so resetting VLC options would have wiped the Lume setting. Its platform-conditional default also exists for a reason that doesn't apply here — VLC drops to software decode on interlaced H.264, whereas the Lume Engine downloads VideoToolbox frames and filters them, keeping hardware decode. Hence Automatic on every platform.

`PlayerEngineSettingsViews.swift` was already at 583/600 lines and the pre-commit hook runs `swiftlint --strict`, so the three Lume Engine views moved verbatim into a new `LumeEngineSettingsViews.swift` (old file → 427 lines). That is most of the diff; it is a pure move.

## Testing
- [x] Acceptance criteria met
- [x] Builds clean — iOS Simulator (iPhone 17 Pro) and tvOS Simulator (Apple TV 4K 3rd gen); XcodeBuildMCP unavailable, so `xcodebuild` with `-derivedDataPath`
- [x] Tests pass — `LumeTests` green except the known-flaky `WatchProgressBufferTests`, which fails identically on clean `main` (verified by stashing)
- [x] SwiftLint clean — `--strict`, via the pre-commit hook
- [ ] Tests added — skipped: no existing coverage for any engine option snapshot (`VLCPlayerOptions`, `KSPlayerOptions`, `LumeEngineOptions`); behaviour is covered by 5 tests engine-side
- [x] UI verified on simulator — screenshots of the real screen in light, dark, and German on iOS, and the tvOS detail pane

## Platforms
- [x] iOS / iPadOS
- [x] tvOS
- [ ] macOS
- [ ] visionOS
<!-- macOS/visionOS share the iOS form and compile, but were not run -->

## Notes
- All 6 new user-facing strings are localized into all 8 shipped languages.
- `LumeUITests/SettingsTests` is **entirely broken on `main`** — `app.buttons["gear"]` matches nothing, so every test in that suite fails, including `testSettingsAccessibleFromToolbar`. Verified on a clean tree; out of scope here, but it means the UI-test route into Settings is currently dead. Visual verification was done by launching the screen directly instead.
