### PR TITLE
feat(player): add VidHub as an external player target

### DIFF
--- a/Lume/Info.plist
+++ b/Lume/Info.plist
@@ -39,6 +39,7 @@
 		<string>vnd.youtube</string>
 		<string>infuse</string>
 		<string>vlc-x-callback</string>
+		<string>open-vidhub</string>
 	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>

--- a/Lume/Services/Player/ExternalPlayer.swift
+++ b/Lume/Services/Player/ExternalPlayer.swift
@@ -53,10 +53,11 @@ enum ExternalPlayer: String, CaseIterable, Identifiable {
     ///   (https://support.firecore.com/hc/en-us/articles/215090997)
     /// - VLC: `vlc-x-callback://x-callback-url/stream?url=…`
     ///   (https://wiki.videolan.org/Documentation:IOS/#x-callback-url)
-    /// - VidHub: `open-vidhub://x-callback-url/play?url=…`
-    ///   (https://vidhub.okaapps.com/3rd-party-app-integration/). `/play` is
-    ///   the current entry point — the older `/open` takes no start position
-    ///   and cannot tell a finished stream from an abandoned one.
+    /// - VidHub: `open-vidhub://x-callback-url/open?url=…`
+    ///   (https://vidhub.okaapps.com/3rd-party-app-integration/). The docs
+    ///   steer new integrations to `/play`, but the shipping App Store build
+    ///   only answers `/open`: it launches and ignores an unrecognised path,
+    ///   and since we send no `x-error` callback the failure is silent.
     func deepLink(for streamURL: URL) -> URL? {
         // The stream URL is carried as a query parameter value, so every
         // reserved character — including `&`, `=` and `?`, which
@@ -68,8 +69,9 @@ enum ExternalPlayer: String, CaseIterable, Identifiable {
             return nil
         }
         let action = switch self {
-        case .infuse, .vidhub: "play"
+        case .infuse: "play"
         case .vlc: "stream"
+        case .vidhub: "open"
         }
         return URL(string: "\(scheme)://x-callback-url/\(action)?url=\(encoded)")
     }

--- a/Lume/Services/Player/ExternalPlayer.swift
+++ b/Lume/Services/Player/ExternalPlayer.swift
@@ -22,6 +22,7 @@ import Foundation
 enum ExternalPlayer: String, CaseIterable, Identifiable {
     case infuse
     case vlc
+    case vidhub
 
     var id: String {
         rawValue
@@ -31,6 +32,7 @@ enum ExternalPlayer: String, CaseIterable, Identifiable {
         switch self {
         case .infuse: "Infuse"
         case .vlc: "VLC"
+        case .vidhub: "VidHub"
         }
     }
 
@@ -41,6 +43,7 @@ enum ExternalPlayer: String, CaseIterable, Identifiable {
         switch self {
         case .infuse: "infuse"
         case .vlc: "vlc-x-callback"
+        case .vidhub: "open-vidhub"
         }
     }
 
@@ -50,6 +53,10 @@ enum ExternalPlayer: String, CaseIterable, Identifiable {
     ///   (https://support.firecore.com/hc/en-us/articles/215090997)
     /// - VLC: `vlc-x-callback://x-callback-url/stream?url=…`
     ///   (https://wiki.videolan.org/Documentation:IOS/#x-callback-url)
+    /// - VidHub: `open-vidhub://x-callback-url/play?url=…`
+    ///   (https://vidhub.okaapps.com/3rd-party-app-integration/). `/play` is
+    ///   the current entry point — the older `/open` takes no start position
+    ///   and cannot tell a finished stream from an abandoned one.
     func deepLink(for streamURL: URL) -> URL? {
         // The stream URL is carried as a query parameter value, so every
         // reserved character — including `&`, `=` and `?`, which
@@ -61,7 +68,7 @@ enum ExternalPlayer: String, CaseIterable, Identifiable {
             return nil
         }
         let action = switch self {
-        case .infuse: "play"
+        case .infuse, .vidhub: "play"
         case .vlc: "stream"
         }
         return URL(string: "\(scheme)://x-callback-url/\(action)?url=\(encoded)")

--- a/LumeTests/Services/ExternalPlayerTests.swift
+++ b/LumeTests/Services/ExternalPlayerTests.swift
@@ -7,14 +7,27 @@ import Testing
 @Suite(.serialized)
 struct ExternalPlayerTests {
     @Test func `player all cases`() {
-        #expect(ExternalPlayer.allCases.count == 2)
+        #expect(ExternalPlayer.allCases.count == 3)
         #expect(ExternalPlayer.infuse.rawValue == "infuse")
         #expect(ExternalPlayer.vlc.rawValue == "vlc")
+        #expect(ExternalPlayer.vidhub.rawValue == "vidhub")
     }
 
     @Test func `player schemes match registered apps`() {
         #expect(ExternalPlayer.infuse.scheme == "infuse")
         #expect(ExternalPlayer.vlc.scheme == "vlc-x-callback")
+        #expect(ExternalPlayer.vidhub.scheme == "open-vidhub")
+    }
+
+    /// Every scheme must be declared in `LSApplicationQueriesSchemes` or
+    /// `canOpenURL(_:)` answers `false` and the hand-off silently never happens.
+    @Test func `every player scheme is declared in Info plist`() throws {
+        let declared = try #require(
+            Bundle.main.object(forInfoDictionaryKey: "LSApplicationQueriesSchemes") as? [String]
+        )
+        for player in ExternalPlayer.allCases {
+            #expect(declared.contains(player.scheme), "\(player.scheme) missing from LSApplicationQueriesSchemes")
+        }
     }
 
     @Test func `infuse deep link wraps stream URL`() throws {
@@ -29,6 +42,23 @@ struct ExternalPlayerTests {
         let link = try #require(ExternalPlayer.vlc.deepLink(for: stream))
         #expect(link.scheme == "vlc-x-callback")
         #expect(link.absoluteString.hasPrefix("vlc-x-callback://x-callback-url/stream?url="))
+    }
+
+    @Test func `vidhub deep link uses the play action`() throws {
+        let stream = try #require(URL(string: "http://example.com/movie.mkv"))
+        let link = try #require(ExternalPlayer.vidhub.deepLink(for: stream))
+        #expect(link.scheme == "open-vidhub")
+        #expect(link.absoluteString == "open-vidhub://x-callback-url/play?url=http%3A%2F%2Fexample.com%2Fmovie.mkv")
+    }
+
+    @Test func `vidhub deep link percent-encodes a live stream query`() throws {
+        let original = "http://host:8080/live/user/pass/1.m3u8?token=a&b=c"
+        let stream = try #require(URL(string: original))
+        let link = try #require(ExternalPlayer.vidhub.deepLink(for: stream))
+        let encoded = try #require(link.absoluteString.components(separatedBy: "url=").last)
+        #expect(!encoded.contains("&"))
+        #expect(!encoded.contains("?"))
+        #expect(encoded.removingPercentEncoding == original)
     }
 
     @Test func `deep link percent-encodes nested query so the stream URL survives`() throws {
@@ -76,6 +106,9 @@ struct ExternalPlayerTests {
 
         defaults.set("vlc", forKey: PlayerSettings.externalPlayerKey)
         #expect(ExternalPlayback.preferred == .vlc)
+
+        defaults.set("vidhub", forKey: PlayerSettings.externalPlayerKey)
+        #expect(ExternalPlayback.preferred == .vidhub)
     }
 
     // MARK: - Scope

--- a/LumeTests/Services/ExternalPlayerTests.swift
+++ b/LumeTests/Services/ExternalPlayerTests.swift
@@ -44,11 +44,14 @@ struct ExternalPlayerTests {
         #expect(link.absoluteString.hasPrefix("vlc-x-callback://x-callback-url/stream?url="))
     }
 
-    @Test func `vidhub deep link uses the play action`() throws {
+    /// `/open`, not the `/play` the docs steer new integrations to: the
+    /// shipping App Store build answers only the former and silently ignores
+    /// the latter.
+    @Test func `vidhub deep link uses the open action`() throws {
         let stream = try #require(URL(string: "http://example.com/movie.mkv"))
         let link = try #require(ExternalPlayer.vidhub.deepLink(for: stream))
         #expect(link.scheme == "open-vidhub")
-        #expect(link.absoluteString == "open-vidhub://x-callback-url/play?url=http%3A%2F%2Fexample.com%2Fmovie.mkv")
+        #expect(link.absoluteString == "open-vidhub://x-callback-url/open?url=http%3A%2F%2Fexample.com%2Fmovie.mkv")
     }
 
     @Test func `vidhub deep link percent-encodes a live stream query`() throws {

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ developed in the open in its own repository —
 failure modes it is built to make structurally impossible.
 
 Prefer a third-party app? Lume can hand streams off to an **external player** —
-**Infuse** or **VLC** — via their deep-link APIs, selectable in **Settings**.
+**Infuse**, **VLC** or **VidHub** — via their deep-link APIs, selectable in **Settings**.
 Because not every app handles every stream — Infuse plays movies and series but no
 live channels — the hand-off covers **movies & series** by default, and can be
 switched to **live TV** or to both. Downloads always play in Lume, and playback falls


### PR DESCRIPTION
## Summary
Adds **VidHub** as a third option in the external-player picker, alongside Infuse and VLC. Users who prefer VidHub can now route Lume playback there instead of having to copy the stream URL out by hand.

## Implementation
One new `ExternalPlayer` case — `vidhub`, scheme `open-vidhub` — plus its `LSApplicationQueriesSchemes` entry so `canOpenURL(_:)` resolves it. The seam from #24 carries everything else: the pickers on iOS and tvOS iterate `allCases`, and `ExternalPlayback.open(_:)` already fails closed to the built-in player when the app isn't installed.

Three decisions worth flagging:

- **`/open`, as the issue specified — verified against the shipping app.** [VidHub's docs](https://vidhub.okaapps.com/3rd-party-app-integration/) steer new integrations to `/play`, so this first went out using it. Testing against the current App Store build showed only `/open` actually plays: `/play` launches VidHub and silently ignores the request, because we send no `x-error` callback and an unrecognised x-callback path produces no visible failure. Reverted to `/open` in d7f52e4. Worth revisiting once `/play` ships — it carries a start position and distinguishes a finished stream from an abandoned one.
- **No platform gating.** The docs list iPhone, iPad, Apple TV and Mac as supporting `/open`, so the picker entry is offered on every Apple platform.
- **Scope default unchanged.** VidHub does handle HLS — the docs' own example is an `.m3u8` — so `.all` is a safe pick for it. But the scope is a single shared preference across all three players and Infuse still plays no live TV, so `ExternalPlayerScope.default` stays `.vod`; users who pick VidHub can switch it to *Everything* themselves.

Passing the OpenSubtitles sidecar through VidHub's `sub` parameter is left out, as the issue suggests — it needs a signature change on `deepLink(for:)` and belongs in its own change.

## Testing
- [x] Acceptance criteria met
- [x] Builds clean (XcodeBuildMCP `build_sim`)
- [x] Tests pass (XcodeBuildMCP `test_sim`, iPhone 17 Pro / iOS 26.4+ — 14/14 in `ExternalPlayerTests`)
- [x] SwiftLint clean
- [x] Tests added — VidHub deep-link shape, percent-encoding round-trip on a live URL with a nested query, preference round-trip, and a new guard that asserts *every* `ExternalPlayer.scheme` is declared in `LSApplicationQueriesSchemes` (a missing entry would otherwise make the hand-off silently never fire)
- [x] UI verified on simulator — picker shows VidHub and unlocks the dependent **Use For** row
- [x] Hand-off verified against the real VidHub app on device (this is what caught `/play`)

## Platforms
- [x] iOS / iPadOS
- [ ] tvOS
- [ ] macOS
- [ ] visionOS
<!-- Source change is platform-neutral; only iOS was exercised on device/simulator. -->

## Related
Closes #172
