### PR TITLE
fix(macos): make the Search tab reachable on macOS 15 without losing the search role on macOS 26

### DIFF
--- a/Lume/Views/MainTabView.swift
+++ b/Lume/Views/MainTabView.swift
@@ -192,23 +192,23 @@ struct MainTabView: View {
                     LiveTVView()
                 }
 
-                #if os(macOS)
-                    // macOS 15's tab bar drops a `role: .search` tab entirely — even
-                    // with an explicit label (the previous workaround), the search tab
-                    // never renders, leaving no way to reach Search on macOS 15. Fall
-                    // back to a plain tab, matching the four above, which render fine.
-                    // iOS/visionOS keep `role: .search` below for the dedicated search
-                    // treatment.
+                // macOS 15's tab bar drops a `role: .search` tab entirely — even
+                // with an explicit label (the previous workaround), the search tab
+                // never renders, leaving no way to reach Search there. macOS 26
+                // renders the role correctly, as do iOS/visionOS 18+, so only
+                // macOS 15 falls back to a plain tab and every other system keeps
+                // the dedicated search treatment.
+                if #unavailable(macOS 26) {
                     Tab("Search", systemImage: "magnifyingglass", value: AppTab.search) {
                         SearchView()
                     }
-                #else
+                } else {
                     Tab(value: AppTab.search, role: .search) {
                         SearchView()
                     } label: {
                         Label("Search", systemImage: "magnifyingglass")
                     }
-                #endif
+                }
             }
         }
     #endif

--- a/Lume/Views/MainTabView.swift
+++ b/Lume/Views/MainTabView.swift
@@ -192,17 +192,23 @@ struct MainTabView: View {
                     LiveTVView()
                 }
 
-                // An explicit label is required: the `Tab(_:systemImage:value:role:)`
-                // convenience is 26-only, and the label-less initializer's
-                // `DefaultTabLabel` renders nothing in the pre-Liquid Glass macOS 15
-                // tab bar — the search tab was invisible there. Supplying the label
-                // keeps `role: .search` (so 26 still gets the dedicated search
-                // treatment) while staying visible on macOS 15 / iOS 18.
-                Tab(value: AppTab.search, role: .search) {
-                    SearchView()
-                } label: {
-                    Label("Search", systemImage: "magnifyingglass")
-                }
+                #if os(macOS)
+                    // macOS 15's tab bar drops a `role: .search` tab entirely — even
+                    // with an explicit label (the previous workaround), the search tab
+                    // never renders, leaving no way to reach Search on macOS 15. Fall
+                    // back to a plain tab, matching the four above, which render fine.
+                    // iOS/visionOS keep `role: .search` below for the dedicated search
+                    // treatment.
+                    Tab("Search", systemImage: "magnifyingglass", value: AppTab.search) {
+                        SearchView()
+                    }
+                #else
+                    Tab(value: AppTab.search, role: .search) {
+                        SearchView()
+                    } label: {
+                        Label("Search", systemImage: "magnifyingglass")
+                    }
+                #endif
             }
         }
     #endif


### PR DESCRIPTION
Supersedes #177. Carries @jmejay's original commit (`aebecfd`) unchanged, plus a follow-up that narrows the fallback to the systems that actually need it.

## Problem

On **macOS 15** (confirmed on 15.7.1, shipping build v1.7.0 build 18), the global **Search tab does not render**. The tab bar shows only Home · Movies · Series · Live TV, and Search is completely unreachable — no search tab, no `⌘F`, no toolbar search field.

The earlier fix (`23aed80`) added an explicit `label:` to the `role: .search` tab. That was not enough: macOS 15's tab bar drops a search-role tab entirely, label or not.

## Fix

`TabRole` is declared `macOS 15.0+`, so `role: .search` *compiles* on macOS 15 and only fails to **render** there. Gating it at compile time with `#if os(macOS)` would therefore also strip the role from macOS 26, which renders it correctly — costing that version its dedicated search affordance (tab-bar search field and the free `⌘F`) to work around a bug it doesn't have.

So the gate is a runtime availability check instead:

```swift
if #unavailable(macOS 26) {
    Tab("Search", systemImage: "magnifyingglass", value: AppTab.search) {
        SearchView()
    }
} else {
    Tab(value: AppTab.search, role: .search) {
        SearchView()
    } label: {
        Label("Search", systemImage: "magnifyingglass")
    }
}
```

| Platform | Result |
|---|---|
| macOS 15 | Plain tab — Search is visible and reachable |
| macOS 26 | `role: .search` — dedicated search treatment and `⌘F` preserved |
| iOS / visionOS 18+ | `role: .search` — unchanged |

`#unavailable(macOS 26)` evaluates to `false` on non-macOS platforms via the check's implicit `*` wildcard, so iOS and visionOS keep the role branch exactly as before. Using `#unavailable` rather than `#if os(macOS)` wrapped around an `if #available` keeps a single copy of the role-based `Tab` instead of three. `TabContentBuilder` supports the conditional — it declares both `buildEither` and `buildLimitedAvailability` (macOS 26.5 SDK swiftinterface).

tvOS is untouched; it has its own `tabView` with a label-only search tab.

## Verification

- ✅ `xcodebuild` macOS (`platform=macOS,arch=arm64`) — BUILD SUCCEEDED, 0 errors, no diagnostics on `MainTabView.swift`
- ✅ `xcodebuild` iOS Simulator (iPhone 17 Pro) — BUILD SUCCEEDED, 0 errors, no "unnecessary check" warning on the availability condition
- ✅ `swiftformat --lint` and `swiftlint` clean (pre-commit hooks passed)
- ✅ Search stays functional on macOS either way — `SearchView` carries its own `.searchable` (`Lume/Views/SearchView.swift:93`); the role only controls where the field lives