### PR TITLE
fix(trakt): follow Trakt's watched pagination and season-progress change

### DIFF
--- a/Lume/Services/Network/Trakt/TraktClient.swift
+++ b/Lume/Services/Network/Trakt/TraktClient.swift
@@ -38,6 +38,16 @@ nonisolated struct TraktClient {
     static let shared = TraktClient()
 
     private let baseURL = "https://api.trakt.tv"
+
+    /// Requested page size for paginated collections. Trakt's documented maximum;
+    /// endpoints that cap lower (watched shows with `extended=progress`) simply
+    /// return fewer items and a larger page count.
+    private static let pageSize = 250
+
+    /// Hard stop on the page walk so a server that keeps reporting more pages
+    /// can't spin the import forever.
+    private static let pageWalkLimit = 200
+
     private let session: URLSession
     private let clientID: String?
     private let clientSecret: String?
@@ -154,7 +164,11 @@ nonisolated struct TraktClient {
     /// The user's full watchlist (movies and shows), each carrying its external
     /// ids so the home screen can match against the local library by TMDB id.
     func watchlist(accessToken: String) async throws -> [TraktWatchlistItem] {
-        try await get("/sync/watchlist?extended=full", accessToken: accessToken)
+        try await allPages(
+            "/sync/watchlist",
+            query: [URLQueryItem(name: "extended", value: "full")],
+            accessToken: accessToken
+        )
     }
 
     // MARK: - Watched history (import)
@@ -162,13 +176,20 @@ nonisolated struct TraktClient {
     /// Every movie in the user's watched history, each carrying its TMDB id so
     /// the import can match it against the local library.
     func watchedMovies(accessToken: String) async throws -> [TraktWatchedMovie] {
-        try await get("/sync/watched/movies", accessToken: accessToken)
+        try await allPages("/sync/watched/movies", accessToken: accessToken)
     }
 
     /// Every show in the user's watched history with the watched seasons and
     /// episodes nested, so the import can mark the matching local episodes.
     func watchedShows(accessToken: String) async throws -> [TraktWatchedShow] {
-        try await get("/sync/watched/shows", accessToken: accessToken)
+        // Since Trakt's 2026 watched-endpoint change the default response carries
+        // no season progress at all, and `extended=full`/`noseason` are no-ops.
+        // `extended=progress` is the only mode that still nests the episodes.
+        try await allPages(
+            "/sync/watched/shows",
+            query: [URLQueryItem(name: "extended", value: "progress")],
+            accessToken: accessToken
+        )
     }
 
     // MARK: - Networking
@@ -176,7 +197,41 @@ nonisolated struct TraktClient {
     private func get<T: Decodable>(_ path: String, accessToken: String? = nil) async throws -> T {
         var request = try makeRequest(path: path, method: "GET", accessToken: accessToken)
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        return try await send(request)
+        return try await send(request).value
+    }
+
+    /// Walks every page of a collection endpoint and returns the concatenated
+    /// items. Trakt paginates these server-side and caps the page size per
+    /// endpoint, so the requested `limit` is a hint: the walk follows the
+    /// `X-Pagination-Page-Count` of each response rather than assuming one.
+    private func allPages<T: Decodable>(
+        _ path: String,
+        query: [URLQueryItem] = [],
+        accessToken: String
+    ) async throws -> [T] {
+        var items: [T] = []
+        var page = 1
+        var pageCount = 1
+
+        while page <= pageCount, page <= Self.pageWalkLimit {
+            let pageQuery = query + [
+                URLQueryItem(name: "page", value: String(page)),
+                URLQueryItem(name: "limit", value: String(Self.pageSize))
+            ]
+            var request = try makeRequest(path: path, method: "GET", query: pageQuery, accessToken: accessToken)
+            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            let (batch, response): ([T], HTTPURLResponse) = try await send(request)
+            if batch.isEmpty { break }
+            items += batch
+
+            if let header = response.value(forHTTPHeaderField: "X-Pagination-Page-Count"),
+               let reported = Int(header)
+            {
+                pageCount = reported
+            }
+            page += 1
+        }
+        return items
     }
 
     private func post<T: Decodable>(
@@ -189,11 +244,22 @@ nonisolated struct TraktClient {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.httpBody = try JSONEncoder().encode(body)
-        return try await send(request)
+        return try await send(request).value
     }
 
-    private func makeRequest(path: String, method: String, accessToken: String?) throws -> URLRequest {
-        guard let clientID, let url = URL(string: baseURL + path) else { throw TraktError.notConfigured }
+    private func makeRequest(
+        path: String,
+        method: String,
+        query: [URLQueryItem] = [],
+        accessToken: String?
+    ) throws -> URLRequest {
+        guard let clientID, var components = URLComponents(string: baseURL + path) else {
+            throw TraktError.notConfigured
+        }
+        if !query.isEmpty {
+            components.queryItems = (components.queryItems ?? []) + query
+        }
+        guard let url = components.url else { throw TraktError.notConfigured }
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.setValue("2", forHTTPHeaderField: "trakt-api-version")
@@ -204,7 +270,7 @@ nonisolated struct TraktClient {
         return request
     }
 
-    private func send<T: Decodable>(_ request: URLRequest) async throws -> T {
+    private func send<T: Decodable>(_ request: URLRequest) async throws -> (value: T, response: HTTPURLResponse) {
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw TraktError.invalidResponse }
         guard (200 ... 299).contains(http.statusCode) else {
@@ -215,10 +281,10 @@ nonisolated struct TraktClient {
         // Some endpoints (revoke) return an empty body; tolerate that for the
         // sentinel `EmptyResponse` decode.
         if data.isEmpty, let empty = EmptyResponse() as? T {
-            return empty
+            return (empty, http)
         }
         do {
-            return try JSONDecoder().decode(T.self, from: data)
+            return try (JSONDecoder().decode(T.self, from: data), http)
         } catch {
             throw TraktError.decoding
         }
@@ -382,6 +448,24 @@ struct TraktWatchedMovie: Decodable {
 struct TraktWatchedShow: Decodable {
     let show: TraktWatchedMedia
     let seasons: [TraktWatchedSeason]
+
+    init(show: TraktWatchedMedia, seasons: [TraktWatchedSeason]) {
+        self.show = show
+        self.seasons = seasons
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        show = try container.decode(TraktWatchedMedia.self, forKey: .show)
+        // Trakt only nests the seasons for `extended=progress`. A missing key
+        // means "no episode progress", not a broken response — failing here
+        // would abort the whole import.
+        seasons = try container.decodeIfPresent([TraktWatchedSeason].self, forKey: .seasons) ?? []
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case show, seasons
+    }
 }
 
 struct TraktWatchedSeason: Decodable {

--- a/LumeTests/Services/TraktClientPagingTests.swift
+++ b/LumeTests/Services/TraktClientPagingTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+@testable import Lume
+import Testing
+
+/// Serves canned Trakt collection pages and records the query each request
+/// carried, so the walk can be asserted end to end.
+private final nonisolated class TraktStubProtocol: URLProtocol {
+    struct Endpoint {
+        /// Response body per requested `page`.
+        var pages: [Int: String]
+        /// Page count reported back in `X-Pagination-Page-Count`.
+        var pageCount: Int
+        var requestedQueries: [[String: String]] = []
+    }
+
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var endpoints: [String: Endpoint] = [:]
+
+    static func register(host: String, endpoint: Endpoint) {
+        lock.withLock { endpoints[host] = endpoint }
+    }
+
+    static func requestedQueries(host: String) -> [[String: String]] {
+        lock.withLock { endpoints[host]?.requestedQueries ?? [] }
+    }
+
+    // `URLProtocol` requires these as `class func` overrides — `static` can't
+    // override.
+    // swiftlint:disable:next static_over_final_class
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    // swiftlint:disable:next static_over_final_class
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url,
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        let host = components.host ?? ""
+        var query: [String: String] = [:]
+        for item in components.queryItems ?? [] {
+            query[item.name] = item.value
+        }
+        let page = Int(query["page"] ?? "") ?? 1
+
+        let (body, pageCount) = Self.lock.withLock { () -> (String?, Int) in
+            Self.endpoints[host]?.requestedQueries.append(query)
+            let endpoint = Self.endpoints[host]
+            return (endpoint?.pages[page], endpoint?.pageCount ?? 1)
+        }
+
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["X-Pagination-Page-Count": String(pageCount)]
+        ) else { return }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data((body ?? "[]").utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+// Serialized: every test drives the same `api.trakt.tv` stub registration.
+@MainActor
+@Suite(.serialized)
+struct TraktClientPagingTests {
+    private func makeClient() -> TraktClient {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [TraktStubProtocol.self]
+        return TraktClient(
+            session: URLSession(configuration: config),
+            clientID: "test-client-id",
+            clientSecret: "test-client-secret"
+        )
+    }
+
+    /// A `/sync/watched/movies` page body carrying the given TMDB ids.
+    private func moviePage(tmdbIDs: ClosedRange<Int>) -> String {
+        let items = tmdbIDs
+            .map { #"{"last_watched_at":"2026-01-0\#($0 % 9 + 1)T12:00:00.000Z","movie":{"ids":{"tmdb":\#($0)}}}"# }
+            .joined(separator: ",")
+        return "[\(items)]"
+    }
+
+    @Test func `watched movies walk every reported page`() async throws {
+        TraktStubProtocol.register(host: "api.trakt.tv", endpoint: .init(
+            pages: [
+                1: moviePage(tmdbIDs: 1 ... 250),
+                2: moviePage(tmdbIDs: 251 ... 500),
+                3: moviePage(tmdbIDs: 501 ... 610)
+            ],
+            pageCount: 3
+        ))
+
+        let movies = try await makeClient().watchedMovies(accessToken: "token")
+
+        #expect(movies.count == 610)
+        #expect(movies.first?.movie.ids.tmdb == 1)
+        #expect(movies.last?.movie.ids.tmdb == 610)
+
+        let queries = TraktStubProtocol.requestedQueries(host: "api.trakt.tv")
+        #expect(queries.count == 3)
+        #expect(queries.map { $0["page"] } == ["1", "2", "3"])
+        #expect(queries.allSatisfy { $0["limit"] == "250" })
+    }
+
+    @Test func `watched shows request season progress`() async throws {
+        let body = """
+        [{"show":{"ids":{"tmdb":300}},"seasons":[{"number":1,"episodes":[\
+        {"number":1,"last_watched_at":"2026-01-02T12:00:00.000Z"}]}]}]
+        """
+        TraktStubProtocol.register(host: "api.trakt.tv", endpoint: .init(pages: [1: body], pageCount: 1))
+
+        let shows = try await makeClient().watchedShows(accessToken: "token")
+
+        #expect(shows.count == 1)
+        #expect(shows.first?.seasons.first?.episodes.first?.number == 1)
+        // Without `extended=progress` Trakt returns no season progress at all.
+        #expect(TraktStubProtocol.requestedQueries(host: "api.trakt.tv").first?["extended"] == "progress")
+    }
+
+    @Test func `a show without seasons decodes as no progress`() async throws {
+        TraktStubProtocol.register(host: "api.trakt.tv", endpoint: .init(
+            pages: [1: #"[{"plays":5,"show":{"ids":{"tmdb":300}},"aired_episodes":12}]"#],
+            pageCount: 1
+        ))
+
+        let shows = try await makeClient().watchedShows(accessToken: "token")
+
+        #expect(shows.count == 1)
+        #expect(shows.first?.show.ids.tmdb == 300)
+        #expect(shows.first?.seasons.isEmpty == true)
+    }
+
+    @Test func `the walk stops on an empty page`() async throws {
+        TraktStubProtocol.register(host: "api.trakt.tv", endpoint: .init(
+            pages: [1: moviePage(tmdbIDs: 1 ... 10), 2: "[]", 3: moviePage(tmdbIDs: 11 ... 20)],
+            pageCount: 3
+        ))
+
+        let movies = try await makeClient().watchedMovies(accessToken: "token")
+
+        #expect(movies.count == 10)
+        #expect(TraktStubProtocol.requestedQueries(host: "api.trakt.tv").count == 2)
+    }
+
+    @Test func `watchlist keeps extended full while paging`() async throws {
+        let page = #"[{"type":"movie","movie":{"title":"A","year":2020,"ids":{"tmdb":7}}}]"#
+        TraktStubProtocol.register(host: "api.trakt.tv", endpoint: .init(
+            pages: [1: page, 2: page],
+            pageCount: 2
+        ))
+
+        let items = try await makeClient().watchlist(accessToken: "token")
+
+        #expect(items.count == 2)
+        let queries = TraktStubProtocol.requestedQueries(host: "api.trakt.tv")
+        #expect(queries.count == 2)
+        #expect(queries.allSatisfy { $0["extended"] == "full" })
+    }
+}


### PR DESCRIPTION
## Summary
Trakt's watched-endpoint change ([trakt/trakt-api#775](https://github.com/trakt/trakt-api/discussions/775)) broke the watched-history import outright. `/sync/watched/shows` no longer nests `seasons` unless `extended=progress` is requested — `extended=full`/`noseason` are now no-ops and the default response carries no season progress at all. `TraktWatchedShow.seasons` was non-optional, so the missing key threw `TraktError.decoding` and `importWatched` failed before applying anything. That matches the report: connect works, import fails every time, on every device.

The same change also enforces pagination on these endpoints. Verified live against the app's client id: `/sync/watched/movies` returns 100 of 1533 items with `X-Pagination-Page-Count: 16`, and `/sync/watchlist` is paginated too (100 of 300). Lume sent no `page`/`limit` and read no pagination headers, so even with decoding fixed it would import only the first 100 movies and 100 shows, and show only the first 100 watchlist entries.

## Implementation
- `watchedShows` now requests `extended=progress`, the only mode that still returns nested seasons/episodes.
- Added a private `allPages` walk in `TraktClient` that follows `X-Pagination-Page-Count` per response rather than assuming the requested `limit` is honored — Trakt caps the page size per endpoint (250 for watched movies, 100 for watched shows with `extended=progress`). Used by watched movies, watched shows, and the watchlist. It stops on an empty page and has a hard page cap so a misbehaving server can't spin the import.
- `send` now returns the `HTTPURLResponse` alongside the decoded value so the walk can read the pagination headers; `get`/`post` are unchanged at their call sites.
- `TraktWatchedShow` decodes a missing `seasons` key as `[]` instead of throwing, so a future default-shape change degrades to "no episode progress" rather than failing the whole import.

## Testing
- [x] Acceptance criteria met
- [x] Builds clean (XcodeBuildMCP `build_sim`, 0 errors)
- [x] Tests pass (XcodeBuildMCP `test_sim`, iPhone 17 Pro / iOS 26.5 — 10/10 across `TraktClientPagingTests` and `TraktWatchedImporterTests`)
- [x] SwiftLint clean (vendored SwiftFormat 0.61.1 + SwiftLint `--strict`)
- [x] Tests added — new `TraktClientPagingTests` covers the multi-page walk, the `extended=progress` query, a `seasons`-less show decoding as no progress, the empty-page stop, and the watchlist keeping `extended=full` while paging
- [ ] UI verified on simulator — n/a: networking-only change with no UI surface; a real end-to-end import needs a connected Trakt account, so the endpoint shapes were verified against the live API with `curl` instead

## Platforms
- [x] iOS / iPadOS
- [ ] tvOS
- [ ] macOS
- [ ] visionOS
<!-- Platform-agnostic networking change; built and tested on iOS -->

## Related
Closes #178