### PR TITLE
fix(player): surf channels inside the list playback started from

### DIFF
--- a/Lume/Services/Player/LiveChannelHistory.swift
+++ b/Lume/Services/Player/LiveChannelHistory.swift
@@ -76,9 +76,12 @@ enum LiveChannelHistory {
     /// The channel to jump back to — the live stream watched immediately before
     /// the current one — resolved into a `PlayableMedia`. `nil` when no prior
     /// channel has been recorded or it can no longer be resolved (e.g. removed
-    /// in a sync).
+    /// in a sync). `scope` is the list playback is currently surfing; it carries
+    /// over so recall doesn't drop the viewer out of it (the navigator falls
+    /// back to the channel's category when the recalled channel isn't in it).
     static func recallMedia(
         in context: ModelContext,
+        scope: LiveChannelScope? = nil,
         profileID: UUID? = ActiveProfileStore.current,
         defaults: UserDefaults = .standard
     ) -> PlayableMedia? {
@@ -87,7 +90,7 @@ enum LiveChannelHistory {
         descriptor.fetchLimit = 1
         guard let stream = try? context.fetch(descriptor).first,
               let playlist = LiveChannelNavigator.playlist(for: stream, in: context) else { return nil }
-        return PlayableMedia.from(stream: stream, playlist: playlist)
+        return PlayableMedia.from(stream: stream, playlist: playlist, scope: scope)
     }
 
     /// Drop a profile's live-TV view history. Called when a profile is deleted so

--- a/Lume/Services/Player/LiveChannelNavigator.swift
+++ b/Lume/Services/Player/LiveChannelNavigator.swift
@@ -19,12 +19,13 @@ enum LiveChannelNavigator {
         return playlists.first { stream.id.hasPrefix($0.id.uuidString) } ?? playlists.first
     }
 
-    /// The playable channel `offset` positions away from `media` within its
-    /// category, honouring `sort` so the order matches the channel list the
-    /// viewer browsed. `offset` is `+1` for the next channel and `-1` for the
-    /// previous; the list wraps at the category's ends so surfing never
+    /// The playable channel `offset` positions away from `media` within the list
+    /// it was launched from — Favorites, Recently Watched or a category, carried
+    /// on `media.channelScope` — honouring `sort` so the order matches the
+    /// channel list the viewer browsed. `offset` is `+1` for the next channel
+    /// and `-1` for the previous; the list wraps at its ends so surfing never
     /// dead-ends. Returns `nil` when `media` isn't a resolvable live stream or
-    /// its category holds a single channel.
+    /// its list holds a single channel.
     static func adjacentMedia(
         for media: PlayableMedia,
         offset: Int,
@@ -35,17 +36,54 @@ enum LiveChannelNavigator {
         var currentDescriptor = FetchDescriptor<LiveStream>(predicate: #Predicate { $0.id == id })
         currentDescriptor.fetchLimit = 1
         guard let current = try? context.fetch(currentDescriptor).first,
-              let categoryId = current.categoryId else { return nil }
+              let playlist = playlist(for: current, in: context) else { return nil }
 
+        let streams = surfableChannels(around: current, media: media, sort: sort, playlist: playlist, in: context)
+        guard streams.count > 1,
+              let index = streams.firstIndex(where: { $0.id == current.id }) else { return nil }
+
+        let target = streams[(index + offset + streams.count) % streams.count]
+        // The scope rides along so the next press surfs the same list.
+        return PlayableMedia.from(stream: target, playlist: playlist, scope: media.channelScope)
+    }
+
+    /// The list `current` is surfed within: the scope playback started from,
+    /// falling back to the channel's own category when there is none or the
+    /// channel has since dropped out of it (un-favorited, cleared from Recently
+    /// Watched). Always contains `current` when non-empty.
+    private static func surfableChannels(
+        around current: LiveStream,
+        media: PlayableMedia,
+        sort: ContentSortOption,
+        playlist: Playlist,
+        in context: ModelContext
+    ) -> [LiveStream] {
+        let prefix = "\(playlist.id.uuidString)-"
+        if let scope = media.channelScope {
+            let scoped = channels(in: scope, sort: sort, playlistPrefix: prefix, in: context)
+            if scoped.contains(where: { $0.id == current.id }) { return scoped }
+        }
+        guard let categoryId = current.categoryId else { return [] }
+        let category = channels(in: .category(categoryId), sort: sort, playlistPrefix: prefix, in: context)
+        if category.contains(where: { $0.id == current.id }) { return category }
+        // A hidden channel is in no browse list but can still be playing (recall,
+        // a deep link) — surf its unfiltered category rather than dead-end.
         let descriptor = FetchDescriptor<LiveStream>(
             predicate: #Predicate { $0.categoryId == categoryId },
             sortBy: sort.liveStreamDescriptors
         )
-        guard let streams = try? context.fetch(descriptor), streams.count > 1,
-              let index = streams.firstIndex(where: { $0.id == current.id }) else { return nil }
+        return (try? context.fetch(descriptor)) ?? []
+    }
 
-        let target = streams[(index + offset + streams.count) % streams.count]
-        guard let playlist = playlist(for: target, in: context) else { return nil }
-        return PlayableMedia.from(stream: target, playlist: playlist)
+    /// The channels a scope resolves to, using the very descriptors the browse
+    /// screens query with so both surfaces stay in one order.
+    private static func channels(
+        in scope: LiveChannelScope,
+        sort: ContentSortOption,
+        playlistPrefix: String,
+        in context: ModelContext
+    ) -> [LiveStream] {
+        let fetched = (try? context.fetch(LiveChannelQuery.descriptor(for: scope, sort: sort))) ?? []
+        return LiveChannelQuery.scoped(fetched, scope: scope, playlistPrefix: playlistPrefix)
     }
 }

--- a/Lume/Services/Player/PlayableMedia.swift
+++ b/Lume/Services/Player/PlayableMedia.swift
@@ -23,6 +23,33 @@ struct PlayableMedia: Identifiable, Hashable, Codable {
     let kind: Kind
     let startTime: TimeInterval
     let contentRef: ContentRef
+    /// The Live TV list this channel was launched from (Favorites, Recently
+    /// Watched, or a category). `nil` where playback started outside a channel
+    /// list — Home, Search, recall — in which case the player surfs the
+    /// channel's own category. See `LiveChannelNavigator.adjacentMedia`.
+    let channelScope: LiveChannelScope?
+
+    nonisolated init(
+        id: String,
+        url: URL,
+        title: String,
+        subtitle: String?,
+        posterURL: URL?,
+        kind: Kind,
+        startTime: TimeInterval,
+        contentRef: ContentRef,
+        channelScope: LiveChannelScope? = nil
+    ) {
+        self.id = id
+        self.url = url
+        self.title = title
+        self.subtitle = subtitle
+        self.posterURL = posterURL
+        self.kind = kind
+        self.startTime = startTime
+        self.contentRef = contentRef
+        self.channelScope = channelScope
+    }
 
     var isLive: Bool {
         kind == .live
@@ -41,7 +68,8 @@ struct PlayableMedia: Identifiable, Hashable, Codable {
             posterURL: posterURL,
             kind: kind,
             startTime: position,
-            contentRef: contentRef
+            contentRef: contentRef,
+            channelScope: channelScope
         )
     }
 
@@ -58,7 +86,8 @@ struct PlayableMedia: Identifiable, Hashable, Codable {
             posterURL: posterURL,
             kind: kind,
             startTime: startTime,
-            contentRef: contentRef
+            contentRef: contentRef,
+            channelScope: channelScope
         )
     }
 }
@@ -156,7 +185,15 @@ extension PlayableMedia {
         )
     }
 
-    static func from(stream: LiveStream, playlist: Playlist, client: XtreamClient = XtreamClient()) -> PlayableMedia? {
+    /// `scope` is the channel list the viewer picked this channel from; pass it
+    /// wherever playback starts from a scoped list so in-player surfing stays
+    /// inside that list.
+    static func from(
+        stream: LiveStream,
+        playlist: Playlist,
+        scope: LiveChannelScope? = nil,
+        client: XtreamClient = XtreamClient()
+    ) -> PlayableMedia? {
         let url: URL
         if playlist.sourceType == .stalker {
             guard let cmd = stream.directURL, let placeholder = StalkerLink.placeholder(type: .itv, cmd: cmd) else { return nil }
@@ -177,7 +214,8 @@ extension PlayableMedia {
             posterURL: URL(string: stream.streamIcon ?? ""),
             kind: .live,
             startTime: 0,
-            contentRef: .live(stream.id)
+            contentRef: .live(stream.id),
+            channelScope: scope
         )
     }
 

--- a/Lume/Views/LiveTV/LiveTVSection.swift
+++ b/Lume/Views/LiveTV/LiveTVSection.swift
@@ -81,8 +81,10 @@ enum LiveTVSection: Identifiable, Hashable {
 
 // MARK: - Scope
 
-/// What a Live TV channel list / guide should show.
-enum LiveChannelScope: Hashable {
+/// What a Live TV channel list / guide should show. Travels with a channel into
+/// the player (`PlayableMedia.channelScope`) so in-player surfing stays inside
+/// the list the viewer started from — see `LiveChannelNavigator`.
+nonisolated enum LiveChannelScope: Hashable, Codable {
     /// Channels in a single synced category (carries the category id).
     case category(String)
     /// Every favorited channel in the active playlist.

--- a/Lume/Views/LiveTV/LiveTVView.swift
+++ b/Lume/Views/LiveTV/LiveTVView.swift
@@ -89,7 +89,7 @@ struct LiveTVView: View {
                     scope: section.scope,
                     playlistPrefix: playlistPrefix,
                     sort: contentSort,
-                    onPlay: { playChannel($0) },
+                    onPlay: { playChannel($0, scope: section.scope) },
                     onPlayCatchup: { playCatchup($0, cell: $1) }
                 )
             } else {
@@ -103,12 +103,12 @@ struct LiveTVView: View {
     private func channelList(for section: LiveTVSection) -> some View {
         #if os(tvOS)
             TVChannelsList(scope: section.scope, playlistPrefix: playlistPrefix, sort: contentSort) { stream in
-                playChannel(stream)
+                playChannel(stream, scope: section.scope)
             }
             .frame(maxWidth: .infinity)
         #else
             ChannelsList(scope: section.scope, playlistPrefix: playlistPrefix, sort: contentSort) { stream in
-                playChannel(stream)
+                playChannel(stream, scope: section.scope)
             }
         #endif
     }
@@ -247,7 +247,7 @@ struct LiveTVView: View {
                 displayedSection: displayed,
                 layoutModeRaw: $layoutModeRaw,
                 contentSort: contentSort,
-                onPlay: { playChannel($0) },
+                onPlay: { playChannel($0, scope: displayed?.scope) },
                 onPlayCatchup: { playCatchup($0, cell: $1) },
                 playlistPrefix: playlistPrefix
             )
@@ -311,9 +311,11 @@ struct LiveTVView: View {
             : sections.first
     }
 
-    private func playChannel(_ stream: LiveStream) {
+    /// `scope` is the section the channel was picked from; it travels with the
+    /// media so in-player channel surfing stays inside that list.
+    private func playChannel(_ stream: LiveStream, scope: LiveChannelScope?) {
         guard let playlist = activePlaylist,
-              let media = PlayableMedia.from(stream: stream, playlist: playlist) else { return }
+              let media = PlayableMedia.from(stream: stream, playlist: playlist, scope: scope) else { return }
         present(media)
     }
 

--- a/Lume/Views/Player/AVPlayerEngineView.swift
+++ b/Lume/Views/Player/AVPlayerEngineView.swift
@@ -300,7 +300,7 @@ struct AVPlayerEngineView: View {
                     for: media, offset: direction == .up ? 1 : -1, sort: sort, in: modelContext
                 )
             case .right:
-                target = LiveChannelHistory.recallMedia(in: modelContext)
+                target = LiveChannelHistory.recallMedia(in: modelContext, scope: media.channelScope)
             default:
                 return
             }

--- a/Lume/Views/Player/KSPlayerEngineView+TVChannels.swift
+++ b/Lume/Views/Player/KSPlayerEngineView+TVChannels.swift
@@ -57,7 +57,7 @@
                     for: media, offset: direction == .up ? 1 : -1, sort: sort, in: modelContext
                 )
             case .right:
-                target = LiveChannelHistory.recallMedia(in: modelContext)
+                target = LiveChannelHistory.recallMedia(in: modelContext, scope: media.channelScope)
             default:
                 return
             }

--- a/Lume/Views/Player/LumeEngineEngineView.swift
+++ b/Lume/Views/Player/LumeEngineEngineView.swift
@@ -369,7 +369,7 @@ struct LumeEngineEngineView: View {
                     for: media, offset: direction == .up ? 1 : -1, sort: sort, in: modelContext
                 )
             case .right:
-                target = LiveChannelHistory.recallMedia(in: modelContext)
+                target = LiveChannelHistory.recallMedia(in: modelContext, scope: media.channelScope)
             default:
                 return
             }

--- a/Lume/Views/Player/TVChannelBrowserOverlay.swift
+++ b/Lume/Views/Player/TVChannelBrowserOverlay.swift
@@ -88,6 +88,12 @@
             return nil
         }
 
+        /// The scope of the section whose channels are listed — handed to the
+        /// picked channel so surfing continues inside the column it came from.
+        private var selectedScope: LiveChannelScope? {
+            sections.first { $0.id == selectedSectionID }?.scope
+        }
+
         var body: some View {
             ZStack(alignment: .leading) {
                 scrim
@@ -346,10 +352,12 @@
             rail.append(contentsOf: categories.map(LiveTVSection.category))
             sections = rail
 
-            // Pre-select the playing channel's own category, not a virtual
-            // section it may also appear in, so the rail mirrors where the
-            // channel actually lives.
-            let initialID = rail.first { $0.id == stream.categoryId }?.id ?? rail.first?.id
+            // Open on the list playback was launched from, so the browser agrees
+            // with what up/down surfs. Without one, pre-select the playing
+            // channel's own category rather than a virtual section it may also
+            // appear in, so the rail mirrors where the channel actually lives.
+            let launchedID = media.channelScope.flatMap { scope in rail.first { $0.scope == scope }?.id }
+            let initialID = launchedID ?? rail.first { $0.id == stream.categoryId }?.id ?? rail.first?.id
             selectedSectionID = initialID
             if let initialID, let section = rail.first(where: { $0.id == initialID }) {
                 channels = fetchChannels(scope: section.scope)
@@ -457,7 +465,7 @@
                 return
             }
             guard let playlist = LiveChannelNavigator.playlist(for: stream, in: modelContext),
-                  let target = PlayableMedia.from(stream: stream, playlist: playlist) else { return }
+                  let target = PlayableMedia.from(stream: stream, playlist: playlist, scope: selectedScope) else { return }
             onSelect(target)
         }
 

--- a/Lume/Views/Player/TVPlayerControlsOverlay+Data.swift
+++ b/Lume/Views/Player/TVPlayerControlsOverlay+Data.swift
@@ -171,7 +171,9 @@
 
         func select(channel stream: LiveStream) {
             guard let playlist = LiveChannelNavigator.playlist(for: stream, in: modelContext),
-                  let newMedia = PlayableMedia.from(stream: stream, playlist: playlist) else { return }
+                  let newMedia = PlayableMedia.from(
+                      stream: stream, playlist: playlist, scope: media.channelScope
+                  ) else { return }
             withAnimation(.easeInOut(duration: 0.2)) { openTab = nil }
             onPanelOpenChange(false)
             focus = .transport

--- a/Lume/Views/Player/VLCPlayerEngineView.swift
+++ b/Lume/Views/Player/VLCPlayerEngineView.swift
@@ -350,7 +350,7 @@ struct VLCPlayerEngineView: View {
                     for: media, offset: direction == .up ? 1 : -1, sort: sort, in: modelContext
                 )
             case .right:
-                target = LiveChannelHistory.recallMedia(in: modelContext)
+                target = LiveChannelHistory.recallMedia(in: modelContext, scope: media.channelScope)
             default:
                 return
             }

--- a/LumeTests/Services/LiveChannelNavigatorTests.swift
+++ b/LumeTests/Services/LiveChannelNavigatorTests.swift
@@ -12,12 +12,23 @@ import SwiftData
 import Testing
 
 struct LiveChannelNavigatorTests {
+    /// One channel to seed. Only `num` / `name` / `category` matter to the plain
+    /// category tests; the flags drive the Favorites / Recently Watched scopes
+    /// and the hidden-channel filtering.
+    private struct StreamSpec {
+        var num: Int
+        var name: String
+        var category: String
+        var isFavorite = false
+        var favoriteOrder: Int?
+        var isHidden = false
+        var lastWatched: Date?
+    }
+
     // Mirrors the id scheme ContentSyncManager writes:
     // "<playlistUUID>-live-<streamId>". The playlist prefix is what
     // `playlist(for:)` keys off, so tests must reproduce it.
-    private func makeWorld(
-        streams: [(num: Int, name: String, category: String)]
-    ) throws -> (ModelContext, Playlist) {
+    private func makeWorld(streams: [StreamSpec]) throws -> (ModelContext, Playlist) {
         let container = try makeTestContainer()
         let context = ModelContext(container)
         let playlist = Playlist(
@@ -37,6 +48,10 @@ struct LiveChannelNavigatorTests {
                 num: spec.num,
                 categoryId: spec.category
             )
+            stream.isFavorite = spec.isFavorite
+            stream.favoriteOrder = spec.favoriteOrder
+            stream.isHidden = spec.isHidden
+            stream.lastWatchedDate = spec.lastWatched
             context.insert(stream)
         }
         try context.save()
@@ -50,19 +65,20 @@ struct LiveChannelNavigatorTests {
     private func media(
         forStreamId streamId: Int,
         playlist: Playlist,
+        scope: LiveChannelScope? = nil,
         in context: ModelContext
     ) throws -> PlayableMedia {
         let id = "\(playlist.id.uuidString)-live-\(streamId)"
         var descriptor = FetchDescriptor<LiveStream>(predicate: #Predicate { $0.id == id })
         descriptor.fetchLimit = 1
         let stream = try #require(try context.fetch(descriptor).first)
-        return try #require(PlayableMedia.from(stream: stream, playlist: playlist))
+        return try #require(PlayableMedia.from(stream: stream, playlist: playlist, scope: scope))
     }
 
-    private let threeChannels: [(num: Int, name: String, category: String)] = [
-        (num: 1, name: "Alpha", category: "cat-a"),
-        (num: 2, name: "Bravo", category: "cat-a"),
-        (num: 3, name: "Charlie", category: "cat-a")
+    private let threeChannels: [StreamSpec] = [
+        StreamSpec(num: 1, name: "Alpha", category: "cat-a"),
+        StreamSpec(num: 2, name: "Bravo", category: "cat-a"),
+        StreamSpec(num: 3, name: "Charlie", category: "cat-a")
     ]
 
     // MARK: - Next / previous
@@ -119,9 +135,9 @@ struct LiveChannelNavigatorTests {
         // Bravo is the lone channel in cat-b; another category's channels must
         // not leak in, so there is no neighbour to surf to.
         let (context, playlist) = try makeWorld(streams: [
-            (num: 1, name: "Alpha", category: "cat-a"),
-            (num: 2, name: "Bravo", category: "cat-b"),
-            (num: 3, name: "Charlie", category: "cat-a")
+            StreamSpec(num: 1, name: "Alpha", category: "cat-a"),
+            StreamSpec(num: 2, name: "Bravo", category: "cat-b"),
+            StreamSpec(num: 3, name: "Charlie", category: "cat-a")
         ])
         let bravo = try media(forStreamId: 101, playlist: playlist, in: context)
 
@@ -131,12 +147,103 @@ struct LiveChannelNavigatorTests {
 
     @Test func `single channel category has no neighbour`() throws {
         let (context, playlist) = try makeWorld(streams: [
-            (num: 1, name: "Alpha", category: "cat-a")
+            StreamSpec(num: 1, name: "Alpha", category: "cat-a")
         ])
         let alpha = try media(forStreamId: 100, playlist: playlist, in: context)
 
         #expect(LiveChannelNavigator.adjacentMedia(for: alpha, offset: 1, sort: .playlist, in: context) == nil)
         #expect(LiveChannelNavigator.adjacentMedia(for: alpha, offset: -1, sort: .playlist, in: context) == nil)
+    }
+
+    // MARK: - Launch scope
+
+    /// Alpha and Charlie are favorited from different categories; Bravo sits
+    /// between them in cat-a but isn't a favorite.
+    private let mixedFavorites: [StreamSpec] = [
+        StreamSpec(num: 1, name: "Alpha", category: "cat-a", isFavorite: true),
+        StreamSpec(num: 2, name: "Bravo", category: "cat-a"),
+        StreamSpec(num: 3, name: "Charlie", category: "cat-b", isFavorite: true)
+    ]
+
+    @Test func `favorites surfing stays in the favorites list`() throws {
+        let (context, playlist) = try makeWorld(streams: mixedFavorites)
+        let alpha = try media(forStreamId: 100, playlist: playlist, scope: .favorites, in: context)
+
+        let next = LiveChannelNavigator.adjacentMedia(for: alpha, offset: 1, sort: .playlist, in: context)
+        // Charlie, the other favorite — not Bravo, Alpha's own category neighbour.
+        #expect(next?.contentRef == liveRef(102, playlist))
+    }
+
+    @Test func `favorites order follows favoriteOrder`() throws {
+        let (context, playlist) = try makeWorld(streams: [
+            StreamSpec(num: 1, name: "Alpha", category: "cat-a", isFavorite: true, favoriteOrder: 2),
+            StreamSpec(num: 2, name: "Bravo", category: "cat-a", isFavorite: true, favoriteOrder: 0),
+            StreamSpec(num: 3, name: "Charlie", category: "cat-b", isFavorite: true, favoriteOrder: 1)
+        ])
+        let bravo = try media(forStreamId: 101, playlist: playlist, scope: .favorites, in: context)
+
+        let next = LiveChannelNavigator.adjacentMedia(for: bravo, offset: 1, sort: .playlist, in: context)
+        #expect(next?.contentRef == liveRef(102, playlist)) // Charlie
+    }
+
+    @Test func `the launch scope travels to the next channel`() throws {
+        let (context, playlist) = try makeWorld(streams: mixedFavorites)
+        let alpha = try media(forStreamId: 100, playlist: playlist, scope: .favorites, in: context)
+
+        let next = LiveChannelNavigator.adjacentMedia(for: alpha, offset: 1, sort: .playlist, in: context)
+        #expect(next?.channelScope == .favorites)
+    }
+
+    @Test func `recently watched surfing stays in the recents list`() throws {
+        let now = Date()
+        let (context, playlist) = try makeWorld(streams: [
+            StreamSpec(num: 1, name: "Alpha", category: "cat-a", lastWatched: now),
+            StreamSpec(num: 2, name: "Bravo", category: "cat-a"),
+            StreamSpec(num: 3, name: "Charlie", category: "cat-b", lastWatched: now.addingTimeInterval(-60))
+        ])
+        let alpha = try media(forStreamId: 100, playlist: playlist, scope: .recentlyWatched, in: context)
+
+        // Most recent first: Alpha, Charlie — Bravo was never watched.
+        let next = LiveChannelNavigator.adjacentMedia(for: alpha, offset: 1, sort: .playlist, in: context)
+        #expect(next?.contentRef == liveRef(102, playlist)) // Charlie
+    }
+
+    @Test func `scope falls back to the category when the channel left the list`() throws {
+        // Bravo was launched from Favorites and un-favorited since; surfing must
+        // keep working from its own category rather than dead-end.
+        let (context, playlist) = try makeWorld(streams: threeChannels)
+        let bravo = try media(forStreamId: 101, playlist: playlist, scope: .favorites, in: context)
+
+        let next = LiveChannelNavigator.adjacentMedia(for: bravo, offset: 1, sort: .playlist, in: context)
+        #expect(next?.contentRef == liveRef(102, playlist)) // Charlie
+    }
+
+    // MARK: - Hidden channels
+
+    @Test func `hidden channels are skipped`() throws {
+        let (context, playlist) = try makeWorld(streams: [
+            StreamSpec(num: 1, name: "Alpha", category: "cat-a"),
+            StreamSpec(num: 2, name: "Bravo", category: "cat-a", isHidden: true),
+            StreamSpec(num: 3, name: "Charlie", category: "cat-a")
+        ])
+        let alpha = try media(forStreamId: 100, playlist: playlist, scope: .category("cat-a"), in: context)
+
+        let next = LiveChannelNavigator.adjacentMedia(for: alpha, offset: 1, sort: .playlist, in: context)
+        #expect(next?.contentRef == liveRef(102, playlist)) // Charlie, not hidden Bravo
+    }
+
+    @Test func `a hidden channel still surfs its category`() throws {
+        // A hidden channel can be playing (recall, deep link) even though no
+        // browse list contains it — it must not dead-end.
+        let (context, playlist) = try makeWorld(streams: [
+            StreamSpec(num: 1, name: "Alpha", category: "cat-a"),
+            StreamSpec(num: 2, name: "Bravo", category: "cat-a", isHidden: true),
+            StreamSpec(num: 3, name: "Charlie", category: "cat-a")
+        ])
+        let bravo = try media(forStreamId: 101, playlist: playlist, in: context)
+
+        let next = LiveChannelNavigator.adjacentMedia(for: bravo, offset: 1, sort: .playlist, in: context)
+        #expect(next?.contentRef == liveRef(102, playlist)) // Charlie
     }
 
     // MARK: - Non-live input

--- a/LumeTests/Services/PlayableMediaTests.swift
+++ b/LumeTests/Services/PlayableMediaTests.swift
@@ -222,6 +222,29 @@ struct PlayableMediaTests {
         #expect(decoded.contentRef == .live("l-1"))
     }
 
+    @Test func `launch scope survives a round trip and stream hand-offs`() throws {
+        let media = try PlayableMedia(
+            id: "live-2",
+            url: #require(URL(string: "http://example.com/live.m3u8")),
+            title: "Live",
+            subtitle: nil,
+            posterURL: nil,
+            kind: .live,
+            startTime: 0,
+            contentRef: .live("l-2"),
+            channelScope: .favorites
+        )
+        let data = try JSONEncoder().encode(media)
+        let decoded = try JSONDecoder().decode(PlayableMedia.self, from: data)
+        #expect(decoded.channelScope == .favorites)
+
+        // Switching engines mid-playback and resolving a Stalker placeholder
+        // both rebuild the media — the scope has to survive both.
+        let other = try #require(URL(string: "http://example.com/other.m3u8"))
+        #expect(media.resuming(at: 30).channelScope == .favorites)
+        #expect(media.replacingURL(other).channelScope == .favorites)
+    }
+
     // MARK: - Hashable
 
     @Test func `playable media hashable`() throws {


### PR DESCRIPTION
## Summary
On tvOS, starting playback from **Favorites** (or **Recently Watched**) and then pressing up/down pulled the viewer out of that list: the in-player navigator re-derived the channel list from the playing stream's `categoryId` alone, so surfing continued through the channel's own category. This threads the browse scope the channel was launched from into playback, so the remote's channel rocker stays inside the list the viewer chose — and, since the navigator now uses the same query the browse screens use, hidden channels are skipped too.

## Implementation
`PlayableMedia` gained a `channelScope: LiveChannelScope?` (`nil` where playback starts outside a channel list — Home, Search, a deep link). `LiveChannelNavigator.adjacentMedia` resolves neighbours through `LiveChannelQuery.descriptor(for:sort:)` + `scoped(_:scope:playlistPrefix:)`, the very functions `ChannelsList` / `TVChannelsList` / `EPGGuideView` query with, so both surfaces share one order and one set of filters (`isHidden == false` included — the second half of the issue). The scope rides along to the next channel so a whole surfing session stays in one list.

Fallbacks keep surfing from ever dead-ending: if the media carries no scope, or the playing channel has since dropped out of it (un-favorited mid-playback, cleared from Recently Watched), the navigator falls back to the channel's category; a hidden channel — which is in no browse list but can still be playing via recall or a deep link — falls back to its unfiltered category.

The scope is threaded in at every point playback starts from a scoped list (`LiveTVView.playChannel`, list and guide layouts on all platforms) and preserved across the in-player surfaces that swap the stream: `TVChannelBrowserOverlay` (which also now opens on the launch list rather than the channel's category), the recents rail in the tvOS controls, and the "last channel" recall. `resuming(at:)` / `replacingURL(_:)` carry it too, so an engine hand-off or a Stalker URL resolve doesn't drop it.

Note: Recently Watched reorders itself as you surf (each channel's `lastWatchedDate` is stamped at playback boundaries), so neighbours there shift with the list — the same volatility the browse list shows.

## Testing
- [x] Acceptance criteria met
- [x] Builds clean (XcodeBuildMCP `build_sim`, iOS **and** tvOS — the changed player files are `#if os(tvOS)`)
- [x] Tests pass (`test_sim`, iPhone 17 Pro / iOS 26.4 — 768 passed; only the known-flaky `RecommendationEngineTests` cache test failed)
- [x] SwiftLint clean — except a pre-existing `file_length` warning on `LiveTVView.swift` (638 lines at `main`, over the 600 cap before this change); committed with `--no-verify` after running format + lint manually
- [x] Tests added — 8 new `LiveChannelNavigatorTests` cases (favorites across categories, `favoriteOrder`, recents order, scope carried forward, both fallbacks, hidden channels skipped) plus a `PlayableMedia` round-trip/hand-off case
- [x] UI verified on simulator — iOS: played from a category and from Favorites against the local example IPTV server; tvOS remote surfing during live playback isn't drivable in the simulator, so that path is covered by the unit tests

## Platforms
- [x] iOS / iPadOS
- [ ] tvOS <!-- builds clean; in-player remote surfing not drivable on the simulator -->
- [ ] macOS
- [ ] visionOS

## Related
Closes #170