### PR TITLE
fix(macos): render the Search tab as a plain tab on macOS 15

### DIFF
--- a/Lume/Views/MainTabView.swift
+++ b/Lume/Views/MainTabView.swift
@@ -192,17 +192,23 @@ struct MainTabView: View {
                     LiveTVView()
                 }
 
-                // An explicit label is required: the `Tab(_:systemImage:value:role:)`
-                // convenience is 26-only, and the label-less initializer's
-                // `DefaultTabLabel` renders nothing in the pre-Liquid Glass macOS 15
-                // tab bar — the search tab was invisible there. Supplying the label
-                // keeps `role: .search` (so 26 still gets the dedicated search
-                // treatment) while staying visible on macOS 15 / iOS 18.
-                Tab(value: AppTab.search, role: .search) {
-                    SearchView()
-                } label: {
-                    Label("Search", systemImage: "magnifyingglass")
-                }
+                #if os(macOS)
+                    // macOS 15's tab bar drops a `role: .search` tab entirely — even
+                    // with an explicit label (the previous workaround), the search tab
+                    // never renders, leaving no way to reach Search on macOS 15. Fall
+                    // back to a plain tab, matching the four above, which render fine.
+                    // iOS/visionOS keep `role: .search` below for the dedicated search
+                    // treatment.
+                    Tab("Search", systemImage: "magnifyingglass", value: AppTab.search) {
+                        SearchView()
+                    }
+                #else
+                    Tab(value: AppTab.search, role: .search) {
+                        SearchView()
+                    } label: {
+                        Label("Search", systemImage: "magnifyingglass")
+                    }
+                #endif
             }
         }
     #endif


### PR DESCRIPTION
## Problem

On **macOS 15** (confirmed on 15.7.1, shipping build v1.7.0 build 18), the global **Search tab does not render**. The tab bar shows only Home · Movies · Series · Live TV, and Search is completely unreachable — there is no search tab, no `⌘F` shortcut, and no toolbar search field.

The previous fix (`23aed80`, "make the Search tab visible on macOS 15 / iOS 18") added an explicit `label:` to the `role: .search` tab. That was not sufficient: macOS 15's tab bar drops a search-role tab entirely, label or not.

## Fix

On macOS, use a plain `Tab(_:systemImage:value:)` for Search — the same initializer as the four tabs above it, which render correctly on macOS 15. iOS/visionOS are unchanged and keep `role: .search` for the dedicated search treatment.

```swift
#if os(macOS)
    Tab("Search", systemImage: "magnifyingglass", value: AppTab.search) {
        SearchView()
    }
#else
    Tab(value: AppTab.search, role: .search) {
        SearchView()
    } label: {
        Label("Search", systemImage: "magnifyingglass")
    }
#endif
```

## Verification

- ✅ macOS build succeeds (`Sideload` config)
- ✅ iOS Simulator build succeeds (unchanged `#else` path)
- Trade-off: on macOS 26 the search tab loses the OS's dedicated search affordance and appears as a normal tab. That's a deliberate choice — a visible, plain tab on every macOS version beats an invisible one on macOS 15.