### PR TITLE
fix(downloads): keep downloads running when the app is backgrounded

### DIFF
--- a/Lume/LumeApp.swift
+++ b/Lume/LumeApp.swift
@@ -27,6 +27,9 @@ struct LumeApp: App {
     @State private var profileManager: ProfileManager
     @State private var playlistSwitch = PlaylistSwitchModel()
     @State private var parentalControls: ParentalControls
+    #if os(iOS)
+        @UIApplicationDelegateAdaptor(LumeAppDelegate.self) private var appDelegate
+    #endif
 
     init() {
         let (catalog, cloud) = Self.makeModelContainers()
@@ -202,6 +205,10 @@ struct LumeApp: App {
                     // can persist download state from its delegate callbacks.
                     #if !os(tvOS)
                         DownloadManager.shared.configure(container: catalogContainer)
+                        // Re-adopt transfers the background session kept running
+                        // while the app was away, and settle any the system
+                        // dropped, before the Downloads UI reads their status.
+                        await DownloadManager.shared.restoreBackgroundSession()
                     #endif
 
                     // Commit any watch progress that a previous session buffered

--- a/Lume/LumeAppDelegate.swift
+++ b/Lume/LumeAppDelegate.swift
@@ -1,0 +1,27 @@
+#if os(iOS)
+    import UIKit
+
+    /// Exists for one thing: the background `URLSession` relaunch hook, which has
+    /// no SwiftUI equivalent.
+    ///
+    /// When a download finishes while Lume is suspended or terminated, the system
+    /// relaunches the app in the background and calls
+    /// `handleEventsForBackgroundURLSession` before delivering the session's
+    /// queued events. There is no `App`- or `Scene`-level modifier for this, so a
+    /// `UIApplicationDelegate` is the only way to receive it.
+    final class LumeAppDelegate: NSObject, UIApplicationDelegate {
+        func application(
+            _: UIApplication,
+            handleEventsForBackgroundURLSession identifier: String,
+            completionHandler: @escaping () -> Void
+        ) {
+            // Touching `shared` here is load-bearing, not incidental: it rebuilds
+            // the session object the queued events are addressed to. See
+            // `DownloadManager.handleBackgroundSessionEvents(identifier:completionHandler:)`.
+            DownloadManager.shared.handleBackgroundSessionEvents(
+                identifier: identifier,
+                completionHandler: completionHandler
+            )
+        }
+    }
+#endif

--- a/Lume/Services/Downloads/DownloadManager+Recovery.swift
+++ b/Lume/Services/Downloads/DownloadManager+Recovery.swift
@@ -1,0 +1,62 @@
+import Foundation
+import OSLog
+import SwiftData
+
+extension DownloadManager {
+    /// Settles catalog items still marked `pending`/`downloading` that the
+    /// restored session knows nothing about.
+    ///
+    /// Two things strand them: the user force-quitting Lume (which makes the
+    /// system cancel its background transfers outright), and the app being
+    /// suspended after the file was moved but before the SwiftData write landed.
+    /// Disk is the authority for telling those apart — if the file is there the
+    /// download did finish, whatever the stored status says.
+    nonisolated static func recoverInterruptedDownloads(
+        liveIDs: Set<String>,
+        directory: URL,
+        container: ModelContainer
+    ) async {
+        let pending = DownloadStatus.pending.rawValue
+        let downloading = DownloadStatus.downloading.rawValue
+        let files = (try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil
+        )) ?? []
+
+        /// The finished file for `id`, if one is already on disk.
+        func downloadedFile(for id: String) -> URL? {
+            let sanitized = sanitize(id)
+            return files.first { $0.deletingPathExtension().lastPathComponent == sanitized }
+        }
+
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+        do {
+            let movies = try context.fetch(FetchDescriptor<Movie>(predicate: #Predicate {
+                $0.downloadStatusRaw == pending || $0.downloadStatusRaw == downloading
+            }))
+            let episodes = try context.fetch(FetchDescriptor<Episode>(predicate: #Predicate {
+                $0.downloadStatusRaw == pending || $0.downloadStatusRaw == downloading
+            }))
+            var recovered = 0
+            for movie in movies where !liveIDs.contains(movie.id) {
+                let file = downloadedFile(for: movie.id)
+                movie.downloadStatus = file == nil ? .failed : .completed
+                movie.localFileURL = file?.path
+                movie.downloadedAt = file == nil ? nil : Date()
+                recovered += 1
+            }
+            for episode in episodes where !liveIDs.contains(episode.id) {
+                let file = downloadedFile(for: episode.id)
+                episode.downloadStatus = file == nil ? .failed : .completed
+                episode.localFileURL = file?.path
+                episode.downloadedAt = file == nil ? nil : Date()
+                recovered += 1
+            }
+            guard recovered > 0 else { return }
+            try context.save()
+            Logger.downloads.info("Recovered \(recovered) interrupted download(s)")
+        } catch {
+            Logger.downloads.error("Failed to recover interrupted downloads: \(error)")
+        }
+    }
+}

--- a/Lume/Services/Downloads/DownloadManager.swift
+++ b/Lume/Services/Downloads/DownloadManager.swift
@@ -3,67 +3,6 @@ import os
 import OSLog
 import SwiftData
 
-// MARK: - Data types
-
-/// Live progress for a single active or queued download.
-///
-/// A per-item `@Observable` box rather than a value in the `activeDownloads`
-/// dictionary: `@Observable` tracks access at stored-property granularity, so
-/// views that read a *value* out of the dictionary observe the whole
-/// dictionary — every progress tick for any download re-rendered every
-/// visible episode card. With a box, ticks mutate the box's own properties
-/// and only the card rendering that download re-renders; the dictionary
-/// itself changes only when a download starts, finishes, or fails.
-@Observable
-final class ActiveDownload: Identifiable {
-    let id: String
-    let title: String
-    var fractionCompleted: Double
-    var bytesWritten: Int64 = 0
-    var totalBytes: Int64 = 0
-    /// Ring-buffer of (timestamp, cumulative bytes) used for speed estimation.
-    /// Capped at 5 seconds of history; populated at most every 500 ms.
-    var samples: [(date: Date, bytes: Int64)] = []
-
-    init(id: String, title: String, fractionCompleted: Double = 0) {
-        self.id = id
-        self.title = title
-        self.fractionCompleted = fractionCompleted
-    }
-
-    /// Bytes per second averaged over the sample window, or nil if too few samples.
-    var speedBytesPerSec: Double? {
-        guard samples.count >= 2 else { return nil }
-        let elapsed = samples.last!.date.timeIntervalSince(samples.first!.date)
-        guard elapsed > 0.3 else { return nil }
-        return Double(samples.last!.bytes - samples.first!.bytes) / elapsed
-    }
-
-    /// Estimated seconds remaining based on current speed, or nil if unknown.
-    var estimatedSecondsRemaining: Double? {
-        guard let speed = speedBytesPerSec, speed > 0, totalBytes > bytesWritten else { return nil }
-        return Double(totalBytes - bytesWritten) / speed
-    }
-
-    /// Human-readable "3.2 MB/s · 2 min" caption, or nil while still measuring.
-    var statsLine: String? {
-        guard fractionCompleted > 0, let speed = speedBytesPerSec, speed > 0 else { return nil }
-        let speedStr = ByteCountFormatter.string(fromByteCount: Int64(speed), countStyle: .memory) + "/s"
-        guard let eta = estimatedSecondsRemaining, eta > 1 else { return speedStr }
-        let etaStr = Duration.seconds(eta).formatted(
-            .units(allowed: [.hours, .minutes, .seconds], width: .abbreviated, maximumUnitCount: 2)
-        )
-        return "\(speedStr) · \(etaStr)"
-    }
-}
-
-private struct PendingDownload {
-    let id: String
-    let title: String
-    let url: URL
-    let filename: String
-}
-
 // MARK: - DownloadManager
 
 /// Central download manager. Serialises file downloads, persists completion
@@ -105,11 +44,34 @@ final class DownloadManager: NSObject {
     private var idToFilename: [String: String] = [:]
     private var pendingQueue: [PendingDownload] = []
 
+    /// Handed over by `UIApplicationDelegate` when the app is relaunched to
+    /// receive background session events. Must be called once the session has
+    /// finished delivering them, or the system considers the relaunch unfinished.
+    private var backgroundCompletionHandler: (() -> Void)?
+
     // MARK: - Init
+
+    /// Identifier of the shared background session. Stable across launches —
+    /// it is how the app reconnects to transfers `nsurlsessiond` is still running.
+    private static let sessionIdentifier = "bilipp.Lume.downloads"
 
     override private init() {
         super.init()
-        let config = URLSessionConfiguration.default
+        // A *background* configuration, not `.default`: a default session is
+        // owned by the app process, so the system suspends it along with the app
+        // and downloads stall the moment the user leaves Lume. A background
+        // session hands the transfer to `nsurlsessiond`, which keeps running
+        // while the app is suspended or terminated.
+        let config = URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)
+        // Relaunch the app in the background to deliver completion events, so a
+        // download that finishes while Lume is not running still gets its file
+        // moved into place and its status persisted.
+        config.sessionSendsLaunchEvents = true
+        // These are user-initiated: the person tapped Download and expects it to
+        // start now, not whenever the system next decides conditions are ideal.
+        // (The default flips to `true` for sessions created while in the
+        // background, so it has to be set explicitly rather than left alone.)
+        config.isDiscretionary = false
         config.timeoutIntervalForResource = 0
         session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
         ensureDownloadsDirectory()
@@ -119,6 +81,71 @@ final class DownloadManager: NSObject {
 
     func configure(container: ModelContainer) {
         modelContainer = container
+    }
+
+    /// Re-adopts whatever the background session is still transferring, then
+    /// reconciles the catalog against it. Call once per launch, after
+    /// `configure(container:)`.
+    ///
+    /// The session outlives the process, so after a relaunch `nsurlsessiond`
+    /// still holds the tasks while every map here is empty. Each task carries
+    /// its own `DownloadTaskInfo`, which is enough to rebuild them.
+    func restoreBackgroundSession() async {
+        var liveIDs: Set<String> = []
+        for task in await session.allTasks {
+            guard let download = task as? URLSessionDownloadTask,
+                  let info = DownloadTaskInfo(taskDescription: task.taskDescription)
+            else {
+                // Nothing here can route this task's file to a destination —
+                // an orphan from an older build, or a non-download task. Drop it
+                // rather than leave it consuming bandwidth for no one.
+                task.cancel()
+                continue
+            }
+            liveIDs.insert(info.id)
+            taskMap[task.taskIdentifier] = info.id
+            idToTask[info.id] = download
+            idToFilename[info.id] = info.filename
+            let active = ActiveDownload(id: info.id, title: info.title)
+            let expected = task.countOfBytesExpectedToReceive
+            if expected > 0 {
+                active.totalBytes = expected
+                active.bytesWritten = task.countOfBytesReceived
+                active.fractionCompleted = Double(task.countOfBytesReceived) / Double(expected)
+            }
+            activeDownloads[info.id] = active
+        }
+        Logger.downloads.info("Adopted \(liveIDs.count) in-flight background download(s)")
+
+        guard let container = modelContainer else { return }
+        let capturedIDs = liveIDs
+        let directory = downloadsDirectory
+        Task.detached {
+            await DownloadManager.recoverInterruptedDownloads(
+                liveIDs: capturedIDs,
+                directory: directory,
+                container: container
+            )
+        }
+    }
+
+    /// Stores the completion handler the system hands over when it relaunches
+    /// the app to deliver background session events, to be invoked from
+    /// `urlSessionDidFinishEvents(forBackgroundURLSession:)`.
+    ///
+    /// Reaching this method is also what *recreates* the session: a background
+    /// session only delivers its queued events to a session object built with
+    /// the same identifier, and `DownloadManager.shared` is lazy, so a
+    /// background relaunch would otherwise never touch it.
+    func handleBackgroundSessionEvents(
+        identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        guard identifier == Self.sessionIdentifier else {
+            completionHandler()
+            return
+        }
+        backgroundCompletionHandler = completionHandler
     }
 
     // MARK: - Public API
@@ -135,7 +162,7 @@ final class DownloadManager: NSObject {
         guard let url = directURL ?? XtreamClient().buildMovieURL(for: movie, playlist: playlist) else { return }
 
         let ext = movie.containerExtension ?? "mp4"
-        let filename = "\(sanitize(id)).\(ext)"
+        let filename = "\(Self.sanitize(id)).\(ext)"
         idToFilename[id] = filename
         enqueue(PendingDownload(id: id, title: movie.name, url: url, filename: filename))
     }
@@ -152,7 +179,7 @@ final class DownloadManager: NSObject {
         guard let url = directURL ?? XtreamClient().buildEpisodeURL(for: episode, playlist: playlist) else { return }
 
         let ext = episode.containerExtension
-        let filename = "\(sanitize(id)).\(ext)"
+        let filename = "\(Self.sanitize(id)).\(ext)"
         let title = episode.series.map { "\($0.name) S\(episode.seasonNum)E\(episode.episodeNum)" } ?? episode.title
         idToFilename[id] = filename
         enqueue(PendingDownload(id: id, title: title, url: url, filename: filename))
@@ -173,7 +200,7 @@ final class DownloadManager: NSObject {
             let fileURL = downloadsDirectory.appendingPathComponent(filename)
             try? FileManager.default.removeItem(at: fileURL)
         } else {
-            let sanitizedID = sanitize(id)
+            let sanitizedID = Self.sanitize(id)
             let all = (try? FileManager.default.contentsOfDirectory(at: downloadsDirectory, includingPropertiesForKeys: nil)) ?? []
             for file in all where file.deletingPathExtension().lastPathComponent == sanitizedID {
                 try? FileManager.default.removeItem(at: file)
@@ -197,14 +224,16 @@ final class DownloadManager: NSObject {
 
     // MARK: - Directory
 
-    var downloadsDirectory: URL {
+    /// `nonisolated` so `didFinishDownloadingTo` can resolve the destination and
+    /// move the file before returning, without hopping to the main actor first.
+    nonisolated var downloadsDirectory: URL {
         FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("Downloads", isDirectory: true)
     }
 
     // MARK: - Private
 
-    private func ensureDownloadsDirectory() {
+    private nonisolated func ensureDownloadsDirectory() {
         try? FileManager.default.createDirectory(
             at: downloadsDirectory,
             withIntermediateDirectories: true
@@ -267,6 +296,9 @@ final class DownloadManager: NSObject {
 
     private func startTask(_ item: PendingDownload) {
         let task = session.downloadTask(with: item.url)
+        task.taskDescription = DownloadTaskInfo(
+            id: item.id, title: item.title, filename: item.filename
+        ).taskDescription
         taskMap[task.taskIdentifier] = item.id
         idToTask[item.id] = task
         activeDownloads[item.id] = ActiveDownload(id: item.id, title: item.title)
@@ -320,7 +352,7 @@ final class DownloadManager: NSObject {
         }
     }
 
-    private nonisolated func sanitize(_ id: String) -> String {
+    nonisolated static func sanitize(_ id: String) -> String {
         id.replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: ":", with: "_")
     }
@@ -370,66 +402,111 @@ extension DownloadManager: URLSessionDownloadDelegate {
         let responseURL = downloadTask.response?.url ?? downloadTask.currentRequest?.url
         let ext = responseURL?.pathExtension.isEmpty == false ? responseURL!.pathExtension : "mp4"
 
-        // URLSession deletes `location` the moment this delegate returns — move it
-        // synchronously to a stable interim path before dispatching to the main actor.
-        let interimDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("lume-dl", isDirectory: true)
-        let interim = interimDir.appendingPathComponent("\(taskID).\(ext)")
+        // Resolve the destination from the task itself rather than from any map
+        // on the main actor: with a background session this callback can arrive
+        // in a process that was relaunched purely to receive it, where those maps
+        // are still empty.
+        guard let info = DownloadTaskInfo(taskDescription: downloadTask.taskDescription) else {
+            finishWithoutTaskInfo(taskID: taskID, location: location, ext: ext)
+            return
+        }
+
+        // URLSession deletes `location` the moment this delegate returns, and the
+        // process may be suspended before any hop to the main actor runs — so the
+        // file has to reach its *final* home synchronously, right here.
+        let destination = downloadsDirectory.appendingPathComponent(info.filename)
         do {
-            try FileManager.default.createDirectory(at: interimDir, withIntermediateDirectories: true)
+            try moveIntoDownloads(from: location, to: destination)
+        } catch {
+            Logger.downloads.error("Failed to save download for \(info.id): \(error)")
+            Task { @MainActor in
+                self.handleFailure(taskID: taskID, id: info.id)
+                self.promoteIfNeeded()
+            }
+            return
+        }
+        Logger.downloads.info("Download complete: \(info.id)")
+        Task { @MainActor in
+            self.finalizeDownload(taskID: taskID, info: info, destination: destination)
+        }
+    }
+
+    /// Moves a finished transfer into the downloads directory, replacing any
+    /// previous file for the same item.
+    private nonisolated func moveIntoDownloads(from location: URL, to destination: URL) throws {
+        try FileManager.default.createDirectory(
+            at: downloadsDirectory, withIntermediateDirectories: true
+        )
+        // Re-apply in case the directory was removed and recreated since
+        // launch — a recreated one would carry no exclusion, and every
+        // download after that would start being backed up again.
+        Self.excludeFromBackup(downloadsDirectory)
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.moveItem(at: location, to: destination)
+    }
+
+    /// Completion path for a task whose `DownloadTaskInfo` could not be decoded.
+    /// Only reachable if encoding it failed when the task was created — which,
+    /// for three strings, it does not — but a finished multi-gigabyte transfer is
+    /// not something to drop on an "impossible" branch. Stages the file out of
+    /// `location` (which URLSession deletes on return) so the content id can be
+    /// resolved from `taskMap` on the main actor.
+    private nonisolated func finishWithoutTaskInfo(taskID: Int, location: URL, ext: String) {
+        let interim = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lume-dl", isDirectory: true)
+            .appendingPathComponent("\(taskID).\(ext)")
+        var staged = true
+        do {
+            try FileManager.default.createDirectory(
+                at: interim.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
             if FileManager.default.fileExists(atPath: interim.path) {
                 try FileManager.default.removeItem(at: interim)
             }
             try FileManager.default.moveItem(at: location, to: interim)
         } catch {
-            Task { @MainActor in
-                guard let id = self.taskMap[taskID] else { return }
-                Logger.downloads.error("Failed to stage download for \(id): \(error)")
+            Logger.downloads.error("Failed to stage download for task \(taskID): \(error)")
+            staged = false
+        }
+        Task { @MainActor in
+            guard let id = self.taskMap[taskID] else {
+                try? FileManager.default.removeItem(at: interim)
+                return
+            }
+            let filename = self.idToFilename[id] ?? "\(Self.sanitize(id)).\(ext)"
+            self.idToFilename[id] = filename
+            let destination = self.downloadsDirectory.appendingPathComponent(filename)
+            do {
+                guard staged else { throw CocoaError(.fileNoSuchFile) }
+                try self.moveIntoDownloads(from: interim, to: destination)
+            } catch {
+                Logger.downloads.error("Failed to save download for \(id): \(error)")
+                try? FileManager.default.removeItem(at: interim)
                 self.handleFailure(taskID: taskID, id: id)
                 self.promoteIfNeeded()
+                return
             }
-            return
+            Logger.downloads.info("Download complete: \(id)")
+            self.finalizeDownload(
+                taskID: taskID,
+                info: DownloadTaskInfo(id: id, title: id, filename: filename),
+                destination: destination
+            )
         }
-        Task { @MainActor in self.finalizeDownload(taskID: taskID, interim: interim, ext: ext) }
     }
 
+    /// Main-actor bookkeeping once the file is already in place: clear the live
+    /// maps and persist the completed status.
     @MainActor
-    private func finalizeDownload(taskID: Int, interim: URL, ext: String) {
+    private func finalizeDownload(taskID: Int, info: DownloadTaskInfo, destination: URL) {
         _ = progressPublishGate.withLock { $0.removeValue(forKey: taskID) }
-        guard let id = taskMap[taskID] else {
-            try? FileManager.default.removeItem(at: interim)
-            return
-        }
-        let filename: String
-        if let name = idToFilename[id] {
-            filename = name
-        } else {
-            filename = "\(sanitize(id)).\(ext)"
-            idToFilename[id] = filename
-        }
-        let destination = downloadsDirectory.appendingPathComponent(filename)
-        do {
-            try FileManager.default.createDirectory(
-                at: downloadsDirectory, withIntermediateDirectories: true
-            )
-            // Re-apply in case the directory was removed and recreated since
-            // launch — a recreated one would carry no exclusion, and every
-            // download after that would start being backed up again.
-            Self.excludeFromBackup(downloadsDirectory)
-            if FileManager.default.fileExists(atPath: destination.path) {
-                try FileManager.default.removeItem(at: destination)
-            }
-            try FileManager.default.moveItem(at: interim, to: destination)
-            Logger.downloads.info("Download complete: \(id)")
-            activeDownloads.removeValue(forKey: id)
-            taskMap.removeValue(forKey: taskID)
-            idToTask.removeValue(forKey: id)
-            scheduleModelUpdate(id: id, status: .completed, localURL: destination.path)
-        } catch {
-            Logger.downloads.error("Failed to save download for \(id): \(error)")
-            try? FileManager.default.removeItem(at: interim)
-            handleFailure(taskID: taskID, id: id)
-        }
+        idToFilename[info.id] = info.filename
+        activeDownloads.removeValue(forKey: info.id)
+        taskMap.removeValue(forKey: taskID)
+        idToTask.removeValue(forKey: info.id)
+        scheduleModelUpdate(id: info.id, status: .completed, localURL: destination.path)
         promoteIfNeeded()
     }
 
@@ -439,12 +516,30 @@ extension DownloadManager: URLSessionDownloadDelegate {
         didCompleteWithError error: Error?
     ) {
         guard let error else { return }
+        // Cancellation is the user tapping the X: `cancelDownload` has already
+        // cleared the item's state and status, so recording a failure here would
+        // resurrect the row as a failed download.
+        if (error as? URLError)?.code == .cancelled { return }
         let taskID = task.taskIdentifier
+        // As in `didFinishDownloadingTo`, the task may outlive the process that
+        // started it, so `taskMap` is not guaranteed to know it.
+        let restoredID = DownloadTaskInfo(taskDescription: task.taskDescription)?.id
         Task { @MainActor in
-            guard let id = self.taskMap[taskID] else { return }
+            guard let id = self.taskMap[taskID] ?? restoredID else { return }
             Logger.downloads.error("Download failed for \(id): \(error)")
             self.handleFailure(taskID: taskID, id: id)
             self.promoteIfNeeded()
+        }
+    }
+
+    /// The session has delivered every event queued while the app was away.
+    /// Releasing the stored handler tells the system the background relaunch is
+    /// finished; failing to call it gets the app throttled out of future ones.
+    nonisolated func urlSessionDidFinishEvents(forBackgroundURLSession _: URLSession) {
+        Task { @MainActor in
+            let handler = self.backgroundCompletionHandler
+            self.backgroundCompletionHandler = nil
+            handler?()
         }
     }
 

--- a/Lume/Services/Downloads/DownloadTypes.swift
+++ b/Lume/Services/Downloads/DownloadTypes.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Live progress for a single active or queued download.
+///
+/// A per-item `@Observable` box rather than a value in the `activeDownloads`
+/// dictionary: `@Observable` tracks access at stored-property granularity, so
+/// views that read a *value* out of the dictionary observe the whole
+/// dictionary — every progress tick for any download re-rendered every
+/// visible episode card. With a box, ticks mutate the box's own properties
+/// and only the card rendering that download re-renders; the dictionary
+/// itself changes only when a download starts, finishes, or fails.
+@Observable
+final class ActiveDownload: Identifiable {
+    let id: String
+    let title: String
+    var fractionCompleted: Double
+    var bytesWritten: Int64 = 0
+    var totalBytes: Int64 = 0
+    /// Ring-buffer of (timestamp, cumulative bytes) used for speed estimation.
+    /// Capped at 5 seconds of history; populated at most every 500 ms.
+    var samples: [(date: Date, bytes: Int64)] = []
+
+    init(id: String, title: String, fractionCompleted: Double = 0) {
+        self.id = id
+        self.title = title
+        self.fractionCompleted = fractionCompleted
+    }
+
+    /// Bytes per second averaged over the sample window, or nil if too few samples.
+    var speedBytesPerSec: Double? {
+        guard samples.count >= 2 else { return nil }
+        let elapsed = samples.last!.date.timeIntervalSince(samples.first!.date)
+        guard elapsed > 0.3 else { return nil }
+        return Double(samples.last!.bytes - samples.first!.bytes) / elapsed
+    }
+
+    /// Estimated seconds remaining based on current speed, or nil if unknown.
+    var estimatedSecondsRemaining: Double? {
+        guard let speed = speedBytesPerSec, speed > 0, totalBytes > bytesWritten else { return nil }
+        return Double(totalBytes - bytesWritten) / speed
+    }
+
+    /// Human-readable "3.2 MB/s · 2 min" caption, or nil while still measuring.
+    var statsLine: String? {
+        guard fractionCompleted > 0, let speed = speedBytesPerSec, speed > 0 else { return nil }
+        let speedStr = ByteCountFormatter.string(fromByteCount: Int64(speed), countStyle: .memory) + "/s"
+        guard let eta = estimatedSecondsRemaining, eta > 1 else { return speedStr }
+        let etaStr = Duration.seconds(eta).formatted(
+            .units(allowed: [.hours, .minutes, .seconds], width: .abbreviated, maximumUnitCount: 2)
+        )
+        return "\(speedStr) · \(etaStr)"
+    }
+}
+
+struct PendingDownload {
+    let id: String
+    let title: String
+    let url: URL
+    let filename: String
+}
+
+/// The per-task state the delegate needs, carried on the task itself.
+///
+/// A background session's tasks live in `nsurlsessiond` and outlive the app
+/// process, so none of `DownloadManager`'s in-memory maps are guaranteed to
+/// exist when a callback arrives — the app may have been relaunched purely to
+/// receive it. `URLSessionTask.taskDescription` is persisted with the task by
+/// the daemon, so encoding this alongside the transfer makes every callback
+/// self-describing: `didFinishDownloadingTo` can compute the destination and
+/// move the file without touching the main actor at all.
+nonisolated struct DownloadTaskInfo: Codable {
+    let id: String
+    let title: String
+    let filename: String
+
+    init(id: String, title: String, filename: String) {
+        self.id = id
+        self.title = title
+        self.filename = filename
+    }
+
+    init?(taskDescription: String?) {
+        guard let data = taskDescription?.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(DownloadTaskInfo.self, from: data)
+        else { return nil }
+        self = decoded
+    }
+
+    var taskDescription: String? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/LumeTests/Services/BackgroundDownloadTests.swift
+++ b/LumeTests/Services/BackgroundDownloadTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+@Suite("Background download task info")
+struct DownloadTaskInfoTests {
+    @Test
+    func `round-trips through taskDescription`() throws {
+        let original = DownloadTaskInfo(
+            id: "playlist-1:movie:42",
+            title: "Big Buck Bunny",
+            filename: "playlist-1_movie_42.mkv"
+        )
+        let description = try #require(original.taskDescription)
+        let decoded = try #require(DownloadTaskInfo(taskDescription: description))
+
+        #expect(decoded.id == original.id)
+        #expect(decoded.title == original.title)
+        #expect(decoded.filename == original.filename)
+    }
+
+    @Test
+    func `returns nil for a missing or unrelated task description`() {
+        #expect(DownloadTaskInfo(taskDescription: nil) == nil)
+        #expect(DownloadTaskInfo(taskDescription: "") == nil)
+        #expect(DownloadTaskInfo(taskDescription: "movie-42") == nil)
+        #expect(DownloadTaskInfo(taskDescription: #"{"id":"a"}"#) == nil)
+    }
+
+    @Test
+    func `path separators never leak into the filename`() {
+        #expect(DownloadManager.sanitize("abc/def:123") == "abc_def_123")
+    }
+}
+
+@Suite("Interrupted download recovery")
+struct DownloadRecoveryTests {
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([
+            Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
+            Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true, cloudKitDatabase: .none)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    private func makeMovie(id: String, status: DownloadStatus?) -> Movie {
+        let movie = Movie(id: id, streamId: 1, name: "Movie \(id)")
+        movie.downloadStatus = status
+        return movie
+    }
+
+    /// A throwaway downloads directory so the sweep's disk probe is deterministic.
+    private func makeDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lume-recovery-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test
+    func `a stranded download whose file never landed is marked failed`() async throws {
+        let container = try makeContainer()
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let context = ModelContext(container)
+        context.insert(makeMovie(id: "gone", status: .downloading))
+        context.insert(makeMovie(id: "queued", status: .pending))
+        try context.save()
+
+        await DownloadManager.recoverInterruptedDownloads(
+            liveIDs: [], directory: directory, container: container
+        )
+
+        let movies = try ModelContext(container).fetch(FetchDescriptor<Movie>())
+        #expect(movies.allSatisfy { $0.downloadStatus == .failed })
+        #expect(movies.allSatisfy { $0.localFileURL == nil })
+    }
+
+    @Test
+    func `a stranded download whose file did land is marked completed`() async throws {
+        let container = try makeContainer()
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // Simulates the app being suspended after the delegate moved the file but
+        // before the SwiftData write landed.
+        let file = directory.appendingPathComponent("landed.mp4")
+        try Data("video".utf8).write(to: file)
+
+        let context = ModelContext(container)
+        context.insert(makeMovie(id: "landed", status: .downloading))
+        try context.save()
+
+        await DownloadManager.recoverInterruptedDownloads(
+            liveIDs: [], directory: directory, container: container
+        )
+
+        let movie = try #require(try ModelContext(container).fetch(FetchDescriptor<Movie>()).first)
+        #expect(movie.downloadStatus == .completed)
+        #expect(movie.localFileURL == file.path)
+        #expect(movie.downloadedAt != nil)
+    }
+
+    @Test
+    func `downloads the restored session is still running are left alone`() async throws {
+        let container = try makeContainer()
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let context = ModelContext(container)
+        context.insert(makeMovie(id: "in-flight", status: .downloading))
+        try context.save()
+
+        await DownloadManager.recoverInterruptedDownloads(
+            liveIDs: ["in-flight"], directory: directory, container: container
+        )
+
+        let movie = try #require(try ModelContext(container).fetch(FetchDescriptor<Movie>()).first)
+        #expect(movie.downloadStatus == .downloading)
+    }
+
+    @Test
+    func `already-completed downloads are never revisited`() async throws {
+        let container = try makeContainer()
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let context = ModelContext(container)
+        let done = makeMovie(id: "done", status: .completed)
+        done.localFileURL = "/some/path/done.mp4"
+        context.insert(done)
+        try context.save()
+
+        await DownloadManager.recoverInterruptedDownloads(
+            liveIDs: [], directory: directory, container: container
+        )
+
+        let movie = try #require(try ModelContext(container).fetch(FetchDescriptor<Movie>()).first)
+        #expect(movie.downloadStatus == .completed)
+        #expect(movie.localFileURL == "/some/path/done.mp4")
+    }
+}


### PR DESCRIPTION
## Summary

Movie and episode downloads stalled the moment the user left Lume and only resumed on the next foreground, so any long download required keeping the app on screen for its whole duration. `DownloadManager` built its session from `URLSessionConfiguration.default`, which the system suspends along with the app. Downloads now run out-of-process in `nsurlsessiond` and continue while Lume is suspended or terminated, finishing cleanly — file moved into place, `downloadStatus` updated — even if the app was killed mid-transfer.

## Implementation

The session moves to `background(withIdentifier:)` with `sessionSendsLaunchEvents = true` and `isDiscretionary = false` (explicit, because the default flips to `true` for sessions created while in the background, and these are user-initiated). A minimal iOS-only `LumeAppDelegate` carries the `handleEventsForBackgroundURLSession` hook, which has no SwiftUI equivalent; reaching it is also what rebuilds the session object a background relaunch needs.

The harder half is that a background session's tasks outlive the process, so the delegate can no longer assume any in-memory state exists when a callback arrives. Each task now carries a `DownloadTaskInfo` (content id, title, destination filename) in `taskDescription`, which the daemon persists alongside the task. That makes `didFinishDownloadingTo` self-contained: it resolves the destination and moves the file to its **final** home synchronously, rather than staging into `tmp` and depending on a main-actor hop the process may be suspended before running.

On launch, `restoreBackgroundSession()` re-adopts whatever is still in flight — rebuilding `taskMap` / `idToTask` / `idToFilename` and the in-progress UI from the live tasks — then reconciles the catalog against them. Downloads the system dropped while the app was gone (force-quitting cancels background transfers) settle by consulting the disk rather than the stored status: the file being present means the download finished, even if the SwiftData write was lost to suspension.

Two smaller things fell out of it. `URLError.cancelled` is now filtered out of `didCompleteWithError` — resolving ids from `taskDescription` would otherwise have turned every user cancel into a spurious "failed" row, since the old code relied on the id already being gone from `taskMap`. And `DownloadManager.swift` was split (value types → `DownloadTypes.swift`, recovery sweep → `DownloadManager+Recovery.swift`) to stay under SwiftLint's 600-line file cap.

**Deliberately not done, both from the issue:**

- **No `UIBackgroundModes` entry.** Background `URLSession` does not require one — the transfer belongs to `nsurlsessiond`, not the app. Declaring an unused background mode is an App Review risk, so `Info.plist` is untouched.
- **No Live Activity.** Scoped out: a download-progress Live Activity needs a widget extension, and `LumeWidgets` + the `group.com.bilipp.lume` App Group already exist on two unmerged branches (`feat/live-activity` for #126, `feat/widgetkit` for #127). Building a third copy here would collide with both. It belongs on top of #126, which already has the ActivityKit plumbing.

## Testing

- [x] Acceptance criteria met
- [x] Builds clean — iOS, tvOS and macOS (all remaining warnings pre-existing)
- [x] Tests pass (iPhone 17 Pro / iOS 26.4)
- [x] SwiftLint clean (`--strict`)
- [x] Tests added — 7 in `LumeTests/Services/BackgroundDownloadTests.swift`: `DownloadTaskInfo` round-trip and rejection of malformed/absent descriptions, id sanitisation, and the four recovery-sweep outcomes (no file → failed, file present → completed, live task → untouched, already-settled → untouched)
- [x] UI verified on simulator

Verified end to end on the simulator against the local example IPTV server:

- The transfer is owned by the daemon — a `CFNetworkDownload_*.tmp` appears under `Library/Caches/com.apple.nsurlsessiond/Downloads/com.bilipp.lume`, and `nsurlsessiond` logs `current discretionary status for com.bilipp.lume is non-discretionary`, confirming `isDiscretionary = false` took effect.
- **Restore across process death:** with a task in flight, terminating and relaunching logs `Adopted 1 in-flight background download(s)`, and the Downloads screen redraws the row with the correct title — which only `taskDescription` could have supplied, since nothing else persists it.
- **Completion:** a 20 MB download landed at the correct sanitised path at full size, with `downloadStatus = completed` and `localFileURL` set. No `tmp/lume-dl` directory was created, confirming the direct-to-destination path rather than the legacy staging fallback. The directory's `com_apple_backup_excludeItem` attribute survived.
- **Cancel:** cancelling clears the status to `nil` rather than leaving a "failed" row — the `URLError.cancelled` guard.

One caveat on the transfer itself: the example server's movies redirect to archive.org, whose mirrors were unreachable from this machine, so the completion run above used a locally served 20 MB file instead (the example-server repo was left unmodified).

## Platforms

- [x] iOS / iPadOS
- [ ] tvOS
- [ ] macOS
- [ ] visionOS

tvOS and macOS build clean but were not exercised at runtime: downloads are not offered on tvOS, and the relaunch hook is iOS-only. macOS keeps the background session and the restore/reconcile pass, so it benefits, but it was not manually verified.

## Related

Closes #175