### PR TITLE
fix(home): honor hidden categories on Home, Search and For You

### DIFF
--- a/Lume/Services/ParentalControls/ContentRestriction.swift
+++ b/Lume/Services/ParentalControls/ContentRestriction.swift
@@ -2,26 +2,53 @@
 //  ContentRestriction.swift
 //  Lume
 //
-//  Describes which content is hidden from the current viewer because of parental
-//  controls. `MainTabView` builds it from the restricted categories and the
-//  active profile's `isChild` flag and injects it into the environment; every
-//  content surface (browse grids, the cross-category rows, Home and Search)
-//  reads it so restricted categories — and any title in them — disappear while a
-//  child profile is active. A parent profile sees everything (`isActive` false).
+//  Describes which content is hidden from the current viewer. Two independent
+//  sources feed it: categories the user hid in Settings › Content Management
+//  (always applied), and categories marked restricted by parental controls
+//  (applied only while a child profile is active, so `isActive` is false for a
+//  parent). `MainTabView` builds it from both and injects it into the
+//  environment; every content surface (browse grids, the cross-category rows,
+//  Home, Search and the "For You" engine) reads it so a hidden or restricted
+//  category — and any title in it — disappears everywhere alike.
 //
 
+import CryptoKit
 import SwiftUI
 
 nonisolated struct ContentRestriction: Equatable {
-    /// True when the active profile is a child: restriction applies only to kids.
+    /// True when the active profile is a child: `restrictedCategoryIDs` applies
+    /// only to kids.
     var isActive = false
     /// Ids of the categories marked restricted.
     var restrictedCategoryIDs: Set<String> = []
+    /// Ids of the categories the user hid in Content Management. Unlike
+    /// restricted ones these apply to every profile.
+    var hiddenCategoryIDs: Set<String> = []
+
+    /// Every category id excluded for the current viewer.
+    var excludedCategoryIDs: Set<String> {
+        isActive ? hiddenCategoryIDs.union(restrictedCategoryIDs) : hiddenCategoryIDs
+    }
+
+    /// A stable digest of `excludedCategoryIDs`, for cache keys that must not
+    /// outlive a visibility change (Home's trending memo, the "For You" list).
+    /// Hashed rather than joined verbatim: a user who hides most of a large
+    /// catalog would otherwise put tens of kilobytes in a key. `hashValue` is
+    /// seeded per process and would differ every launch, so it can't be used.
+    var visibilityToken: String {
+        Self.visibilityToken(for: excludedCategoryIDs)
+    }
+
+    static func visibilityToken(for excludedCategoryIDs: Set<String>) -> String {
+        let joined = excludedCategoryIDs.sorted().joined(separator: "\n")
+        return SHA256.hash(data: Data(joined.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
 
     /// Whether content in `categoryID` should be hidden from the current viewer.
     func hides(categoryID: String?) -> Bool {
-        guard isActive, let categoryID else { return false }
-        return restrictedCategoryIDs.contains(categoryID)
+        guard let categoryID else { return false }
+        if hiddenCategoryIDs.contains(categoryID) { return true }
+        return isActive && restrictedCategoryIDs.contains(categoryID)
     }
 }
 
@@ -30,7 +57,8 @@ extension EnvironmentValues {
 }
 
 /// Content that belongs to a `Category`, so it can be filtered when that category
-/// is restricted. Movies, series and live channels all carry a `categoryId`.
+/// is hidden or restricted. Movies, series and live channels all carry a
+/// `categoryId`.
 protocol CategorizedContent {
     var categoryId: String? { get }
 }
@@ -40,12 +68,11 @@ extension Series: CategorizedContent {}
 extension LiveStream: CategorizedContent {}
 
 extension Sequence where Element: CategorizedContent {
-    /// Drops items whose category is restricted for the current viewer. A no-op
-    /// when restriction is inactive (a parent profile) or nothing is restricted.
+    /// Drops items whose category is hidden or restricted for the current
+    /// viewer. A no-op when nothing is excluded.
     func excludingRestricted(_ restriction: ContentRestriction) -> [Element] {
-        guard restriction.isActive, !restriction.restrictedCategoryIDs.isEmpty else {
-            return Array(self)
-        }
-        return filter { !restriction.restrictedCategoryIDs.contains($0.categoryId ?? "") }
+        let excluded = restriction.excludedCategoryIDs
+        guard !excluded.isEmpty else { return Array(self) }
+        return filter { !excluded.contains($0.categoryId ?? "") }
     }
 }

--- a/Lume/Services/Recommendations/RecommendationCacheStore.swift
+++ b/Lume/Services/Recommendations/RecommendationCacheStore.swift
@@ -10,10 +10,22 @@
 
 import Foundation
 
-/// A cached recommendation list plus when it was produced.
+/// A cached recommendation list plus when it was produced and the content
+/// visibility it was ranked under.
 nonisolated struct RecommendationCache: Codable, Equatable {
     var computedAt: Date
     var items: [ScoredRecommendation]
+    /// `ContentRestriction.visibilityToken` for the categories excluded when the
+    /// list was computed. `nil` for a cache written before visibility was accounted for,
+    /// which therefore never matches and recomputes once. Optional so decoding
+    /// those older entries still succeeds.
+    var visibilityToken: String?
+
+    init(computedAt: Date, items: [ScoredRecommendation], visibilityToken: String? = nil) {
+        self.computedAt = computedAt
+        self.items = items
+        self.visibilityToken = visibilityToken
+    }
 }
 
 nonisolated struct RecommendationCacheStore {

--- a/Lume/Services/Recommendations/RecommendationEngine.swift
+++ b/Lume/Services/Recommendations/RecommendationEngine.swift
@@ -68,16 +68,24 @@ actor RecommendationEngine {
     }
 
     /// The top `limit` unwatched titles for the active profile, best first.
+    /// Candidates in `excludedCategoryIDs` (hidden in Content Management, or
+    /// restricted for a child profile) never enter the ranking, so the row isn't
+    /// filled with titles the caller has to drop again.
     ///
     /// Throttled: a non-empty list computed within `recalculationInterval` is
     /// returned from the cache instead of re-ranking the catalog. The caller
     /// re-validates each entry against live state, so a freshly watched, favorited
     /// or voted title still drops out between recomputes. Empty when the user has
     /// no taste signals yet — the caller then simply hides the row.
-    func recommendations(limit: Int = 30) -> [ScoredRecommendation] {
+    func recommendations(limit: Int = 30, excluding excludedCategoryIDs: Set<String> = []) -> [ScoredRecommendation] {
         let profileID = ActiveProfileStore.current
+        let visibility = ContentRestriction.visibilityToken(for: excludedCategoryIDs)
+        // A changed visibility set invalidates the cache: the list was ranked
+        // against the previous one, so titles the user just un-hid would stay
+        // missing until the interval elapsed.
         if let cached = cacheStore.cache(for: profileID),
            !cached.items.isEmpty,
+           cached.visibilityToken == visibility,
            Date().timeIntervalSince(cached.computedAt) < recalculationInterval
         {
             return cached.items
@@ -87,12 +95,17 @@ actor RecommendationEngine {
             return []
         }
         let dislike = RecommendationScoring.centroid(of: dislikeSignals())
-        let ranked = rankCandidates(limit: limit, taste: taste, dislike: dislike)
+        let ranked = rankCandidates(
+            limit: limit, taste: taste, dislike: dislike, excluding: excludedCategoryIDs
+        )
 
         // Only cache a real result — an empty one means "no signal yet", which
         // should retry cheaply as soon as the user favorites or watches something.
         if !ranked.isEmpty {
-            cacheStore.save(RecommendationCache(computedAt: Date(), items: ranked), for: profileID)
+            cacheStore.save(
+                RecommendationCache(computedAt: Date(), items: ranked, visibilityToken: visibility),
+                for: profileID
+            )
         }
         return ranked
     }
@@ -170,9 +183,13 @@ actor RecommendationEngine {
 
     // MARK: - Candidate ranking
 
-    /// Scores every unwatched candidate against the taste profile a page at a
-    /// time, keeping only the running top `limit`.
-    private func rankCandidates(limit: Int, taste: [Float], dislike: [Float]?) -> [ScoredRecommendation] {
+    /// Scores every unwatched, visible candidate against the taste profile a page
+    /// at a time, keeping only the running top `limit`. The pages already walk
+    /// the whole candidate set, so the category exclusion is applied in memory
+    /// rather than widening the (index-served) predicate.
+    private func rankCandidates(
+        limit: Int, taste: [Float], dislike: [Float]?, excluding excluded: Set<String>
+    ) -> [ScoredRecommendation] {
         var top: [(item: ScoredRecommendation, score: Float)] = []
 
         func consider(_ id: String, _ kind: RecommendedKind, _ score: Float) {
@@ -184,49 +201,49 @@ actor RecommendationEngine {
 
         // Movies: unwatched, not favorited, never opened, not yet voted on (a
         // voted title — up or down — has already left the rail).
-        var movieOffset = 0
-        while true {
-            let context = ModelContext(modelContainer)
-            var descriptor = FetchDescriptor<Movie>(
-                predicate: #Predicate {
-                    $0.embeddingData != nil && !$0.isWatched && !$0.isFavorite
-                        && $0.lastWatchedDate == nil && $0.recommendationVoteRaw == 0
-                },
-                sortBy: [SortDescriptor(\.id)]
-            )
-            descriptor.fetchOffset = movieOffset
-            descriptor.fetchLimit = pageSize
-            let page = (try? context.fetch(descriptor)) ?? []
-            for movie in page {
-                guard let vector = movie.embeddingData.map(TextEmbedder.decode) else { continue }
-                consider(movie.id, .movie, RecommendationScoring.score(candidate: vector, taste: taste, dislike: dislike))
-            }
-            if page.count < pageSize { break }
-            movieOffset += pageSize
+        forEachPage(predicate: #Predicate<Movie> {
+            $0.embeddingData != nil && !$0.isWatched && !$0.isFavorite
+                && $0.lastWatchedDate == nil && $0.recommendationVoteRaw == 0
+        }, sortBy: [SortDescriptor(\.id)]) { movie in
+            guard !excluded.contains(movie.categoryId ?? ""),
+                  let vector = movie.embeddingData.map(TextEmbedder.decode) else { return }
+            consider(movie.id, .movie, RecommendationScoring.score(candidate: vector, taste: taste, dislike: dislike))
         }
 
         // Series: not favorited, never opened, not yet voted on.
-        var seriesOffset = 0
-        while true {
-            let context = ModelContext(modelContainer)
-            var descriptor = FetchDescriptor<Series>(
-                predicate: #Predicate {
-                    $0.embeddingData != nil && !$0.isFavorite
-                        && $0.lastWatchedDate == nil && $0.recommendationVoteRaw == 0
-                },
-                sortBy: [SortDescriptor(\.id)]
-            )
-            descriptor.fetchOffset = seriesOffset
-            descriptor.fetchLimit = pageSize
-            let page = (try? context.fetch(descriptor)) ?? []
-            for show in page {
-                guard let vector = show.embeddingData.map(TextEmbedder.decode) else { continue }
-                consider(show.id, .series, RecommendationScoring.score(candidate: vector, taste: taste, dislike: dislike))
-            }
-            if page.count < pageSize { break }
-            seriesOffset += pageSize
+        forEachPage(predicate: #Predicate<Series> {
+            $0.embeddingData != nil && !$0.isFavorite
+                && $0.lastWatchedDate == nil && $0.recommendationVoteRaw == 0
+        }, sortBy: [SortDescriptor(\.id)]) { show in
+            guard !excluded.contains(show.categoryId ?? ""),
+                  let vector = show.embeddingData.map(TextEmbedder.decode) else { return }
+            consider(show.id, .series, RecommendationScoring.score(candidate: vector, taste: taste, dislike: dislike))
         }
 
         return top.map(\.item)
+    }
+
+    /// Walks every matching row `pageSize` at a time on a fresh context per page,
+    /// so no managed object outlives the page it came from — what keeps peak
+    /// memory bounded regardless of catalog size. `sortBy` must be stable, or
+    /// offset paging would skip or repeat rows.
+    private func forEachPage<Model: PersistentModel>(
+        predicate: Predicate<Model>,
+        sortBy: [SortDescriptor<Model>],
+        body: (Model) -> Void
+    ) {
+        var offset = 0
+        while true {
+            let context = ModelContext(modelContainer)
+            var descriptor = FetchDescriptor<Model>(predicate: predicate, sortBy: sortBy)
+            descriptor.fetchOffset = offset
+            descriptor.fetchLimit = pageSize
+            let page = (try? context.fetch(descriptor)) ?? []
+            page.forEach(body)
+            if page.count < pageSize {
+                return
+            }
+            offset += pageSize
+        }
     }
 }

--- a/Lume/Views/Components/GenreBrowse.swift
+++ b/Lume/Views/Components/GenreBrowse.swift
@@ -48,7 +48,7 @@ enum GenreDerivation {
         }.value
     }
 
-    /// Scopes the sampled rows to the active playlist and viewer (the parental
+    /// Scopes the sampled rows to the active playlist and viewer (the
     /// `excludingRestricted` filter, inlined so this stays `nonisolated`), then
     /// derives the distinct genres. Runs on the caller's background context.
     private nonisolated static func derive(
@@ -56,10 +56,10 @@ enum GenreDerivation {
         restriction: ContentRestriction,
         rows: [some GenreCarrying]
     ) -> [String] {
-        let restricted = restriction.isActive ? restriction.restrictedCategoryIDs : []
+        let excluded = restriction.excludedCategoryIDs
         let genres = rows.lazy
             .filter { $0.id.hasPrefix(playlistPrefix) }
-            .filter { restricted.isEmpty || !restricted.contains($0.categoryId ?? "") }
+            .filter { excluded.isEmpty || !excluded.contains($0.categoryId ?? "") }
             .map(\.genre)
         return GenreParser.distinctByFrequency(Array(genres))
     }

--- a/Lume/Views/Home/HomeView.swift
+++ b/Lume/Views/Home/HomeView.swift
@@ -98,8 +98,10 @@ struct HomeView: View {
         series.fetchLimit = 20
         _watchedSeries = Query(series)
 
+        // Channels hidden in Content Management drop out here, the same way Live
+        // TV drops them; a hidden *category* is handled by `excludingRestricted`.
         var streams = FetchDescriptor<LiveStream>(
-            predicate: #Predicate { $0.lastWatchedDate != nil },
+            predicate: #Predicate { $0.lastWatchedDate != nil && $0.isHidden == false },
             sortBy: [SortDescriptor(\.lastWatchedDate, order: .reverse)]
         )
         streams.fetchLimit = 20
@@ -123,7 +125,7 @@ struct HomeView: View {
         _favoriteSeries = Query(favSeries)
 
         var favStreams = FetchDescriptor<LiveStream>(
-            predicate: #Predicate { $0.isFavorite },
+            predicate: #Predicate { $0.isFavorite && $0.isHidden == false },
             sortBy: [SortDescriptor(\.favoriteOrder), SortDescriptor(\.name)]
         )
         favStreams.fetchLimit = 30
@@ -209,11 +211,11 @@ struct HomeView: View {
                     }
                 }
             #endif
-                .task(id: "\(playlists.count)-\(selectedPlaylistID)-\(activePlaylist?.lastSyncDate?.timeIntervalSince1970 ?? 0)") {
-                    await loadTrending(cacheKey: "\(playlists.count)-\(selectedPlaylistID)-\(activePlaylist?.lastSyncDate?.timeIntervalSince1970 ?? 0)")
+                .task(id: trendingKey) {
+                    await loadTrending(cacheKey: trendingKey)
                 }
-                .task(id: "watchlist-\(trakt.isConnected)-\(selectedPlaylistID)") {
-                    await loadWatchlist(cacheKey: "watchlist-\(trakt.isConnected)-\(selectedPlaylistID)")
+                .task(id: watchlistKey) {
+                    await loadWatchlist(cacheKey: watchlistKey)
                 }
                 .task(id: recommendationsKey) {
                     await loadRecommendations()
@@ -294,6 +296,19 @@ struct HomeView: View {
                 animationNamespace: animationNamespace
             )
         }
+    }
+
+    /// Identity of the trending/hero load, and the key its session memo is
+    /// stored under. Includes the visibility token so hiding a category in
+    /// Content Management reloads the rows instead of replaying a cached list
+    /// that was matched against the whole catalog.
+    var trendingKey: String {
+        let synced = activePlaylist?.lastSyncDate?.timeIntervalSince1970 ?? 0
+        return "\(playlists.count)-\(selectedPlaylistID)-\(synced)-\(restriction.visibilityToken)"
+    }
+
+    var watchlistKey: String {
+        "watchlist-\(trakt.isConnected)-\(selectedPlaylistID)-\(restriction.visibilityToken)"
     }
 
     // MARK: - Playlist scoping
@@ -412,13 +427,14 @@ struct HomeView: View {
 // MARK: - For You
 
 private extension HomeView {
-    /// Refresh the row when the active playlist or the favorites/history queries
-    /// change. This only re-resolves the list (cheap, and re-validates each entry
-    /// against live state) — the engine still throttles the actual re-ranking to
+    /// Refresh the row when the active playlist, the favorites/history queries or
+    /// the hidden categories change. This only re-resolves the list (cheap, and
+    /// re-validates each entry against live state) — the engine still throttles the actual re-ranking to
     /// its recalculation interval.
     var recommendationsKey: String {
         let counts = "\(watchedMovies.count)-\(watchedSeries.count)-\(favoriteMovies.count)-\(favoriteSeries.count)"
-        return "rec-\(recommendationsEnabled)-\(premium.isPremium)-\(isSyncBusy)-\(recommendationsRecalcToken)-\(counts)-\(selectedPlaylistID)"
+        let visibility = restriction.visibilityToken
+        return "rec-\(recommendationsEnabled)-\(premium.isPremium)-\(isSyncBusy)-\(recommendationsRecalcToken)-\(counts)-\(selectedPlaylistID)-\(visibility)"
     }
 
     /// True while a playlist sync, iCloud sync or EPG import is running. The For
@@ -449,7 +465,7 @@ private extension HomeView {
         defer { Perf.end(interval) }
 
         let engine = RecommendationEngine(modelContainer: modelContext.container)
-        let scored = await engine.recommendations()
+        let scored = await engine.recommendations(excluding: restriction.excludedCategoryIDs)
         var items: [HomeMediaItem] = []
         for recommendation in scored {
             switch recommendation.kind {

--- a/Lume/Views/MainTabView.swift
+++ b/Lume/Views/MainTabView.swift
@@ -15,9 +15,11 @@ struct MainTabView: View {
     @Environment(PlaylistSwitchModel.self) private var playlistSwitch: PlaylistSwitchModel?
     @Environment(ProfileManager.self) private var profileManager: ProfileManager?
     @Query private var playlists: [Playlist]
-    /// Categories marked restricted. Fetched once here so a single source feeds
-    /// the restriction context every content surface reads from the environment.
+    /// Categories marked restricted, and categories hidden in Content
+    /// Management. Fetched once here so a single source feeds the restriction
+    /// context every content surface reads from the environment.
     @Query(filter: #Predicate<Category> { $0.isRestricted }) private var restrictedCategories: [Category]
+    @Query(filter: #Predicate<Category> { $0.isHidden }) private var hiddenCategories: [Category]
 
     @AppStorage(SyncFrequency.storageKey) private var syncFrequencyRaw: String = SyncFrequency.defaultValue.rawValue
     @AppStorage(PlaylistSelectionStore.key) private var selectedPlaylistID: String = ""
@@ -48,12 +50,14 @@ struct MainTabView: View {
         CommandLine.arguments.contains("-ui-testing")
     }
 
-    /// Hides restricted categories (and their content) from every browse, Home
-    /// and Search surface while a child profile is active.
+    /// Hides categories (and their content) from every browse, Home and Search
+    /// surface: the ones hidden in Content Management always, the restricted
+    /// ones while a child profile is active.
     private var contentRestriction: ContentRestriction {
         ContentRestriction(
             isActive: profileManager?.activeProfileIsChild ?? false,
-            restrictedCategoryIDs: Set(restrictedCategories.map(\.id))
+            restrictedCategoryIDs: Set(restrictedCategories.map(\.id)),
+            hiddenCategoryIDs: Set(hiddenCategories.map(\.id))
         )
     }
 

--- a/Lume/Views/SearchFetching.swift
+++ b/Lume/Views/SearchFetching.swift
@@ -1,0 +1,141 @@
+//
+//  SearchFetching.swift
+//  Lume
+//
+//  The off-main fetch behind `SearchView` and the predicates it runs. Split out
+//  of the view file to keep it within the size limit; the predicates are also
+//  `internal` so the tests can run them against a SQLite store, where their SQL
+//  is actually generated.
+//
+
+import SwiftData
+import SwiftUI
+
+// MARK: - Off-main search fetch
+
+/// The matched rows' persistent identifiers, grouped by type. Plain value type
+/// so it can cross back from the background fetch context.
+nonisolated struct SearchHits {
+    var movies: [PersistentIdentifier] = []
+    var series: [PersistentIdentifier] = []
+    var streams: [PersistentIdentifier] = []
+}
+
+/// The settled query and the per-type toggles, bundled so the off-main fetch
+/// takes a single `Sendable` value.
+nonisolated struct SearchRequest {
+    let query: String
+    let playlistID: String
+    let restrictToPlaylist: Bool
+    let wantMovies: Bool
+    let wantSeries: Bool
+    let wantLive: Bool
+    let excludedCategoryIDs: Set<String>
+    let limit: Int
+}
+
+/// Runs the bounded `localizedStandardContains` fetches on a background
+/// `ModelContext` and returns only identifiers — never managed objects, which
+/// can't cross actor boundaries.
+nonisolated enum SearchFetcher {
+    static func fetch(container: ModelContainer, request: SearchRequest) -> SearchHits {
+        let scope = SearchScope(
+            query: request.query,
+            playlistID: request.playlistID,
+            restrictToPlaylist: request.restrictToPlaylist,
+            excluded: request.excludedCategoryIDs
+        )
+        let limit = request.limit
+        let context = ModelContext(container)
+        var hits = SearchHits()
+
+        if request.wantMovies {
+            var descriptor = FetchDescriptor<Movie>(
+                predicate: searchMoviePredicate(scope: scope),
+                sortBy: [SortDescriptor(\.name)]
+            )
+            descriptor.fetchLimit = limit
+            hits.movies = ((try? context.fetch(descriptor)) ?? []).map(\.persistentModelID)
+        }
+
+        if request.wantSeries {
+            var descriptor = FetchDescriptor<Series>(
+                predicate: searchSeriesPredicate(scope: scope),
+                sortBy: [SortDescriptor(\.name)]
+            )
+            descriptor.fetchLimit = limit
+            hits.series = ((try? context.fetch(descriptor)) ?? []).map(\.persistentModelID)
+        }
+
+        if request.wantLive {
+            var descriptor = FetchDescriptor<LiveStream>(
+                predicate: searchLiveStreamPredicate(scope: scope),
+                sortBy: [SortDescriptor(\.name)]
+            )
+            descriptor.fetchLimit = limit
+            hits.streams = ((try? context.fetch(descriptor)) ?? []).map(\.persistentModelID)
+        }
+
+        return hits
+    }
+}
+
+// MARK: - Search predicates
+
+/// What a search fetch is scoped to: the query, the optional single-playlist
+/// restriction and the categories hidden from the current viewer.
+nonisolated struct SearchScope {
+    let query: String
+    let playlistID: String
+    let restrictToPlaylist: Bool
+    let excluded: Set<String>
+
+    /// The excluded ids as optionals, so a predicate can test the optional
+    /// `categoryId` against them directly. Neither `?? ""` (a ternary) nor a
+    /// nil-check plus force-unwrap survives SwiftData's SQL generation; matching
+    /// a `Set<String?>` builds a plain `IN` clause — see `movieTmdbIdPredicate`.
+    var excludedOptional: Set<String?> {
+        Set(excluded.map(String?.some))
+    }
+}
+
+/// Internal (not fileprivate) so the tests can run them against a SQLite store,
+/// where predicate SQL is actually generated.
+nonisolated func searchMoviePredicate(scope: SearchScope) -> Predicate<Movie> {
+    let (query, playlistID) = (scope.query, scope.playlistID)
+    let restrictToPlaylist = scope.restrictToPlaylist
+    let excluded = scope.excludedOptional
+    let filtersCategories = !excluded.isEmpty
+    return #Predicate { movie in
+        movie.name.localizedStandardContains(query)
+            && (!restrictToPlaylist || (movie.categoryId?.localizedStandardContains(playlistID) ?? false))
+            && (!filtersCategories || movie.categoryId == nil || !excluded.contains(movie.categoryId))
+    }
+}
+
+nonisolated func searchSeriesPredicate(scope: SearchScope) -> Predicate<Series> {
+    let (query, playlistID) = (scope.query, scope.playlistID)
+    let restrictToPlaylist = scope.restrictToPlaylist
+    let excluded = scope.excludedOptional
+    let filtersCategories = !excluded.isEmpty
+    return #Predicate { series in
+        series.name.localizedStandardContains(query)
+            && (!restrictToPlaylist || (series.categoryId?.localizedStandardContains(playlistID) ?? false))
+            && (!filtersCategories || series.categoryId == nil || !excluded.contains(series.categoryId))
+    }
+}
+
+/// Live channels also carry their own Content Management visibility, so a
+/// channel hidden individually is excluded here as well.
+nonisolated func searchLiveStreamPredicate(scope: SearchScope) -> Predicate<LiveStream> {
+    let (query, playlistID) = (scope.query, scope.playlistID)
+    let restrictToPlaylist = scope.restrictToPlaylist
+    let excluded = scope.excludedOptional
+    let filtersCategories = !excluded.isEmpty
+    return #Predicate { stream in
+        stream.name.localizedStandardContains(query)
+            && stream.isHidden == false
+            && (!restrictToPlaylist || (stream.categoryId?.localizedStandardContains(playlistID) ?? false))
+            && (!filtersCategories || stream.categoryId == nil || !excluded.contains(stream.categoryId))
+    }
+}

--- a/Lume/Views/SearchView.swift
+++ b/Lume/Views/SearchView.swift
@@ -211,7 +211,9 @@ struct SearchView: View {
         // Scope to the active playlist unless cross-playlist search is on. Every
         // category id is prefixed with its playlist's UUID (see Category.id),
         // which appears nowhere else, so matching it within categoryId limits
-        // results to that playlist.
+        // results to that playlist. Hidden/restricted categories are excluded in
+        // the fetch rather than afterwards, so `resultLimit` isn't spent on rows
+        // the viewer will never see.
         let request = SearchRequest(
             query: query,
             playlistID: playlist?.id.uuidString ?? "",
@@ -219,6 +221,7 @@ struct SearchView: View {
             wantMovies: wantMovies,
             wantSeries: wantSeries,
             wantLive: wantLive,
+            excludedCategoryIDs: restriction.excludedCategoryIDs,
             limit: resultLimit
         )
         let container = modelContext.container
@@ -275,80 +278,6 @@ struct SearchView: View {
         )) ?? []
         let byId = Dictionary(fetched.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         return ids.compactMap { byId[$0] }
-    }
-}
-
-// MARK: - Off-main search fetch
-
-/// The matched rows' persistent identifiers, grouped by type. Plain value type
-/// so it can cross back from the background fetch context.
-private nonisolated struct SearchHits {
-    var movies: [PersistentIdentifier] = []
-    var series: [PersistentIdentifier] = []
-    var streams: [PersistentIdentifier] = []
-}
-
-/// The settled query and the per-type toggles, bundled so the off-main fetch
-/// takes a single `Sendable` value.
-private nonisolated struct SearchRequest {
-    let query: String
-    let playlistID: String
-    let restrictToPlaylist: Bool
-    let wantMovies: Bool
-    let wantSeries: Bool
-    let wantLive: Bool
-    let limit: Int
-}
-
-/// Runs the bounded `localizedStandardContains` fetches on a background
-/// `ModelContext` and returns only identifiers — never managed objects, which
-/// can't cross actor boundaries.
-private nonisolated enum SearchFetcher {
-    static func fetch(container: ModelContainer, request: SearchRequest) -> SearchHits {
-        let query = request.query
-        let playlistID = request.playlistID
-        let restrictToPlaylist = request.restrictToPlaylist
-        let limit = request.limit
-        let context = ModelContext(container)
-        var hits = SearchHits()
-
-        if request.wantMovies {
-            var descriptor = FetchDescriptor<Movie>(
-                predicate: #Predicate { movie in
-                    movie.name.localizedStandardContains(query)
-                        && (!restrictToPlaylist || (movie.categoryId?.localizedStandardContains(playlistID) ?? false))
-                },
-                sortBy: [SortDescriptor(\.name)]
-            )
-            descriptor.fetchLimit = limit
-            hits.movies = ((try? context.fetch(descriptor)) ?? []).map(\.persistentModelID)
-        }
-
-        if request.wantSeries {
-            var descriptor = FetchDescriptor<Series>(
-                predicate: #Predicate { series in
-                    series.name.localizedStandardContains(query)
-                        && (!restrictToPlaylist || (series.categoryId?.localizedStandardContains(playlistID) ?? false))
-                },
-                sortBy: [SortDescriptor(\.name)]
-            )
-            descriptor.fetchLimit = limit
-            hits.series = ((try? context.fetch(descriptor)) ?? []).map(\.persistentModelID)
-        }
-
-        if request.wantLive {
-            var descriptor = FetchDescriptor<LiveStream>(
-                predicate: #Predicate { stream in
-                    stream.name.localizedStandardContains(query)
-                        && (!restrictToPlaylist || (stream.categoryId?.localizedStandardContains(playlistID) ?? false))
-                },
-                sortBy: [SortDescriptor(\.name)]
-            )
-            descriptor.fetchLimit = limit
-            hits.streams = ((try? context.fetch(descriptor)) ?? []).map(\.persistentModelID)
-        }
-
-        return hits
     }
 }
 

--- a/LumeTests/Services/ContentRestrictionTests.swift
+++ b/LumeTests/Services/ContentRestrictionTests.swift
@@ -2,9 +2,9 @@
 //  ContentRestrictionTests.swift
 //  LumeTests
 //
-//  Covers the parental-control content filter: restricted categories (and the
-//  content in them) are excluded only while a child profile is active, and a
-//  parent profile keeps seeing everything.
+//  Covers the content-visibility filter: categories hidden in Content
+//  Management are excluded for every profile, while restricted categories (and
+//  the content in them) are excluded only while a child profile is active.
 //
 
 import Foundation
@@ -53,5 +53,32 @@ struct ContentRestrictionTests {
         let items = [StubItem(categoryId: "a"), StubItem(categoryId: "b")]
         let restriction = ContentRestriction(isActive: true, restrictedCategoryIDs: [])
         #expect(items.excludingRestricted(restriction).count == 2)
+    }
+
+    // MARK: - Content Management visibility
+
+    @Test func `hidden categories are hidden from every profile`() {
+        let restriction = ContentRestriction(isActive: false, hiddenCategoryIDs: ["nl"])
+        #expect(restriction.hides(categoryID: "nl") == true)
+        #expect(restriction.hides(categoryID: "en") == false)
+        #expect(restriction.hides(categoryID: nil) == false)
+    }
+
+    @Test func `excluded ids combine hidden and restricted only for a child profile`() {
+        let parent = ContentRestriction(
+            isActive: false, restrictedCategoryIDs: ["adult"], hiddenCategoryIDs: ["nl"]
+        )
+        #expect(parent.excludedCategoryIDs == ["nl"])
+
+        let child = ContentRestriction(
+            isActive: true, restrictedCategoryIDs: ["adult"], hiddenCategoryIDs: ["nl"]
+        )
+        #expect(child.excludedCategoryIDs == ["nl", "adult"])
+    }
+
+    @Test func `excluding restricted drops hidden categories on a parent profile`() {
+        let items = [StubItem(categoryId: "nl"), StubItem(categoryId: "en"), StubItem(categoryId: nil)]
+        let restriction = ContentRestriction(isActive: false, hiddenCategoryIDs: ["nl"])
+        #expect(items.excludingRestricted(restriction).map(\.categoryId) == ["en", nil])
     }
 }

--- a/LumeTests/Services/RecommendationTests.swift
+++ b/LumeTests/Services/RecommendationTests.swift
@@ -55,7 +55,8 @@ struct RecommendationEngineTests {
         vector: [Float],
         favorite: Bool = false,
         watched: Bool = false,
-        vote: RecommendationVote? = nil
+        vote: RecommendationVote? = nil,
+        category: String? = nil
     ) {
         let movie = Movie(id: id, streamId: 1, name: id)
         movie.embeddingData = TextEmbedder.encode(vector)
@@ -63,6 +64,7 @@ struct RecommendationEngineTests {
         movie.isFavorite = favorite
         movie.isWatched = watched
         movie.recommendationVote = vote
+        movie.categoryId = category
         container.mainContext.insert(movie)
     }
 
@@ -172,5 +174,52 @@ struct RecommendationEngineTests {
         // A zero interval forces a fresh rank every call, so the new title wins.
         let second = await makeEngine(container, cacheStore: store, interval: 0).recommendations().map(\.id)
         #expect(second.first == "closer")
+    }
+
+    // MARK: - Content Management visibility
+
+    @Test func `candidates in an excluded category are never ranked`() async throws {
+        let container = try makeTestContainer()
+        makeMovie(container, id: "liked", vector: [1, 0, 0, 0], favorite: true, category: "en")
+        makeMovie(container, id: "hidden-closer", vector: [0.99, 0.01, 0, 0], category: "nl")
+        makeMovie(container, id: "visible", vector: [0.9, 0.1, 0, 0], category: "en")
+        try container.mainContext.save()
+
+        let ids = await makeEngine(container).recommendations(excluding: ["nl"]).map(\.id)
+        #expect(!ids.contains("hidden-closer"))
+        #expect(ids.first == "visible")
+    }
+
+    @Test func `changing the excluded set invalidates the cached list`() async throws {
+        let container = try makeTestContainer()
+        makeMovie(container, id: "liked", vector: [1, 0, 0, 0], favorite: true, category: "en")
+        makeMovie(container, id: "dutch", vector: [0.9, 0.1, 0, 0], category: "nl")
+        try container.mainContext.save()
+
+        let store = isolatedStore()
+        let hidden = await makeEngine(container, cacheStore: store).recommendations(excluding: ["nl"]).map(\.id)
+        #expect(!hidden.contains("dutch"))
+
+        // Un-hiding must not wait out the (day-long) recalculation interval.
+        let shown = await makeEngine(container, cacheStore: store).recommendations().map(\.id)
+        #expect(shown.contains("dutch"))
+    }
+
+    @Test func `a cache written before visibility tracking is recomputed`() throws {
+        let legacy = Data(#"{"computedAt": 0, "items": [{"id": "a", "kind": "movie"}]}"#.utf8)
+        let decoded = try JSONDecoder().decode(RecommendationCache.self, from: legacy)
+        #expect(decoded.visibilityToken == nil)
+        #expect(decoded.visibilityToken != ContentRestriction.visibilityToken(for: []))
+    }
+
+    @Test func `the visibility token is order independent and set specific`() {
+        #expect(
+            ContentRestriction.visibilityToken(for: ["a", "b"])
+                == ContentRestriction.visibilityToken(for: ["b", "a"])
+        )
+        #expect(
+            ContentRestriction.visibilityToken(for: ["a"])
+                != ContentRestriction.visibilityToken(for: ["a", "b"])
+        )
     }
 }

--- a/LumeTests/Services/SearchPredicateTests.swift
+++ b/LumeTests/Services/SearchPredicateTests.swift
@@ -1,0 +1,133 @@
+//
+//  SearchPredicateTests.swift
+//  LumeTests
+//
+//  Search excludes hidden/restricted categories inside the fetch, so the
+//  per-type result limit isn't spent on rows the viewer will never see. The
+//  predicates must run against an on-disk SQLite store: in-memory stores
+//  evaluate predicates without SQL generation, so a form CoreData can't render
+//  passes there and traps on device (see `TmdbIdPredicateTests`).
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+@MainActor
+struct SearchPredicateTests {
+    /// The container must be held for the test's duration — a
+    /// `makeSQLiteContainer().mainContext` temporary deallocates the store out
+    /// from under the context and traps inside SwiftData on the first save.
+    private func makeSQLiteContainer() throws -> ModelContainer {
+        let schema = Schema([
+            Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
+            Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self
+        ])
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("catalog.store")
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        let config = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    private func scope(query: String, excluded: Set<String> = []) -> SearchScope {
+        SearchScope(query: query, playlistID: "", restrictToPlaylist: false, excluded: excluded)
+    }
+
+    private func insertMovies(_ context: ModelContext) throws {
+        for (id, category) in [("m1", "en"), ("m2", "nl")] {
+            let movie = Movie(id: id, streamId: 1, name: "The Matrix")
+            movie.categoryId = category
+            context.insert(movie)
+        }
+        // An uncategorised title — m3u sources don't always supply a category.
+        let orphan = Movie(id: "m3", streamId: 3, name: "The Matrix")
+        context.insert(orphan)
+        try context.save()
+    }
+
+    @Test func `movie search drops excluded categories and keeps uncategorised titles`() throws {
+        let container = try makeSQLiteContainer()
+        let context = container.mainContext
+        try insertMovies(context)
+
+        let fetched = try context.fetch(
+            FetchDescriptor<Movie>(predicate: searchMoviePredicate(scope: scope(query: "matrix", excluded: ["nl"])))
+        )
+        #expect(Set(fetched.map(\.id)) == ["m1", "m3"])
+    }
+
+    @Test func `movie search returns everything when nothing is excluded`() throws {
+        let container = try makeSQLiteContainer()
+        let context = container.mainContext
+        try insertMovies(context)
+
+        let fetched = try context.fetch(
+            FetchDescriptor<Movie>(predicate: searchMoviePredicate(scope: scope(query: "matrix")))
+        )
+        #expect(Set(fetched.map(\.id)) == ["m1", "m2", "m3"])
+    }
+
+    @Test func `series search drops excluded categories`() throws {
+        let container = try makeSQLiteContainer()
+        let context = container.mainContext
+        let visible = Series(id: "s1", seriesId: 1, name: "Dark Matter")
+        visible.categoryId = "en"
+        let hidden = Series(id: "s2", seriesId: 2, name: "Dark Matter")
+        hidden.categoryId = "nl"
+        context.insert(visible)
+        context.insert(hidden)
+        try context.save()
+
+        let fetched = try context.fetch(
+            FetchDescriptor<Series>(predicate: searchSeriesPredicate(scope: scope(query: "dark", excluded: ["nl"])))
+        )
+        #expect(fetched.map(\.id) == ["s1"])
+    }
+
+    @Test func `live search drops excluded categories and individually hidden channels`() throws {
+        let container = try makeSQLiteContainer()
+        let context = container.mainContext
+        let visible = LiveStream(id: "l1", streamId: 1, name: "News One")
+        visible.categoryId = "en"
+        let inHiddenCategory = LiveStream(id: "l2", streamId: 2, name: "News Two")
+        inHiddenCategory.categoryId = "nl"
+        let hiddenChannel = LiveStream(id: "l3", streamId: 3, name: "News Three")
+        hiddenChannel.categoryId = "en"
+        hiddenChannel.isHidden = true
+        for stream in [visible, inHiddenCategory, hiddenChannel] {
+            context.insert(stream)
+        }
+        try context.save()
+
+        let fetched = try context.fetch(
+            FetchDescriptor<LiveStream>(
+                predicate: searchLiveStreamPredicate(scope: scope(query: "news", excluded: ["nl"]))
+            )
+        )
+        #expect(fetched.map(\.id) == ["l1"])
+    }
+
+    @Test func `playlist scoping still applies alongside the exclusion`() throws {
+        let container = try makeSQLiteContainer()
+        let context = container.mainContext
+        let mine = Movie(id: "m1", streamId: 1, name: "The Matrix")
+        mine.categoryId = "PL-A-vod-1"
+        let other = Movie(id: "m2", streamId: 2, name: "The Matrix")
+        other.categoryId = "PL-B-vod-1"
+        context.insert(mine)
+        context.insert(other)
+        try context.save()
+
+        let fetched = try context.fetch(
+            FetchDescriptor<Movie>(predicate: searchMoviePredicate(scope: SearchScope(
+                query: "matrix", playlistID: "PL-A", restrictToPlaylist: true, excluded: ["nl"]
+            )))
+        )
+        #expect(fetched.map(\.id) == ["m1"])
+    }
+}


### PR DESCRIPTION
## Summary
Categories hidden in Settings → Content Management were respected by the Movies / Series / Live TV browse screens but ignored everywhere else. Home's hero and rails, the "For You" engine and Search all filtered through `ContentRestriction`, which only carried *parental* restriction — and that is inactive unless a child profile is active, so on a normal profile those surfaces did no category filtering at all. A user who hid every non-English category still saw `NL - …` / `IR - …` titles on Home and in search results.

## Implementation
`ContentRestriction` now carries the hidden category ids alongside the restricted ones and applies them to **every** profile (`excludedCategoryIDs` = hidden always, plus restricted while a child profile is active). Because every surface already routed through `hides(categoryID:)` / `excludingRestricted(_:)`, that one change fixes Home's rails, the trending/watchlist catalog match, the cross-category rows, genre derivation, Search and the widget deep-link resolvers together. `MainTabView` feeds the set from a second `@Query` on the (already indexed) `Category.isHidden` — the same model type it already queries, so no new invalidation source.

Three places needed more than the shared filter:

- **Search** pushes the exclusion into the fetch predicate rather than filtering afterwards, so the 50-per-type limit isn't spent on rows the viewer can't see. The predicates moved to `SearchFetching.swift` (the view file was over the 600-line lint cap) and are `internal` so tests can run them against a real SQLite store — `Set<String?>` matching is the only form that survives SwiftData's SQL generation, and titles with no `categoryId` must survive it.
- **The For You engine** skips excluded candidates while ranking, so hidden titles don't consume ranking slots.
- **Both session caches** (Home's trending/hero memo and the throttled For You list) are keyed on a digest of the excluded set, so hiding *or* showing a category takes effect immediately instead of replaying a list matched against the old visibility.

Trending/For You prefer a *visible* copy of a duplicated title rather than dropping the row: hidden copies are filtered before the per-`tmdbId` dedupe, so the first visible one wins.

Channels hidden individually (`LiveStream.isHidden`) get the same treatment on Home's Favorites / Recently Watched rails and in Search — the same defect one level down, previously only handled by Live TV.

## Testing
- [x] Acceptance criteria met
- [x] Builds clean — iOS Simulator, tvOS Simulator and macOS
- [x] Tests pass — 68 tests across `ContentRestrictionTests`, `SearchPredicateTests`, `RecommendationEngineTests`, `RecommendationScoringTests`, `GenreDerivationTests`, `TmdbIdPredicateTests` (iPhone 17 Pro / iOS 26.4)
- [x] SwiftLint clean (pre-commit hooks passed)
- [x] Tests added — hidden-vs-restricted precedence and `excludingRestricted`; the search predicates against an on-disk SQLite store (including a title with no `categoryId`, and an individually hidden channel); the engine skipping excluded candidates and invalidating its cache when the visibility set changes
- [x] UI verified on simulator — see below

Note: a full `-only-testing:LumeTests` run crashes partway through on this machine and cascades the remaining tests; that reproduces identically on unmodified `main` (79 passed, rest cascade-failed), so it is pre-existing and unrelated. The suites touched by this change were run and pass.

### Manual verification (iPhone 17 Pro Max, iOS 26.4, local example IPTV server)
1. Searched "Scream" → `Scream 7 (2026)` found (its only copy is in the HORROR category).
2. Favorited it → it appears in Home's **Favorites** rail.
3. Settings → Content Management → Movies → hid **HORROR**.
4. Home immediately drops the title — the Favorites rail disappears entirely, since that was its only entry. No relaunch needed.
5. Searching "Scream" now returns **No Results**.
6. Un-hiding HORROR restores both the rail and the search hit immediately.

## Platforms
- [x] iOS / iPadOS
- [ ] tvOS <!-- builds clean; shares the changed code, not driven manually -->
- [ ] macOS <!-- builds clean; shares the changed code, not driven manually -->
- [ ] visionOS

## Related
Closes #180