### PR TITLE
fix(xtream): use provider settings for catch-up URLs

### DIFF
--- a/Lume/Services/Network/XtreamClient.swift
+++ b/Lume/Services/Network/XtreamClient.swift
@@ -404,14 +404,16 @@ class XtreamClient: APIClient {
     /// playlist's own container preference; when omitted the playlist decides,
     /// falling back to HLS.
     func buildLiveStreamURL(for stream: LiveStream, playlist: Playlist, format: StreamFormat? = nil) -> URL? {
-        let ext = Self.resolvedFormat(format, playlist: playlist).rawValue
+        let ext = Self.resolvedFormat(format, playlist: playlist, fallback: .m3u8).rawValue
         return URL(string: "\(playlist.serverURL)/live/\(playlist.username)/\(playlist.password)/\(stream.streamId).\(ext)")
     }
 
-    /// HLS is the fallback because it is what every Xtream URL Lume ever built
-    /// used before the container became configurable.
-    private nonisolated static func resolvedFormat(_ requested: StreamFormat?, playlist: Playlist) -> StreamFormat {
-        requested ?? playlist.streamFormat.xtreamFormat ?? .m3u8
+    private nonisolated static func resolvedFormat(
+        _ requested: StreamFormat?,
+        playlist: Playlist,
+        fallback: StreamFormat
+    ) -> StreamFormat {
+        requested ?? playlist.streamFormat.xtreamFormat ?? fallback
     }
 
     /// `Y-m-d:H-i` is the start format Xtream Codes panels expect in a timeshift
@@ -440,7 +442,10 @@ class XtreamClient: APIClient {
         format: StreamFormat? = nil
     ) -> URL? {
         guard durationMinutes > 0 else { return nil }
-        let ext = Self.resolvedFormat(format, playlist: playlist).rawValue
+        // Xtream-compatible panels commonly expose catch-up as an MPEG-TS
+        // resource even when normal live playback defaults to HLS. Respect an
+        // explicit playlist/argument choice, but prefer TS when it is unknown.
+        let ext = Self.resolvedFormat(format, playlist: playlist, fallback: .tsStream).rawValue
         let startString = Self.timeshiftStartFormatter.string(from: start)
         return URL(string: "\(playlist.serverURL)/timeshift/\(playlist.username)/\(playlist.password)/\(durationMinutes)/\(startString)/\(stream.streamId).\(ext)")
     }

--- a/Lume/Services/Network/XtreamClient.swift
+++ b/Lume/Services/Network/XtreamClient.swift
@@ -417,15 +417,16 @@ class XtreamClient: APIClient {
     }
 
     /// `Y-m-d:H-i` is the start format Xtream Codes panels expect in a timeshift
-    /// path. Formatted in the device's local timezone — the panel interprets the
-    /// value as wall-clock time, and EPG `start` dates are absolute instants, so
-    /// this keeps the requested moment aligned with what the guide showed.
-    private nonisolated static let timeshiftStartFormatter: DateFormatter = {
+    /// path. The value is wall-clock time in the timezone advertised by the
+    /// account. Fall back to the device timezone for older panels that omit it,
+    /// preserving Lume's historical behaviour for those providers.
+    private nonisolated static func timeshiftStartString(for start: Date, playlist: Playlist) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd:HH-mm"
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        return formatter
-    }()
+        formatter.timeZone = playlist.serverTimezone.flatMap(TimeZone.init(identifier:)) ?? .current
+        return formatter.string(from: start)
+    }
 
     /// Builds a catch-up / timeshift URL for a past programme on a live stream.
     ///
@@ -446,7 +447,7 @@ class XtreamClient: APIClient {
         // resource even when normal live playback defaults to HLS. Respect an
         // explicit playlist/argument choice, but prefer TS when it is unknown.
         let ext = Self.resolvedFormat(format, playlist: playlist, fallback: .tsStream).rawValue
-        let startString = Self.timeshiftStartFormatter.string(from: start)
+        let startString = Self.timeshiftStartString(for: start, playlist: playlist)
         return URL(string: "\(playlist.serverURL)/timeshift/\(playlist.username)/\(playlist.password)/\(durationMinutes)/\(startString)/\(stream.streamId).\(ext)")
     }
 }

--- a/LumeTests/Models/PlaylistStreamFormatTests.swift
+++ b/LumeTests/Models/PlaylistStreamFormatTests.swift
@@ -84,15 +84,33 @@ struct PlaylistStreamFormatTests {
 
     // MARK: - Xtream catch-up URLs
 
-    @Test func `catchup follows the playlist container`() throws {
+    @Test func `automatic catchup defaults to MPEGTS`() throws {
         let stream = LiveStream(id: "l-5", streamId: 777, name: "Catchup Channel")
         let url = try #require(makeClient().buildCatchupURL(
+            for: stream,
+            playlist: makePlaylist(),
+            start: Date(timeIntervalSince1970: 1_700_000_000),
+            durationMinutes: 90
+        ))
+        #expect(url.absoluteString.hasSuffix("/777.ts"))
+    }
+
+    @Test func `catchup follows the playlist container`() throws {
+        let stream = LiveStream(id: "l-6", streamId: 777, name: "Catchup Channel")
+        let tsURL = try #require(makeClient().buildCatchupURL(
             for: stream,
             playlist: makePlaylist(format: .mpegTS),
             start: Date(timeIntervalSince1970: 1_700_000_000),
             durationMinutes: 90
         ))
-        #expect(url.absoluteString.hasSuffix("/777.ts"))
+        let hlsURL = try #require(makeClient().buildCatchupURL(
+            for: stream,
+            playlist: makePlaylist(format: .hls),
+            start: Date(timeIntervalSince1970: 1_700_000_000),
+            durationMinutes: 90
+        ))
+        #expect(tsURL.absoluteString.hasSuffix("/777.ts"))
+        #expect(hlsURL.absoluteString.hasSuffix("/777.m3u8"))
     }
 
     // MARK: - m3u direct URL rewriting

--- a/LumeTests/Services/PlayableMediaTests.swift
+++ b/LumeTests/Services/PlayableMediaTests.swift
@@ -121,7 +121,7 @@ struct PlayableMediaTests {
         #expect(media.contentRef == .live("l-3"))
         #expect(media.startTime == 0)
         #expect(media.url.absoluteString.contains("/timeshift/user/pass/60/"))
-        #expect(media.url.absoluteString.hasSuffix("/300.m3u8"))
+        #expect(media.url.absoluteString.hasSuffix("/300.ts"))
     }
 
     @Test func `catchup returns nil without archive`() {

--- a/LumeTests/Services/XtreamClientURLTests.swift
+++ b/LumeTests/Services/XtreamClientURLTests.swift
@@ -115,9 +115,9 @@ struct XtreamClientURLTests {
         let url = try #require(client.buildCatchupURL(for: stream, playlist: playlist, start: start, durationMinutes: 90))
         let string = url.absoluteString
         #expect(string.hasPrefix("http://example.com:8080/timeshift/testuser/testpass/90/"))
-        #expect(string.hasSuffix("/777.m3u8"))
+        #expect(string.hasSuffix("/777.ts"))
         // The start segment is the Xtream `Y-m-d:H-i` wall-clock format.
-        #expect(string.range(of: #"/\d{4}-\d{2}-\d{2}:\d{2}-\d{2}/777\.m3u8$"#, options: .regularExpression) != nil)
+        #expect(string.range(of: #"/\d{4}-\d{2}-\d{2}:\d{2}-\d{2}/777\.ts$"#, options: .regularExpression) != nil)
     }
 
     @Test func `build catchup URL rejects non-positive duration`() {

--- a/LumeTests/Services/XtreamClientURLTests.swift
+++ b/LumeTests/Services/XtreamClientURLTests.swift
@@ -120,10 +120,30 @@ struct XtreamClientURLTests {
         #expect(string.range(of: #"/\d{4}-\d{2}-\d{2}:\d{2}-\d{2}/777\.ts$"#, options: .regularExpression) != nil)
     }
 
+    @Test func `build catchup URL uses advertised server timezone`() throws {
+        let client = makeClient()
+        let stream = LiveStream(id: "l-4", streamId: 778, name: "Catchup Channel")
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        let utcPlaylist = makePlaylist()
+        utcPlaylist.serverTimezone = "UTC"
+        let perthPlaylist = makePlaylist()
+        perthPlaylist.serverTimezone = "Australia/Perth"
+
+        let utcURL = try #require(client.buildCatchupURL(
+            for: stream, playlist: utcPlaylist, start: start, durationMinutes: 60
+        ))
+        let perthURL = try #require(client.buildCatchupURL(
+            for: stream, playlist: perthPlaylist, start: start, durationMinutes: 60
+        ))
+
+        #expect(utcURL.absoluteString.contains("/2023-11-14:22-13/"))
+        #expect(perthURL.absoluteString.contains("/2023-11-15:06-13/"))
+    }
+
     @Test func `build catchup URL rejects non-positive duration`() {
         let client = makeClient()
         let playlist = makePlaylist()
-        let stream = LiveStream(id: "l-4", streamId: 778, name: "Catchup Channel")
+        let stream = LiveStream(id: "l-5", streamId: 779, name: "Catchup Channel")
         #expect(client.buildCatchupURL(for: stream, playlist: playlist, start: Date(), durationMinutes: 0) == nil)
     }
 


### PR DESCRIPTION
## Summary

- Default automatic Xtream catch-up requests to MPEG-TS while preserving explicit HLS selection.
- Format timeshift start timestamps using the existing advertised server timezone, falling back to the device timezone when unavailable.
- Leave normal live-stream defaults unchanged.
- Add URL tests for format selection and UTC/non-UTC server timezones.

## Why

XC-compatible servers such as Dispatcharr expose MPEG-TS timeshift URLs and expect the programme start in the server-advertised timezone. Using an HLS suffix caused HTTP 404, while formatting the absolute EPG date in the device timezone caused HTTP 400. Suspect this is also the case with other catch-up providers.

## Testing

- Focused XtreamClientURLTests, PlaylistStreamFormatTests, and PlayableMediaTests pass on iPhone 17 Pro Simulator.
- macOS Sideload build tested against Dispatcharr; catch-up playback confirmed.