### PR TITLE
feat(settings): add bulk hide/show and search to content management

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -11503,6 +11503,58 @@
         }
       }
     },
+    "Everything currently listed will be hidden from browsing. Use Show All to bring it back." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alles, was aktuell aufgelistet ist, wird beim Stöbern ausgeblendet. Mit „Alle anzeigen“ holst du es zurück."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo lo que aparece en la lista se ocultará de la navegación. Usa «Mostrar todo» para recuperarlo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout ce qui figure actuellement dans la liste sera masqué lors de la navigation. Utilisez « Tout afficher » pour le récupérer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutto ciò che è attualmente elencato verrà nascosto dalla navigazione. Usa \"Mostra tutto\" per ripristinarlo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在リストに表示されているものはすべて閲覧時に非表示になります。「すべて表示」で元に戻せます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 목록에 있는 모든 항목이 둘러보기에서 숨겨집니다. 모두 보기로 다시 표시할 수 있습니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tudo o que está listado no momento será ocultado da navegação. Use \"Mostrar Tudo\" para trazê-lo de volta."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前列出的所有内容都将在浏览时隐藏。使用“显示全部”可恢复。"
+          }
+        }
+      }
+    },
     "Exit Picture in Picture" : {
       "localizations" : {
         "de" : {
@@ -13127,6 +13179,162 @@
         }
       }
     },
+    "Hide All" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle ausblenden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar todo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout masquer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nascondi tutto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべて非表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모두 숨기기"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar Tudo"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏全部"
+          }
+        }
+      }
+    },
+    "Hide All Categories?" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Kategorien ausblenden?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Ocultar todas las categorías?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer toutes les catégories ?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nascondere tutte le categorie?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのカテゴリを非表示にしますか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 카테고리를 숨길까요?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar todas as categorias?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏所有类别？"
+          }
+        }
+      }
+    },
+    "Hide All Channels?" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Kanäle ausblenden?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Ocultar todos los canales?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer toutes les chaînes ?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nascondere tutti i canali?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのチャンネルを非表示にしますか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 채널을 숨길까요?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar todos os canais?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏所有频道？"
+          }
+        }
+      }
+    },
     "Hide and reorder categories and channels for the active playlist." : {
       "localizations" : {
         "de" : {
@@ -13283,54 +13491,54 @@
         }
       }
     },
-    "Hide channels to remove them from this category, or drag to reorder. Reset restores the provider's order and shows everything." : {
+    "Hide channels to remove them from this category, or drag to reorder." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Blende Kanäle aus, um sie aus dieser Kategorie zu entfernen, oder ziehe sie, um sie neu anzuordnen. Zurücksetzen stellt die Reihenfolge des Anbieters wieder her und zeigt alles an."
+            "value" : "Blende Kanäle aus, um sie aus dieser Kategorie zu entfernen, oder ziehe sie, um sie neu anzuordnen."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Oculta canales para quitarlos de esta categoría, o arrastra para reordenar. «Restablecer» restaura el orden del proveedor y lo muestra todo."
+            "value" : "Oculta canales para quitarlos de esta categoría, o arrastra para reordenar."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Masquez des chaînes pour les retirer de cette catégorie, ou glissez pour les réorganiser. Réinitialiser rétablit l’ordre du fournisseur et affiche tout."
+            "value" : "Masquez des chaînes pour les retirer de cette catégorie, ou glissez pour les réorganiser."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nascondi i canali per rimuoverli da questa categoria, oppure trascina per riordinarli. \"Reimposta\" ripristina l'ordine del provider e mostra tutto."
+            "value" : "Nascondi i canali per rimuoverli da questa categoria, oppure trascina per riordinarli."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを非表示にしてこのカテゴリから削除するか、ドラッグして並べ替えます。「リセット」でプロバイダの順序に戻り、すべてが表示されます。"
+            "value" : "チャンネルを非表示にしてこのカテゴリから削除するか、ドラッグして並べ替えます。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "채널을 숨겨 이 카테고리에서 제거하거나, 드래그하여 순서를 변경하세요. 재설정하면 공급자의 순서로 복원되고 모두 표시됩니다."
+            "value" : "채널을 숨겨 이 카테고리에서 제거하거나, 드래그하여 순서를 변경하세요."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Oculte canais para removê-los desta categoria ou arraste para reordenar. Redefinir restaura a ordem do provedor e mostra tudo."
+            "value" : "Oculte canais para removê-los desta categoria ou arraste para reordenar."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "隐藏频道以将其从此类别中移除，或拖动以重新排列。“重置”可恢复服务商的顺序并显示全部。"
+            "value" : "隐藏频道以将其从此类别中移除，或拖动以重新排列。"
           }
         }
       }
@@ -16208,54 +16416,54 @@
         }
       }
     },
-    "Lock a category to hide it from child profiles. Drag to reorder. Reset restores the playlist's order and shows everything." : {
+    "Lock a category to hide it from child profiles. Drag to reorder." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sperre eine Kategorie, um sie in Kinderprofilen auszublenden. Ziehe zum Umsortieren. „Zurücksetzen“ stellt die Reihenfolge der Playlist wieder her und zeigt alles an."
+            "value" : "Sperre eine Kategorie, um sie in Kinderprofilen auszublenden. Ziehe zum Umsortieren."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bloquea una categoría para ocultarla de los perfiles infantiles. Arrastra para reordenar. «Restablecer» restaura el orden de la lista de reproducción y lo muestra todo."
+            "value" : "Bloquea una categoría para ocultarla de los perfiles infantiles. Arrastra para reordenar."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verrouillez une catégorie pour la masquer aux profils enfants. Glissez pour réorganiser. Réinitialiser rétablit l’ordre de la playlist et affiche tout."
+            "value" : "Verrouillez une catégorie pour la masquer aux profils enfants. Glissez pour réorganiser."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Blocca una categoria per nasconderla ai profili bambino. Trascina per riordinare. \"Reimposta\" ripristina l'ordine della playlist e mostra tutto."
+            "value" : "Blocca una categoria per nasconderla ai profili bambino. Trascina per riordinare."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "カテゴリをロックすると、子供用プロファイルから非表示になります。ドラッグして並べ替えます。「リセット」でプレイリストの順序に戻り、すべてが表示されます。"
+            "value" : "カテゴリをロックすると、子供用プロファイルから非表示になります。ドラッグして並べ替えます。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "카테고리를 잠가 어린이 프로필에서 숨기세요. 드래그하여 순서를 변경하세요. 재설정하면 재생목록의 순서로 복원되고 모두 표시됩니다."
+            "value" : "카테고리를 잠가 어린이 프로필에서 숨기세요. 드래그하여 순서를 변경하세요."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bloqueie uma categoria para ocultá-la dos perfis infantis. Arraste para reordenar. Redefinir restaura a ordem da playlist e mostra tudo."
+            "value" : "Bloqueie uma categoria para ocultá-la dos perfis infantis. Arraste para reordenar."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "锁定某个类别可将其对儿童个人资料隐藏。拖动以重新排列。“重置”可恢复播放列表的顺序并显示全部。"
+            "value" : "锁定某个类别可将其对儿童个人资料隐藏。拖动以重新排列。"
           }
         }
       }
@@ -19667,6 +19875,58 @@
         }
       }
     },
+    "No categories match your search." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Kategorien entsprechen deiner Suche."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ninguna categoría coincide con tu búsqueda."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune catégorie ne correspond à votre recherche."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna categoria corrisponde alla ricerca."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索に一致するカテゴリはありません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색과 일치하는 카테고리가 없습니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhuma categoria corresponde à sua busca."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有类别与您的搜索匹配。"
+          }
+        }
+      }
+    },
     "No Channels" : {
       "localizations" : {
         "de" : {
@@ -19715,6 +19975,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无频道"
+          }
+        }
+      }
+    },
+    "No channels match your search." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Kanäle entsprechen deiner Suche."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ningún canal coincide con tu búsqueda."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune chaîne ne correspond à votre recherche."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun canale corrisponde alla ricerca."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索に一致するチャンネルはありません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색과 일치하는 채널이 없습니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum canal corresponde à sua busca."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有频道与您的搜索匹配。"
           }
         }
       }
@@ -25688,6 +26000,110 @@
         }
       }
     },
+    "Reset restores the playlist's order and shows everything." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "„Zurücksetzen“ stellt die Reihenfolge der Playlist wieder her und zeigt alles an."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«Restablecer» restaura el orden de la lista de reproducción y lo muestra todo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réinitialiser rétablit l’ordre de la playlist et affiche tout."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"Reimposta\" ripristina l'ordine della playlist e mostra tutto."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「リセット」でプレイリストの順序に戻り、すべてが表示されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재설정하면 재생목록의 순서로 복원되고 모두 표시됩니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redefinir restaura a ordem da playlist e mostra tudo."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“重置”可恢复播放列表的顺序并显示全部。"
+          }
+        }
+      }
+    },
+    "Reset restores the provider's order and shows everything." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zurücksetzen stellt die Reihenfolge des Anbieters wieder her und zeigt alles an."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«Restablecer» restaura el orden del proveedor y lo muestra todo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réinitialiser rétablit l’ordre du fournisseur et affiche tout."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"Reimposta\" ripristina l'ordine del provider e mostra tutto."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「リセット」でプロバイダの順序に戻り、すべてが表示されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재설정하면 공급자의 순서로 복원되고 모두 표시됩니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redefinir restaura a ordem do provedor e mostra tudo."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“重置”可恢复服务商的顺序并显示全部。"
+          }
+        }
+      }
+    },
     "Restart" : {
       "localizations" : {
         "de" : {
@@ -27004,6 +27420,110 @@
         }
       }
     },
+    "Search Categories" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kategorien suchen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar categorías"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher des catégories"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca categorie"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カテゴリを検索"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카테고리 검색"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar categorias"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索类别"
+          }
+        }
+      }
+    },
+    "Search Channels" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kanäle suchen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar canales"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher des chaînes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca canali"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを検索"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "채널 검색"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar canais"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索频道"
+          }
+        }
+      }
+    },
     "Search for movies, series, or live TV channels" : {
       "localizations" : {
         "de" : {
@@ -28144,6 +28664,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示全部"
+          }
+        }
+      }
+    },
+    "Show All and Hide All apply to whatever the list is showing, so you can search first and bulk-apply to the matches." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "„Alle anzeigen“ und „Alle ausblenden“ gelten für das, was die Liste gerade zeigt – du kannst also erst suchen und die Aktion dann auf die Treffer anwenden."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "«Mostrar todo» y «Ocultar todo» se aplican a lo que muestra la lista, así que puedes buscar primero y aplicarlo a las coincidencias."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "« Tout afficher » et « Tout masquer » s’appliquent à ce que la liste affiche : vous pouvez donc d’abord rechercher, puis appliquer l’action aux résultats."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"Mostra tutto\" e \"Nascondi tutto\" si applicano a ciò che la lista sta mostrando, quindi puoi prima cercare e poi applicarli ai risultati."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「すべて表示」と「すべて非表示」はリストに表示されている内容に適用されるため、先に検索してから一致した項目にまとめて適用できます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모두 보기와 모두 숨기기는 목록에 표시된 항목에 적용되므로, 먼저 검색한 뒤 일치하는 항목에 일괄 적용할 수 있습니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"Mostrar Tudo\" e \"Ocultar Tudo\" se aplicam ao que a lista está exibindo, então você pode buscar primeiro e aplicar em massa aos resultados."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“显示全部”和“隐藏全部”作用于列表当前显示的内容，因此你可以先搜索，再对匹配项批量应用。"
           }
         }
       }

--- a/Lume/Models/ContentOrganizing.swift
+++ b/Lume/Models/ContentOrganizing.swift
@@ -67,6 +67,15 @@ enum ContentOrganizer {
         }
     }
 
+    /// Hides every item in a group — the counterpart to `showAll`, so a user with
+    /// a 10k-channel provider can start from a blank slate and opt content back
+    /// in rather than tapping thousands of per-row toggles.
+    static func hideAll(_ items: [some ContentItem]) {
+        for item in items {
+            item.isHidden = true
+        }
+    }
+
     private static func stampOrder(_ arranged: [some ContentItem]) {
         stamp(arranged, into: \.customOrder)
     }

--- a/Lume/Views/Settings/ChannelManagementView.swift
+++ b/Lume/Views/Settings/ChannelManagementView.swift
@@ -31,10 +31,39 @@ struct ChannelManagementView: View {
         )
     }
 
+    @State private var showHideAllConfirmation = false
+
+    #if !os(tvOS)
+        @State private var searchText = ""
+    #endif
+
+    /// What the screen is actually showing, and therefore what the bulk hide /
+    /// show actions apply to — the whole category unless a search narrows it.
+    private var listedStreams: [LiveStream] {
+        #if os(tvOS)
+            streams
+        #else
+            guard !searchText.isEmpty else { return streams }
+            return streams.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+        #endif
+    }
+
     private func move(from source: IndexSet, to destination: Int) {
         ContentOrganizer.reorder(streams, from: source, to: destination)
     }
 
+    #if !os(tvOS)
+        /// A filtered list's offsets don't map onto the full group, so reordering
+        /// is only offered when nothing is filtered out.
+        private var moveHandler: ((IndexSet, Int) -> Void)? {
+            guard searchText.isEmpty else { return nil }
+            return move
+        }
+    #endif
+
+    /// Reset deliberately spans the whole category rather than the listed
+    /// subset: `customOrder` is stamped densely across a group, so clearing part
+    /// of one would leave it half-ordered.
     private func reset() {
         ContentOrganizer.resetOrder(streams)
         ContentOrganizer.showAll(streams)
@@ -58,9 +87,12 @@ struct ChannelManagementView: View {
                         HStack {
                             TVSettingsSectionLabel("Channels")
                             Spacer()
-                            Button("Reset") { reset() }
-                                .buttonStyle(TVSettingsActionButtonStyle())
-                                .disabled(streams.isEmpty || isReordering)
+                            ContentBulkActionButtons(
+                                showAll: { ContentOrganizer.showAll(listedStreams) },
+                                hideAll: { showHideAllConfirmation = true },
+                                reset: reset
+                            )
+                            .disabled(streams.isEmpty || isReordering)
                         }
 
                         if isReordering {
@@ -94,16 +126,32 @@ struct ChannelManagementView: View {
                 }
             }
             .tvSettingsBackground()
+            .hideAllConfirmation("Hide All Channels?", isPresented: $showHideAllConfirmation) {
+                ContentOrganizer.hideAll(listedStreams)
+            }
         }
     #else
         var body: some View {
             List {
+                if !streams.isEmpty {
+                    Section {
+                        ContentBulkActionsRow(
+                            showAll: { ContentOrganizer.showAll(listedStreams) },
+                            hideAll: { showHideAllConfirmation = true },
+                            reset: reset
+                        )
+                    }
+                }
+
                 Section {
                     if streams.isEmpty {
                         Text("This category has no channels.")
                             .foregroundStyle(.secondary)
+                    } else if listedStreams.isEmpty {
+                        Text("No channels match your search.")
+                            .foregroundStyle(.secondary)
                     } else {
-                        ForEach(streams) { stream in
+                        ForEach(listedStreams) { stream in
                             ChannelManageRow(
                                 title: stream.name,
                                 iconURL: URL(string: stream.streamIcon ?? ""),
@@ -111,15 +159,16 @@ struct ChannelManagementView: View {
                                 onToggleHidden: { stream.isHidden.toggle() }
                             )
                         }
-                        .onMove(perform: move)
+                        .onMove(perform: moveHandler)
                     }
                 } footer: {
-                    Text("Hide channels to remove them from this category, or drag to reorder. Reset restores the provider's order and shows everything.")
+                    Text(footerText)
                 }
             }
             #if os(macOS)
             .listStyle(.inset(alternatesRowBackgrounds: true))
             #endif
+            .searchable(text: $searchText, prompt: Text("Search Channels"))
             .navigationTitle(category.name)
             #if os(iOS)
                 .navigationBarTitleDisplayMode(.inline)
@@ -130,11 +179,18 @@ struct ChannelManagementView: View {
                             EditButton()
                         }
                     #endif
-                    ToolbarItem(placement: .automatic) {
-                        Button("Reset", role: .destructive) { reset() }
-                            .disabled(streams.isEmpty)
-                    }
                 }
+                .hideAllConfirmation("Hide All Channels?", isPresented: $showHideAllConfirmation) {
+                    ContentOrganizer.hideAll(listedStreams)
+                }
+        }
+
+        private var footerText: String {
+            [
+                String(localized: "Hide channels to remove them from this category, or drag to reorder."),
+                String(localized: "Show All and Hide All apply to whatever the list is showing, so you can search first and bulk-apply to the matches."),
+                String(localized: "Reset restores the provider's order and shows everything.")
+            ].joined(separator: " ")
         }
     #endif
 }

--- a/Lume/Views/Settings/ContentBulkActions.swift
+++ b/Lume/Views/Settings/ContentBulkActions.swift
@@ -1,0 +1,93 @@
+//
+//  ContentBulkActions.swift
+//  Lume
+//
+//  The Show All / Hide All / Reset controls shared by the two Content Management
+//  screens (the playlist's categories, and one category's channels). Hiding is
+//  the sweeping direction — on a provider with thousands of channels it is the
+//  only practical way to keep a handful — so it always confirms first.
+//
+//  The actions apply to whatever the screen is currently listing, which is what
+//  makes "hide all, search for your country, show all matches" a two-step prune
+//  instead of thousands of taps. Reset is the exception: it clears `customOrder`,
+//  which is stamped densely across a whole group, so it always spans the full
+//  group rather than a filtered subset.
+//
+
+import SwiftUI
+
+extension View {
+    /// Confirmation gate for a Hide All action. `title` names what's about to be
+    /// hidden ("Hide All Categories?" / "Hide All Channels?").
+    func hideAllConfirmation(
+        _ title: LocalizedStringKey,
+        isPresented: Binding<Bool>,
+        hideAll: @escaping @MainActor () -> Void
+    ) -> some View {
+        confirmationDialog(title, isPresented: isPresented, titleVisibility: .visible) {
+            Button("Hide All", role: .destructive, action: hideAll)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Everything currently listed will be hidden from browsing. Use Show All to bring it back.")
+        }
+    }
+}
+
+#if os(tvOS)
+    /// Section-header buttons for the tvOS management screens.
+    struct ContentBulkActionButtons: View {
+        let showAll: @MainActor () -> Void
+        let hideAll: @MainActor () -> Void
+        let reset: @MainActor () -> Void
+
+        var body: some View {
+            HStack(spacing: 12) {
+                Button("Show All", action: showAll)
+                Button("Hide All", action: hideAll)
+                Button("Reset", action: reset)
+            }
+            .buttonStyle(TVSettingsActionButtonStyle())
+        }
+    }
+#else
+    /// A list row of bulk actions for the iOS / macOS management screens.
+    ///
+    /// Deliberately in the list rather than the toolbar: while a `.searchable`
+    /// query is active iOS 26 hands the whole navigation bar over to the search
+    /// field, so a toolbar button would disappear at exactly the moment the user
+    /// wants to apply an action to the matches.
+    struct ContentBulkActionsRow: View {
+        let showAll: @MainActor () -> Void
+        let hideAll: @MainActor () -> Void
+        let reset: @MainActor () -> Void
+
+        var body: some View {
+            HStack(spacing: 0) {
+                button("Show All", tint: .accentColor, action: showAll)
+                separator
+                button("Hide All", tint: .accentColor, action: hideAll)
+                separator
+                button("Reset", tint: .red, action: reset)
+            }
+            .font(.callout)
+        }
+
+        private var separator: some View {
+            Divider().frame(height: 20)
+        }
+
+        private func button(
+            _ title: LocalizedStringKey,
+            tint: Color,
+            action: @escaping @MainActor () -> Void
+        ) -> some View {
+            Button(action: action) {
+                Text(title)
+                    .foregroundStyle(tint)
+                    .frame(maxWidth: .infinity)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.borderless)
+        }
+    }
+#endif

--- a/Lume/Views/Settings/ContentManagementView.swift
+++ b/Lume/Views/Settings/ContentManagementView.swift
@@ -23,8 +23,10 @@ struct ContentManagementView: View {
     @State private var selectedType: CategoryType = .live
 
     /// True while a category is lifted for placement on tvOS — used to disable
-    /// the type picker and Reset so they can't steal focus mid-move.
+    /// the type picker and the bulk actions so they can't steal focus mid-move.
     @State private var isReordering = false
+
+    @State private var showHideAllConfirmation = false
 
     /// Every category across all playlists; scoped and sorted in-memory. Category
     /// counts are small (tens–low hundreds per playlist), so an in-memory pass is
@@ -37,6 +39,7 @@ struct ContentManagementView: View {
         @State private var selectedCategory: Category?
         /// Drives the drill-in to favorites reordering, same rationale as above.
         @State private var favoritesRoute: FavoritesRoute?
+        @State private var searchText = ""
     #endif
 
     var body: some View {
@@ -50,6 +53,9 @@ struct ContentManagementView: View {
                     description: Text("Add a playlist to manage its content.")
                 )
             }
+        }
+        .hideAllConfirmation("Hide All Categories?", isPresented: $showHideAllConfirmation) {
+            ContentOrganizer.hideAll(listedCategories)
         }
         #if os(tvOS)
         // tvOS pushes via NavigationLink(value:) from TVReorderableContentList.
@@ -93,12 +99,36 @@ struct ContentManagementView: View {
             }
     }
 
+    /// What the screen is actually showing, and therefore what the bulk hide /
+    /// show actions apply to. Identical to `categories` unless a search narrows
+    /// it, which is what makes "hide all, search, show all matches" work.
+    private var listedCategories: [Category] {
+        #if os(tvOS)
+            categories
+        #else
+            guard !searchText.isEmpty else { return categories }
+            return categories.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+        #endif
+    }
+
     // MARK: - Mutations
 
     private func move(from source: IndexSet, to destination: Int) {
         ContentOrganizer.reorder(categories, from: source, to: destination)
     }
 
+    #if !os(tvOS)
+        /// A filtered list's offsets don't map onto the full group, so reordering
+        /// is only offered when nothing is filtered out.
+        private var moveHandler: ((IndexSet, Int) -> Void)? {
+            guard searchText.isEmpty else { return nil }
+            return move
+        }
+    #endif
+
+    /// Reset deliberately spans the whole type rather than the listed subset:
+    /// `customOrder` is stamped densely across a group, so clearing part of one
+    /// would leave it half-ordered.
     private func resetCurrentType() {
         ContentOrganizer.resetOrder(categories)
         ContentOrganizer.showAll(categories)
@@ -177,9 +207,12 @@ struct ContentManagementView: View {
             HStack {
                 TVSettingsSectionLabel("Categories")
                 Spacer()
-                Button("Reset") { resetCurrentType() }
-                    .buttonStyle(TVSettingsActionButtonStyle())
-                    .disabled(isReordering)
+                ContentBulkActionButtons(
+                    showAll: { ContentOrganizer.showAll(listedCategories) },
+                    hideAll: { showHideAllConfirmation = true },
+                    reset: resetCurrentType
+                )
+                .disabled(isReordering)
             }
 
             if isReordering {
@@ -246,12 +279,25 @@ struct ContentManagementView: View {
                     .listRowBackground(Color.clear)
                 }
 
+                if !categories.isEmpty {
+                    Section {
+                        ContentBulkActionsRow(
+                            showAll: { ContentOrganizer.showAll(listedCategories) },
+                            hideAll: { showHideAllConfirmation = true },
+                            reset: resetCurrentType
+                        )
+                    }
+                }
+
                 Section {
                     if categories.isEmpty {
                         Text("Nothing to manage yet. Sync this playlist first.")
                             .foregroundStyle(.secondary)
+                    } else if listedCategories.isEmpty {
+                        Text("No categories match your search.")
+                            .foregroundStyle(.secondary)
                     } else {
-                        ForEach(categories) { category in
+                        ForEach(listedCategories) { category in
                             ContentManageRow(
                                 title: category.name,
                                 isHidden: category.isHidden,
@@ -262,7 +308,7 @@ struct ContentManagementView: View {
                                 onDrillIn: { selectedCategory = $0 }
                             )
                         }
-                        .onMove(perform: move)
+                        .onMove(perform: moveHandler)
                     }
                 } header: {
                     Text("Categories")
@@ -273,6 +319,7 @@ struct ContentManagementView: View {
             #if os(macOS)
             .listStyle(.inset(alternatesRowBackgrounds: true))
             #endif
+            .searchable(text: $searchText, prompt: Text("Search Categories"))
             .platformNavigationTitle("Content")
             #if os(iOS)
                 .navigationBarTitleDisplayMode(.inline)
@@ -283,10 +330,6 @@ struct ContentManagementView: View {
                             EditButton()
                         }
                     #endif
-                    ToolbarItem(placement: .automatic) {
-                        Button("Reset", role: .destructive) { resetCurrentType() }
-                            .disabled(categories.isEmpty)
-                    }
                 }
         }
 
@@ -294,7 +337,10 @@ struct ContentManagementView: View {
             let lead = selectedType == .live
                 ? String(localized: "Hide categories to remove them from Live TV, or tap a category to manage its channels.")
                 : String(localized: "Hide categories to remove them from \(selectedType.label).")
-            return lead + " " + String(localized: "Lock a category to hide it from child profiles. Drag to reorder. Reset restores the playlist's order and shows everything.")
+            let controls = String(localized: "Lock a category to hide it from child profiles. Drag to reorder.")
+            let bulk = String(localized: "Show All and Hide All apply to whatever the list is showing, so you can search first and bulk-apply to the matches.")
+            let reset = String(localized: "Reset restores the playlist's order and shows everything.")
+            return [lead, controls, bulk, reset].joined(separator: " ")
         }
     #endif
 }

--- a/LumeTests/Models/ContentOrganizerTests.swift
+++ b/LumeTests/Models/ContentOrganizerTests.swift
@@ -63,6 +63,52 @@ struct ContentOrganizerTests {
         #expect(cats.allSatisfy { !$0.isHidden })
     }
 
+    // MARK: - Bulk hide / show
+
+    @Test func `hide all sets the hidden flag on every item`() {
+        let cats = makeCategories(["A", "B", "C"])
+        cats[1].isHidden = true // already hidden — stays hidden
+
+        ContentOrganizer.hideAll(cats)
+        // Bound outside #expect: SwiftFormat rewrites the closure to a key path,
+        // which the macro can't type-check inline.
+        let allHidden = cats.allSatisfy(\.isHidden)
+        #expect(allHidden)
+    }
+
+    @Test func `hide all leaves the custom order untouched`() {
+        let cats = makeCategories(["A", "B", "C"])
+        ContentOrganizer.reorder(cats, from: IndexSet(integer: 2), to: 0)
+
+        ContentOrganizer.hideAll(cats)
+        // Hiding is not Reset: the user's arrangement survives.
+        #expect(CategorySortOption.playlist.sort(cats).map(\.name) == ["C", "A", "B"])
+    }
+
+    @Test func `hide all then show all on a subset opts that subset back in`() {
+        let cats = makeCategories(["UK One", "DE Eins", "UK Two"])
+        ContentOrganizer.hideAll(cats)
+
+        // The "hide everything, search UK, show the matches" prune.
+        let matches = cats.filter { $0.name.localizedCaseInsensitiveContains("UK") }
+        ContentOrganizer.showAll(matches)
+
+        #expect(cats.filter { !$0.isHidden }.map(\.name) == ["UK One", "UK Two"])
+    }
+
+    @Test func `hide all applies to live streams too`() {
+        let streams = [
+            LiveStream(id: "l-1", streamId: 1, name: "First", num: 1),
+            LiveStream(id: "l-2", streamId: 2, name: "Second", num: 2)
+        ]
+        ContentOrganizer.hideAll(streams)
+        let allHidden = streams.allSatisfy(\.isHidden)
+        #expect(allHidden)
+
+        ContentOrganizer.showAll(streams)
+        #expect(streams.allSatisfy { !$0.isHidden })
+    }
+
     // MARK: - LiveStream custom order precedence
 
     @Test func `live stream custom order overrides provider order`() {


### PR DESCRIPTION
## Summary
Content Management only offered per-row hide toggles plus a Reset that could only ever *un*-hide. On a 10k-channel provider the "I only want my country" workflow meant thousands of taps, with no way to start from a blank slate and opt content back in. This adds **Hide All** — the missing counterpart to the existing `showAll` — surfaces **Show All** separately from Reset, and pairs both with a search field so the reporter's actual workflow becomes two actions: *hide everything → search `UK` → show all matches*.

## Implementation
`ContentOrganizer.hideAll(_:)` mirrors `showAll` over the existing `ContentItem` protocol, so one helper serves both `Category` and `LiveStream`. A new `ContentBulkActions.swift` holds the shared surface: the Show All / Hide All / Reset controls (a list row on iOS/macOS, section-header buttons on tvOS) and the Hide All confirmation, which always gates the sweeping direction.

Key decisions:

- **Scope.** Show All / Hide All apply to whatever the screen is *listing*, so a search narrows them — that's what makes the two-step prune work. Reset is deliberately excluded: it clears `customOrder`, which is stamped densely across a whole group, so clearing a filtered subset would leave the group half-ordered. Reset always spans the full group.
- **Reordering is suppressed while filtering** — a filtered list's `onMove` offsets don't map onto the full group.
- **The bulk actions live in the list, not the toolbar.** This was the one real surprise: iOS 26 hands the entire navigation bar over to the search field while a query is active, so a toolbar button (verified on the simulator) vanished at exactly the moment the user wanted to apply it to the matches. `.navigationBarDrawer(displayMode: .always)` did not help. An inline row stays reachable in every state and reads more discoverably than a `•••` menu.
- **CloudKit cost** (raised in the issue): kept category-scoped rather than inverting the hidden default. Hiding *categories* is the cheap primary path — one `UserContentState` record each, tens per playlist — and already removes their channels from browse without touching per-channel records. Channel-level Hide All is bounded by the single category the screen is scoped to, and mints no more records than toggling those same rows by hand would. No architectural inversion needed.

tvOS gets the bulk buttons but not search — text entry in the settings detail pane is a poor trade against the focus-engine complexity.

## Testing
- [x] Acceptance criteria met
- [x] Builds clean (XcodeBuildMCP `build_sim` iOS + tvOS, `build_macos`) — no new warnings
- [x] Tests pass (XcodeBuildMCP `test_sim`, iPhone 17 Pro / iOS 26.4) — 14/14 `ContentOrganizerTests`
- [x] SwiftLint clean (vendored SwiftFormat + SwiftLint, `--strict`)
- [x] Tests added — 4 new cases covering `hideAll` on both model types, that it leaves `customOrder` intact, and the hide-all → filter → show-all prune
- [x] UI verified on simulator — full workflow driven end to end: Hide All (with confirmation) hid all 6 categories, search `SPO` + Show All restored only SPORTS, the other 5 stayed hidden; channel screen verified in dark mode

## Platforms
- [x] iOS / iPadOS
- [ ] tvOS
- [ ] macOS
- [ ] visionOS
<!-- tvOS and macOS build clean but were not driven interactively; only iOS was verified on-device. -->

## Related
Closes #154