### PR TITLE
feat(tvos): quick-switch overlay for playlists and profiles

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -1749,6 +1749,59 @@
         }
       }
     },
+    "Active" : {
+      "comment" : "Accessibility value on the playlist or profile row that is currently in use",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktiv"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En uso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En cours d'utilisation"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In uso"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용 중"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Em uso"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用中"
+          }
+        }
+      }
+    },
     "Active Connections" : {
       "localizations" : {
         "de" : {
@@ -21702,6 +21755,59 @@
         }
       }
     },
+    "No playlists yet" : {
+      "comment" : "Empty state shown in the playlists column of the tvOS quick-switch modal",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch keine Playlists"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no hay listas de reproducción"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune playlist pour le moment"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna playlist per ora"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレイリストはまだありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아직 재생목록이 없습니다"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ainda não há playlists"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无播放列表"
+          }
+        }
+      }
+    },
     "No playlists yet. Add your IPTV provider to start streaming." : {
       "localizations" : {
         "de" : {
@@ -21750,6 +21856,59 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暂无播放列表。添加您的IPTV服务商即可开始流媒体播放。"
+          }
+        }
+      }
+    },
+    "No profiles yet" : {
+      "comment" : "Empty state shown in the profiles column of the tvOS quick-switch modal",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch keine Profile"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no hay perfiles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun profil pour le moment"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun profilo per ora"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロファイルはまだありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아직 프로필이 없습니다"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ainda não há perfis"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无个人资料"
           }
         }
       }
@@ -25059,6 +25218,112 @@
         }
       }
     },
+    "Press Menu to close" : {
+      "comment" : "Hint at the bottom of the tvOS quick-switch modal telling the viewer which remote button closes it",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drücke Menü zum Schließen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulsa Menú para cerrar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appuyez sur Menu pour fermer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Premi Menu per chiudere"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メニューボタンで閉じます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메뉴를 눌러 닫기"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pressione Menu para fechar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按菜单键关闭"
+          }
+        }
+      }
+    },
+    "Press Play/Pause to switch playlist or profile" : {
+      "comment" : "First-run hint on the tvOS Home screen teaching the Play/Pause remote button that opens the playlist/profile quick-switch modal",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drücke Play/Pause, um Playlist oder Profil zu wechseln"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulsa Reproducir/Pausa para cambiar de lista de reproducción o perfil"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appuyez sur Lecture/Pause pour changer de playlist ou de profil"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Premi Play/Pausa per cambiare playlist o profilo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再生/一時停止ボタンでプレイリストまたはプロファイルを切り替えます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재생/일시정지를 눌러 재생목록 또는 프로필을 전환하세요"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pressione Play/Pause para trocar de playlist ou perfil"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按播放/暂停键切换播放列表或个人资料"
+          }
+        }
+      }
+    },
     "Primary" : {
       "localizations" : {
         "de" : {
@@ -25524,6 +25789,59 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "队列深度以内存换取流畅度：解码后的 4K 视频帧很大，因此请谨慎提高视频队列。将在下次播放开始时生效。"
+          }
+        }
+      }
+    },
+    "Quick Switch" : {
+      "comment" : "Title of the tvOS quick-switch modal, which switches the active playlist or profile",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schnellwechsel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambio rápido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changement rapide"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambio rapido"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クイック切り替え"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "빠른 전환"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Troca rápida"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速切换"
           }
         }
       }
@@ -32227,6 +32545,59 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换播放列表会更改主页、电影、剧集和直播电视中显示的内容。"
+          }
+        }
+      }
+    },
+    "Switching profile to %@" : {
+      "comment" : "Loading message shown while the app switches to another user profile",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wechsle zu Profil %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiando al perfil %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passage au profil %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passaggio al profilo %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロファイルを%@に切り替え中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 프로필로 전환 중"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trocando para o perfil %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在切换到个人资料%@"
           }
         }
       }

--- a/Lume/Services/DeepLink/DeepLinkRouter.swift
+++ b/Lume/Services/DeepLink/DeepLinkRouter.swift
@@ -30,5 +30,13 @@ final class DeepLinkRouter {
         var isMultiViewPresented: Bool {
             multiViewLaunch != nil
         }
+
+        /// Whether the playlist/profile quick-switch modal is covering the app.
+        /// Like Multi-View it is presented from `MainTabView` as a plain overlay
+        /// rather than a `fullScreenCover`, because a tvOS cover always dismisses
+        /// itself on Menu and nothing stops it — neither `onExitCommand` nor
+        /// `interactiveDismissDisabled`. The modal needs Menu for itself so a PIN
+        /// pad nested over it can consume the press first.
+        var isQuickSwitchPresented = false
     #endif
 }

--- a/Lume/Services/Profiles/ProfileManager.swift
+++ b/Lume/Services/Profiles/ProfileManager.swift
@@ -34,9 +34,23 @@ final class ProfileManager {
     /// True once launch bootstrap has resolved the active profile and claimed any
     /// legacy records. The switcher waits on this before offering a switch.
     private(set) var isReady = false
+    /// The profile a switch is re-projecting the catalog onto. The single stored
+    /// piece of switch state — the flag and the overlay's copy both derive from
+    /// it, so they cannot drift apart.
+    private var switchingToProfileID: UUID?
+
     /// True while a profile switch is re-projecting the catalog — the UI blocks
     /// interaction so a half-projected catalog is never shown.
-    private(set) var isSwitching = false
+    var isSwitching: Bool {
+        switchingToProfileID != nil
+    }
+
+    /// Name of the profile being switched to, for the blocking progress overlay.
+    var pendingProfileName: String? {
+        switchingToProfileID.flatMap {
+            QuickSwitchResolver.currentProfile(in: profiles, activeProfileID: $0)?.name
+        }
+    }
 
     /// The profile roster the UI reads (instead of a `@Query`). `UserProfile`
     /// lives in the cloud store — a separate container the browse `@Query`s don't
@@ -158,7 +172,7 @@ final class ProfileManager {
     func switchProfile(to id: UUID) async {
         guard id != activeProfileID, !isSwitching else { return }
         let from = activeProfileID
-        isSwitching = true
+        switchingToProfileID = id
         // Flush any pending catalog edits (e.g. a favorite toggled moments ago,
         // not yet autosaved) so the engine — which reads the catalog through its
         // own background context — exports the outgoing profile's *current* state
@@ -170,7 +184,7 @@ final class ProfileManager {
         // no window where the catalog and the active-profile pointer disagree.
         await coordinator.switchProfile(from: from, to: id)
         activeProfileID = id
-        isSwitching = false
+        switchingToProfileID = nil
         // Re-baseline the freshly projected state against the cloud.
         coordinator.reconcile()
     }

--- a/Lume/Services/Profiles/QuickSwitchResolver.swift
+++ b/Lume/Services/Profiles/QuickSwitchResolver.swift
@@ -1,0 +1,83 @@
+//
+//  QuickSwitchResolver.swift
+//  Lume
+//
+//  The single answer to "which playlist / which profile is currently active, and
+//  which rows can be switched to" — shared by every switch surface (the iOS /
+//  macOS toolbar switcher, the tvOS Settings panes, the tvOS quick-switch
+//  overlay) so the decision never gets a fourth divergent copy.
+//
+//  Deliberately platform-agnostic and view-free: the test targets exclude
+//  appletvos, so nothing here may be gated behind `#if os(tvOS)`.
+//
+
+import Foundation
+
+// MARK: - Rows
+
+/// One row on a switch surface: the playlist or profile it stands for, plus
+/// whether it is the one in effect right now — including via the
+/// empty-selection / deleted-playlist fallback to the first playlist.
+struct QuickSwitchRow<Item>: Identifiable {
+    let item: Item
+    let isCurrent: Bool
+    let id: UUID
+}
+
+// MARK: - Active playlist
+
+extension [Playlist] {
+    /// Resolves the stored selection (the raw `PlaylistSelectionStore.key` value)
+    /// to a concrete playlist, falling back to the first available playlist when
+    /// the stored id is empty or no longer exists (e.g. the selected playlist was
+    /// deleted).
+    func active(for storedID: String) -> Playlist? {
+        first(where: { $0.id.uuidString == storedID }) ?? first
+    }
+
+    /// The in-effect playlist's `id.uuidString`, or an empty string when there is
+    /// no playlist at all. Never compare a raw stored value instead — it can name
+    /// a deleted playlist.
+    func activeID(for storedID: String) -> String {
+        active(for: storedID)?.id.uuidString ?? ""
+    }
+}
+
+// MARK: - Resolver
+
+enum QuickSwitchResolver {
+    // MARK: Playlists
+
+    /// The playlist rows in the order they were handed in, each tagged with
+    /// whether it is current.
+    static func playlistRows(_ playlists: [Playlist], storedID: String) -> [QuickSwitchRow<Playlist>] {
+        rows(playlists, id: \.id, currentID: playlists.active(for: storedID)?.id)
+    }
+
+    // MARK: Profiles
+
+    /// The active profile out of `profiles` (always `ProfileManager.profiles` —
+    /// `UserProfile` lives in the CloudKit-mirrored container, which the view
+    /// contexts don't bind to, so it can never come from a `@Query`).
+    static func currentProfile(in profiles: [UserProfile], activeProfileID: UUID) -> UserProfile? {
+        profiles.first { $0.id == activeProfileID }
+    }
+
+    /// The profile rows in roster order, each tagged with whether it is active.
+    static func profileRows(_ profiles: [UserProfile], activeProfileID: UUID) -> [QuickSwitchRow<UserProfile>] {
+        rows(profiles, id: \.id, currentID: activeProfileID)
+    }
+
+    // MARK: Shared
+
+    private static func rows<Item>(
+        _ items: [Item],
+        id: (Item) -> UUID,
+        currentID: UUID?
+    ) -> [QuickSwitchRow<Item>] {
+        items.map { item in
+            let itemID = id(item)
+            return QuickSwitchRow(item: item, isCurrent: itemID == currentID, id: itemID)
+        }
+    }
+}

--- a/Lume/Views/Components/PlaylistSwitchProgress.swift
+++ b/Lume/Views/Components/PlaylistSwitchProgress.swift
@@ -21,6 +21,27 @@ final class PlaylistSwitchModel {
     /// wave of poster loads without flashing away instantly.
     private let settleDuration: Duration = .milliseconds(450)
 
+    /// One-shot: set immediately before a switch whose caller wants the app to
+    /// land in the cached catalog instead of handing the screen to the blocking
+    /// auto-sync cover (minutes on a large playlist) — the tvOS quick-switch
+    /// modal. The due sync is picked up by the next launch / foreground pass.
+    @ObservationIgnored private var deferredDueSync = false
+
+    /// Marks the next switch as one that skips the blocking auto-sync cover.
+    /// Scoped to that one switch — the next one from Settings or the iOS/macOS
+    /// switcher presents the cover again.
+    func deferNextDueSync() {
+        deferredDueSync = true
+    }
+
+    /// Reads and clears the deferral. Deliberately does not mark the playlist
+    /// attempted: skipping the cover for this switch must not skip it for the
+    /// rest of the session.
+    func consumeDeferredDueSync() -> Bool {
+        defer { deferredDueSync = false }
+        return deferredDueSync
+    }
+
     /// Begins a switch to `name`, deferring the caller's `apply` (the actual
     /// `@AppStorage` write) until the overlay is on screen.
     func switchTo(name: String, apply: @escaping () -> Void) {
@@ -38,13 +59,52 @@ final class PlaylistSwitchModel {
     }
 }
 
-/// Full-screen blocking overlay shown while a playlist switch is in progress.
-struct PlaylistSwitchOverlay: View {
-    let playlistName: String
+extension View {
+    /// Layers the blocking switch-progress overlay over this view for whichever
+    /// switch is in flight. The fade lives here rather than on the call site so
+    /// the animated transaction covers the overlay layer only — attached to the
+    /// tab hierarchy it would open one over every animatable attribute in every
+    /// live tab.
+    func switchProgressOverlay(playlist: PlaylistSwitchModel?, profile: ProfileManager?) -> some View {
+        overlay {
+            ZStack {
+                if let message = switchProgressMessage(playlist: playlist, profile: profile) {
+                    SwitchProgressOverlay(message: message)
+                        .transition(.opacity)
+                }
+            }
+            .animation(.easeInOut(duration: 0.2), value: playlist?.isSwitching)
+            .animation(.easeInOut(duration: 0.2), value: profile?.isSwitching)
+        }
+    }
+}
+
+/// The message for the switch in flight, or `nil` when none is. The profile case
+/// stays up for the whole asynchronous re-projection, the playlist case for a
+/// fixed settle.
+private func switchProgressMessage(playlist: PlaylistSwitchModel?, profile: ProfileManager?) -> Text? {
+    if let playlist, playlist.isSwitching {
+        return Text(
+            "Switching to \(playlist.targetName)",
+            comment: "Loading message shown while the app switches to another IPTV playlist"
+        )
+    }
+    if let profile, profile.isSwitching {
+        return Text(
+            "Switching profile to \(profile.pendingProfileName ?? "")",
+            comment: "Loading message shown while the app switches to another user profile"
+        )
+    }
+    return nil
+}
+
+/// The visual every switch shares.
+private struct SwitchProgressOverlay: View {
+    let message: Text
 
     var body: some View {
         ZStack {
-            // Dim and capture taps so the half-rendered new playlist isn't
+            // Dim and capture taps so the half-rendered catalog isn't
             // interacted with mid-switch.
             Color.black.opacity(0.35)
 
@@ -55,14 +115,11 @@ struct PlaylistSwitchOverlay: View {
                     // tvOS but reads as untinted elsewhere) over the dim backdrop.
                     .tint(.white)
 
-                Text(
-                    "Switching to \(playlistName)",
-                    comment: "Loading message shown while the app switches to another IPTV playlist"
-                )
-                .font(font)
-                .fontWeight(.semibold)
-                .foregroundStyle(.white)
-                .multilineTextAlignment(.center)
+                message
+                    .font(font)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
             }
             .padding(padding)
             .background(.ultraThinMaterial, in: .rect(cornerRadius: 24))
@@ -85,6 +142,10 @@ struct PlaylistSwitchOverlay: View {
     #endif
 }
 
-#Preview {
-    PlaylistSwitchOverlay(playlistName: "My IPTV")
+#Preview("Playlist") {
+    SwitchProgressOverlay(message: Text(verbatim: "Switching to My IPTV"))
+}
+
+#Preview("Profile") {
+    SwitchProgressOverlay(message: Text(verbatim: "Switching profile to Profile 2"))
 }

--- a/Lume/Views/Components/PlaylistSwitcher.swift
+++ b/Lume/Views/Components/PlaylistSwitcher.swift
@@ -19,15 +19,6 @@ enum PlaylistSelectionStore {
     static let key = "lume.selectedPlaylistID"
 }
 
-extension [Playlist] {
-    /// Resolves the stored selection to a concrete playlist, falling back to the
-    /// first available playlist when the stored id is empty or no longer exists
-    /// (e.g. the selected playlist was deleted).
-    func active(for storedID: String) -> Playlist? {
-        first(where: { $0.id.uuidString == storedID }) ?? first
-    }
-}
-
 // MARK: - Switcher
 
 /// Toolbar menu that switches the global active playlist. Drop one into any
@@ -99,7 +90,7 @@ struct PlaylistSwitcher: View {
     /// The id that is actually in effect, accounting for the empty-default /
     /// deleted-playlist fallback to the first playlist.
     private var effectiveID: String {
-        playlists.active(for: selectedPlaylistID)?.id.uuidString ?? ""
+        playlists.activeID(for: selectedPlaylistID)
     }
 
     private var effectiveName: String {

--- a/Lume/Views/Home/HomeView.swift
+++ b/Lume/Views/Home/HomeView.swift
@@ -155,6 +155,7 @@ struct HomeView: View {
                             onSelectHero: { selectedHero = $0 },
                             rows: { homeRows }
                         )
+                        .tvQuickSwitchHint(interacted: selectedHero != nil)
                     #else
                         ScrollView {
                             LazyVStack(alignment: .leading, spacing: 28) {

--- a/Lume/Views/MainTabView.swift
+++ b/Lume/Views/MainTabView.swift
@@ -61,9 +61,17 @@ struct MainTabView: View {
         @Bindable var router = router
         return tabView(selection: $router.selectedTab)
         #if os(tvOS)
-            // Multi-View owns the screen while it is up: tvOS focus is not
-            // clipped by z-order, so the tab bar behind would still take presses.
-            .disabled(router.isMultiViewPresented)
+            .disabled(blockingOverlayOwnsScreen || router.isQuickSwitchPresented)
+            // Attached OUTSIDE `.disabled` so the same button closes the modal it
+            // opened, and above the tabs but below every player: the engines are
+            // presented as `fullScreenCover`s from inside a tab, so their own
+            // `onPlayPauseCommand` sits above this one in the focused chain and is
+            // never shadowed. The guard covers the plain overlays instead, which
+            // tvOS focus reaches straight through.
+            .onPlayPauseCommand {
+                guard playPauseTogglesQuickSwitch else { return }
+                router.isQuickSwitchPresented.toggle()
+            }
         #endif
             .environment(router)
             .environment(\.contentRestriction, contentRestriction)
@@ -79,7 +87,9 @@ struct MainTabView: View {
                 enqueueDueSyncs(playlists)
             }
             .onChange(of: selectedPlaylistID) {
-                // On playlist switch, sync the newly selected one if it's due.
+                // On playlist switch, sync the newly selected one if it's due —
+                // unless the switch asked to land in the cached catalog instead.
+                guard playlistSwitch?.consumeDeferredDueSync() != true else { return }
                 if let playlist = playlists.active(for: selectedPlaylistID) {
                     enqueueDueSyncs([playlist])
                 }
@@ -92,14 +102,18 @@ struct MainTabView: View {
                 }
             }
             .syncCover(item: $activeSyncPlaylist, onDismiss: promoteNextIfIdle)
-            .overlay {
-                if playlistSwitch?.isSwitching == true {
-                    PlaylistSwitchOverlay(playlistName: playlistSwitch?.targetName ?? "")
-                        .transition(.opacity)
-                }
-            }
+            .switchProgressOverlay(playlist: playlistSwitch, profile: profileManager)
         #if os(tvOS)
-            .overlay {
+            .overlay { tvOverlays }
+        #endif
+    }
+
+    #if os(tvOS)
+        /// The plain overlays layered over the tabs. One always-mounted container,
+        /// so the fade is a transaction over this layer instead of over every
+        /// animatable attribute in every live tab.
+        private var tvOverlays: some View {
+            ZStack {
                 if let launch = router.multiViewLaunch {
                     MultiViewScreen(
                         seed: launch.seed,
@@ -111,12 +125,18 @@ struct MainTabView: View {
                     .id(launch.id)
                     .transition(.opacity)
                 }
-            }
-        #endif
-            .animation(.easeInOut(duration: 0.2), value: playlistSwitch?.isSwitching)
-    }
 
-    #if os(tvOS)
+                if router.isQuickSwitchPresented {
+                    // Built only while presented: a permanently mounted list of
+                    // focusable rows would regrow the focus/AX responder walk
+                    // that `activeOnly(_:selection:)` exists to contain.
+                    TVQuickSwitchOverlay(router: router, playlists: playlists)
+                        .transition(.opacity)
+                }
+            }
+            .animation(.easeInOut(duration: 0.2), value: router.isQuickSwitchPresented)
+        }
+
         private func tabView(selection: Binding<AppTab>) -> some View {
             TabView(selection: selection) {
                 Tab(value: AppTab.search) {
@@ -155,6 +175,29 @@ struct MainTabView: View {
                     Image(systemName: "gear")
                 }
             }
+        }
+
+        /// Whether something layered over the tabs owns the screen: tvOS focus is
+        /// not clipped by z-order, so the tab bar and the cards behind a plain
+        /// overlay would still take presses. The playlist switch is deliberately
+        /// absent — it settles in under half a second, and disabling the tabs for
+        /// it would move focus and hand it back somewhere else.
+        private var blockingOverlayOwnsScreen: Bool {
+            router.isMultiViewPresented
+                || activeSyncPlaylist != nil
+                || profileManager?.isSwitching == true
+        }
+
+        /// Whether Play/Pause may toggle the quick-switch modal right now. Off
+        /// while a blocking overlay owns the screen, and off when neither column
+        /// would have a focusable row — an empty modal over a disabled tab bar has
+        /// nothing to hand focus to, and so nothing to deliver Menu either.
+        private var playPauseTogglesQuickSwitch: Bool {
+            if router.isQuickSwitchPresented {
+                return true
+            }
+            guard !blockingOverlayOwnsScreen else { return false }
+            return !playlists.isEmpty || profileManager?.isReady == true
         }
 
         /// tvOS `TabView` keeps every *visited* tab's view hierarchy alive, and

--- a/Lume/Views/Player/SubtitleSearchView+TV.swift
+++ b/Lume/Views/Player/SubtitleSearchView+TV.swift
@@ -50,7 +50,7 @@
         private var header: some View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Subtitles")
-                    .font(.system(size: 46, weight: .bold))
+                    .font(.system(size: TVSettingsMetrics.titleFontSize, weight: .bold))
                 // The stream's own name — data, so verbatim.
                 Text(verbatim: media.title)
                     .font(.system(size: 26))
@@ -91,7 +91,7 @@
                         ProgressView()
                         Text("Searching…")
                     }
-                    .tvSubtitleStatusText()
+                    .tvSettingsSecondaryText()
                 case let .failed(message):
                     Text(verbatim: message)
                         .font(.system(size: 24))
@@ -99,10 +99,10 @@
                         .padding(.horizontal, TVSettingsMetrics.rowHPadding)
                 case .unsupported:
                     Text("Subtitle search is only available for movies and episodes.")
-                        .tvSubtitleStatusText()
+                        .tvSettingsSecondaryText()
                 case .empty:
                     Text("No subtitles found for this title.")
-                        .tvSubtitleStatusText()
+                        .tvSettingsSecondaryText()
                 case .results:
                     LazyVStack(spacing: 8) {
                         ForEach(results) { subtitle in
@@ -125,20 +125,11 @@
 
                     if let remaining = service.remainingDownloads {
                         Text("\(remaining) downloads left today.")
-                            .tvSubtitleStatusText()
+                            .tvSettingsSecondaryText()
                             .padding(.top, 4)
                     }
                 }
             }
-        }
-    }
-
-    private extension View {
-        /// The quiet secondary line the status messages share.
-        func tvSubtitleStatusText() -> some View {
-            font(.system(size: 24))
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, TVSettingsMetrics.rowHPadding)
         }
     }
 
@@ -195,7 +186,7 @@
             ScrollView {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Languages")
-                        .font(.system(size: 46, weight: .bold))
+                        .font(.system(size: TVSettingsMetrics.titleFontSize, weight: .bold))
                         .padding(.bottom, 18)
 
                     LazyVStack(spacing: 8) {

--- a/Lume/Views/Profiles/ProfileMenu.swift
+++ b/Lume/Views/Profiles/ProfileMenu.swift
@@ -2,8 +2,9 @@ import SwiftData
 import SwiftUI
 
 /// The top-left profile switcher: the active profile's avatar, tapping it opens
-/// a menu to switch profile or manage profiles. iOS / macOS only — tvOS surfaces
-/// profiles through Settings to avoid disturbing the immersive home's focus.
+/// a menu to switch profile or manage profiles. iOS / macOS only — placing it on
+/// the immersive tvOS home would disturb its focus, so tvOS switches through the
+/// Play/Pause quick-switch overlay and manages profiles in Settings.
 ///
 /// Hidden while there's only a single profile: there's nothing to switch to, and
 /// creating more profiles stays reachable through Settings.
@@ -89,7 +90,9 @@ struct ProfileMenu: View {
 extension View {
     /// Places the ``ProfileMenu`` in the navigation bar's leading edge. Shared by
     /// the top-level library screens (Home, Movies, Series). iOS / macOS only —
-    /// tvOS surfaces profiles through Settings.
+    /// tvOS and visionOS have no toolbar to place it in: tvOS switches through
+    /// the Play/Pause quick-switch overlay, visionOS through Settings;
+    /// management is in Settings on both.
     func profileMenuToolbar() -> some View {
         #if os(iOS)
             toolbar {

--- a/Lume/Views/Settings/SettingsView+Playlists.swift
+++ b/Lume/Views/Settings/SettingsView+Playlists.swift
@@ -2,10 +2,12 @@
 //  SettingsView+Playlists.swift
 //  Lume
 //
-//  The tvOS Playlists settings pane. tvOS has no toolbar playlist switcher (the
-//  immersive home has no toolbar), so Settings is the entry point for switching
-//  the active playlist, adding new ones and editing them — mirroring the Profiles
-//  pane. iOS/macOS use the PlaylistSwitcher in the library toolbar instead.
+//  The tvOS Playlists settings pane — the management surface: add, edit, delete,
+//  and switch the active playlist. A switch made here presents the blocking sync
+//  cover; the fast path that skips it is the Play/Pause quick-switch overlay
+//  (TVQuickSwitchOverlay), which switches only. tvOS has no toolbar to host a
+//  PlaylistSwitcher (the immersive home has none); iOS/macOS use that switcher in
+//  the library toolbar instead.
 //
 
 import SwiftUI
@@ -74,29 +76,13 @@ import SwiftUI
         /// deleted fallback the content tabs use, so the first playlist reads as
         /// active by default.
         private func tvPlaylistRow(_ playlist: Playlist) -> some View {
-            let isActive = playlist.id.uuidString == effectivePlaylistID
-            return HStack(spacing: 16) {
-                Button {
+            HStack(spacing: 16) {
+                TVPlaylistSwitchRow(
+                    playlist: playlist,
+                    isActive: playlist.id.uuidString == effectivePlaylistID
+                ) {
                     switchPlaylist(to: playlist)
-                } label: {
-                    HStack(spacing: 16) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(playlist.name)
-                            Text(playlist.serverURL)
-                                .font(.system(size: 20))
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                        }
-                        Spacer(minLength: 0)
-                        if isActive {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 22, weight: .semibold))
-                                .foregroundStyle(.tint)
-                        }
-                    }
                 }
-                .buttonStyle(TVSettingsRowButtonStyle())
 
                 Button {
                     selectedPlaylist = playlist
@@ -109,9 +95,9 @@ import SwiftUI
         }
 
         /// The active playlist's id, accounting for the empty-default / deleted
-        /// fallback to the first playlist (matches `[Playlist].active(for:)`).
+        /// fallback to the first playlist.
         private var effectivePlaylistID: String {
-            playlists.active(for: selectedPlaylistID)?.id.uuidString ?? ""
+            playlists.activeID(for: selectedPlaylistID)
         }
 
         /// Switches the global selection, routing through the blocking overlay when

--- a/Lume/Views/Settings/SettingsView+Profiles.swift
+++ b/Lume/Views/Settings/SettingsView+Profiles.swift
@@ -2,10 +2,11 @@
 //  SettingsView+Profiles.swift
 //  Lume
 //
-//  The tvOS Profiles settings pane. tvOS has no top-left profile switcher (it
-//  would disturb the immersive home's focus), so Settings is the entry point for
-//  switching, adding and editing profiles there. iOS/macOS use the top-left
-//  ProfileMenu instead.
+//  The tvOS Profiles settings pane — the management surface: switch, add, edit
+//  and delete profiles. Switching alone also has a fast path, the Play/Pause
+//  quick-switch overlay (TVQuickSwitchOverlay). tvOS carries no top-left
+//  ProfileMenu (it would disturb the immersive home's focus); iOS/macOS use that
+//  menu instead.
 //
 
 import SwiftData
@@ -54,9 +55,15 @@ import SwiftUI
         @Environment(ProfileManager.self) private var profileManager: ProfileManager?
         @Environment(ParentalControls.self) private var parental: ParentalControls?
         /// The roster comes from `ProfileManager` — `UserProfile` lives in the
-        /// cloud store (a separate container this view's env context doesn't bind to).
-        private var profiles: [UserProfile] {
-            profileManager?.profiles ?? []
+        /// cloud store (a separate container this view's env context doesn't bind
+        /// to) — and which row is active is resolved the same way every other
+        /// switch surface resolves it.
+        private var profileRows: [QuickSwitchRow<UserProfile>] {
+            guard let profileManager else { return [] }
+            return QuickSwitchResolver.profileRows(
+                profileManager.profiles,
+                activeProfileID: profileManager.activeProfileID
+            )
         }
 
         @State private var creatingProfile = false
@@ -81,12 +88,12 @@ import SwiftUI
             VStack(alignment: .leading, spacing: 8) {
                 TVSettingsSectionLabel("Profiles")
 
-                ForEach(profiles) { profile in
-                    row(profile)
+                ForEach(profileRows) { profileRow in
+                    row(profileRow)
                 }
 
                 Button {
-                    if premium.isPremium || profiles.isEmpty {
+                    if premium.isPremium || profileRows.isEmpty {
                         creatingProfile = true
                     } else {
                         showPaywall = true
@@ -173,29 +180,17 @@ import SwiftUI
             }
         }
 
-        private func row(_ profile: UserProfile) -> some View {
-            let isActive = profile.id == profileManager?.activeProfileID
+        private func row(_ profileRow: QuickSwitchRow<UserProfile>) -> some View {
+            let profile = profileRow.item
             return HStack(spacing: 16) {
-                Button {
-                    guard let profileManager, !isActive else { return }
+                TVProfileSwitchRow(profile: profile, isActive: profileRow.isCurrent) {
+                    guard let profileManager, !profileRow.isCurrent else { return }
                     if parental?.requiresPIN(toSwitchTo: profile) == true {
                         pendingSwitch = profile
                     } else {
                         Task { await profileManager.switchProfile(to: profile.id) }
                     }
-                } label: {
-                    HStack(spacing: 16) {
-                        ProfileAvatarView(profile: profile, size: 44)
-                        Text(profile.name)
-                        Spacer(minLength: 0)
-                        if isActive {
-                            Image(systemName: "checkmark")
-                                .font(.system(size: 22, weight: .semibold))
-                                .foregroundStyle(.tint)
-                        }
-                    }
                 }
-                .buttonStyle(TVSettingsRowButtonStyle())
 
                 Button {
                     editingProfile = profile

--- a/Lume/Views/Settings/SettingsView.swift
+++ b/Lume/Views/Settings/SettingsView.swift
@@ -56,9 +56,10 @@ struct SettingsView: View {
 
     #if os(tvOS)
         /// The globally-selected playlist, shared with the content tabs. tvOS has
-        /// no toolbar switcher, so the Playlists settings pane is where the active
-        /// playlist is chosen. Not `private`: read by the SettingsView+Playlists
-        /// extension (separate file).
+        /// no toolbar switcher: this pane is the management surface where the
+        /// active playlist is chosen, and the Play/Pause quick-switch overlay the
+        /// fast path that writes the same key. Not `private`: read by the
+        /// SettingsView+Playlists extension (separate file).
         @AppStorage(PlaylistSelectionStore.key) var selectedPlaylistID: String = ""
         /// Routes the switch through the blocking overlay (see PlaylistSwitchModel).
         /// Not `private`: read by the SettingsView+Playlists extension.

--- a/Lume/Views/Settings/TVSettingsComponents.swift
+++ b/Lume/Views/Settings/TVSettingsComponents.swift
@@ -21,10 +21,14 @@
         static let rowCornerRadius: CGFloat = 10
         static let labelFontSize: CGFloat = 18
         static let secondaryFontSize: CGFloat = 20
+        static let statusFontSize: CGFloat = 24
+        static let titleFontSize: CGFloat = 46
         static let contentMaxWidth: CGFloat = 760
         /// Width of the Settings detail pane content (sits next to the sidebar, so
         /// it gets a touch more room than the full-screen `contentMaxWidth`).
         static let detailMaxWidth: CGFloat = 860
+        /// Width of a secondary column sitting beside a `contentMaxWidth` one.
+        static let sideColumnWidth: CGFloat = 560
         static let background = Color(white: 0.09)
     }
 
@@ -32,6 +36,14 @@
         /// The flat dark fill shared by every tvOS settings surface.
         func tvSettingsBackground() -> some View {
             background(TVSettingsMetrics.background.ignoresSafeArea())
+        }
+
+        /// The quiet secondary line shared by the status and empty-state
+        /// messages, inset to line up with the row labels above it.
+        func tvSettingsSecondaryText() -> some View {
+            font(.system(size: TVSettingsMetrics.statusFontSize))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, TVSettingsMetrics.rowHPadding)
         }
     }
 

--- a/Lume/Views/TV/TVQuickSwitchHint.swift
+++ b/Lume/Views/TV/TVQuickSwitchHint.swift
@@ -1,0 +1,108 @@
+//
+//  TVQuickSwitchHint.swift
+//  Lume
+//
+//  One-time teaching hint for the Play/Pause quick-switch gesture, shown over
+//  the tvOS Home screen on first run.
+//
+
+#if os(tvOS)
+
+    import SwiftUI
+
+    extension View {
+        /// Overlays the first-run Play/Pause hint. Drawn in an overlay and built
+        /// from plain `Text`/`Image`, so it adds no focus target and cannot change
+        /// the geometry of what it covers — the tab bar's up-handoff sentinel and
+        /// the hero fold's snap both depend on that geometry staying put.
+        ///
+        /// `interacted` carries the host view's own signal that the viewer has
+        /// moved on (a title was picked); the modal and tab-change signals are
+        /// read from the router in the leaf, so observing them never re-renders
+        /// the host. The remote is never read directly.
+        func tvQuickSwitchHint(interacted: Bool) -> some View {
+            modifier(TVQuickSwitchHintOverlay(interacted: interacted))
+        }
+    }
+
+    private struct TVQuickSwitchHintOverlay: ViewModifier {
+        let interacted: Bool
+
+        /// Device-local on purpose: a hint already seen on this Apple TV says
+        /// nothing about the user's other devices, so it is deliberately not
+        /// mirrored to CloudKit.
+        @AppStorage("tv.quickSwitch.hintShown.v1") private var hasBeenShown = false
+        @Environment(DeepLinkRouter.self) private var router
+
+        @State private var isVisible = false
+
+        /// Left long enough to read once, short enough that it never competes
+        /// with the hero for attention.
+        private static let visibleDuration: Duration = .seconds(8)
+
+        /// Lets the hero fold settle and take initial focus before the hint
+        /// fades in over it.
+        private static let appearDelay: Duration = .milliseconds(600)
+
+        func body(content: Content) -> some View {
+            content
+                .overlay(alignment: .bottom) {
+                    if isVisible {
+                        TVQuickSwitchHintBanner()
+                            .transition(.opacity)
+                    }
+                }
+                .task {
+                    guard !hasBeenShown else { return }
+                    try? await Task.sleep(for: Self.appearDelay)
+                    withAnimation(.easeInOut(duration: 0.3)) { isVisible = true }
+                    try? await Task.sleep(for: Self.visibleDuration)
+                    dismiss()
+                }
+                .onChange(of: hasMovedOn) { _, moved in
+                    guard moved else { return }
+                    // The signals feeding this fire inside the focus engine's
+                    // animated context.
+                    Task { @MainActor in dismiss() }
+                }
+                // Home can unmount before the timeout — a hint that was on
+                // screen still counts as shown, which `dismiss()` records.
+                .onDisappear(perform: dismiss)
+        }
+
+        /// The viewer has moved on: a title was picked, the quick-switch modal
+        /// opened, or another tab took over. Guarded on `hasBeenShown` so that
+        /// once the hint is spent nothing here observes the router any more.
+        private var hasMovedOn: Bool {
+            guard !hasBeenShown else { return false }
+            return interacted || router.isQuickSwitchPresented || router.selectedTab != .home
+        }
+
+        private func dismiss() {
+            guard isVisible else { return }
+            withAnimation(.easeInOut(duration: 0.3)) { isVisible = false }
+            hasBeenShown = true
+        }
+    }
+
+    private struct TVQuickSwitchHintBanner: View {
+        var body: some View {
+            HStack(spacing: 16) {
+                Image(systemName: "playpause.fill")
+                Text(
+                    "Press Play/Pause to switch playlist or profile",
+                    comment: "First-run hint on the tvOS Home screen teaching the Play/Pause remote button that opens the playlist/profile quick-switch modal"
+                )
+            }
+            .font(.system(size: TVSettingsMetrics.rowFontSize, weight: .medium))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 36)
+            .padding(.vertical, 20)
+            .background(Color.black.opacity(0.75), in: Capsule())
+            .overlay(Capsule().strokeBorder(Color.white.opacity(0.15), lineWidth: 1))
+            .padding(.bottom, 60)
+            .allowsHitTesting(false)
+        }
+    }
+
+#endif

--- a/Lume/Views/TV/TVQuickSwitchOverlay.swift
+++ b/Lume/Views/TV/TVQuickSwitchOverlay.swift
@@ -1,0 +1,246 @@
+//
+//  TVQuickSwitchOverlay.swift
+//  Lume
+//
+//  The tvOS quick-switch modal: playlists on the left, profiles on the right,
+//  a checkmark on the active row of each. Switching only — adding, editing and
+//  deleting stay in Settings, which remains the management surface.
+//
+//  Presented as a plain overlay, never a `fullScreenCover`: a tvOS cover always
+//  self-dismisses on Menu, and neither `onExitCommand` nor
+//  `interactiveDismissDisabled` stops it.
+//
+
+#if os(tvOS)
+
+    import SwiftUI
+
+    struct TVQuickSwitchOverlay: View {
+        /// Owns the presentation flag this modal clears to dismiss itself. Handed
+        /// in rather than read from the environment: this modal is layered onto
+        /// the tab content by `MainTabView`, not nested inside it.
+        let router: DeepLinkRouter
+        /// Handed in for the same reason, and because `MainTabView` already holds
+        /// this fetch — a `@Query` here would register a second store observer
+        /// for the identical result.
+        let playlists: [Playlist]
+
+        /// The roster comes from `ProfileManager` — `UserProfile` lives in the
+        /// CloudKit-mirrored store, a separate container the browse `@Query`s
+        /// don't bind to.
+        @Environment(ProfileManager.self) private var profileManager: ProfileManager?
+        @Environment(ParentalControls.self) private var parental: ParentalControls?
+        @Environment(PlaylistSwitchModel.self) private var playlistSwitch: PlaylistSwitchModel?
+        @AppStorage(PlaylistSelectionStore.key) private var selectedPlaylistID: String = ""
+
+        /// A profile awaiting PIN entry before the switch goes through.
+        @State private var pendingSwitch: UserProfile?
+
+        @FocusState private var focus: FocusTarget?
+
+        private enum FocusTarget: Hashable {
+            case playlist(UUID)
+            case profile(UUID)
+        }
+
+        var body: some View {
+            let playlistRows = QuickSwitchResolver.playlistRows(playlists, storedID: selectedPlaylistID)
+            let profileRows = resolvedProfileRows
+            let focusTarget = initialFocus(playlists: playlistRows, profiles: profileRows)
+
+            return ZStack {
+                Color.black.opacity(0.92)
+                    .ignoresSafeArea()
+
+                VStack(alignment: .leading, spacing: 28) {
+                    Text(
+                        "Quick Switch",
+                        comment: "Title of the tvOS quick-switch modal, which switches the active playlist or profile"
+                    )
+                    .font(.system(size: TVSettingsMetrics.titleFontSize, weight: .bold))
+                    .foregroundStyle(.white)
+
+                    HStack(alignment: .top, spacing: 60) {
+                        playlistColumn(playlistRows)
+                        profileColumn(profileRows)
+                    }
+
+                    Text(
+                        "Press Menu to close",
+                        comment: "Hint at the bottom of the tvOS quick-switch modal telling the viewer which remote button closes it"
+                    )
+                    .font(.system(size: TVSettingsMetrics.secondaryFontSize))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .padding(.horizontal, TVSubtitleSearchMetrics.horizontalInset)
+                .padding(.vertical, TVSubtitleSearchMetrics.verticalInset)
+            }
+            .defaultFocus($focus, focusTarget, priority: .userInitiated)
+            .onAppear { landInitialFocus(focusTarget) }
+            .onExitCommand(perform: close)
+            .pinPrompt(target: $pendingSwitch) { profile in
+                guard let profileManager else { return }
+                close()
+                Task { await profileManager.switchProfile(to: profile.id) }
+            }
+        }
+
+        // MARK: - Columns
+
+        private func playlistColumn(_ rows: [QuickSwitchRow<Playlist>]) -> some View {
+            column("Playlists", width: TVSettingsMetrics.contentMaxWidth) {
+                if rows.isEmpty {
+                    emptyLabel(
+                        Text(
+                            "No playlists yet",
+                            comment: "Empty state shown in the playlists column of the tvOS quick-switch modal"
+                        )
+                    )
+                } else {
+                    ForEach(rows) { row in
+                        TVPlaylistSwitchRow(playlist: row.item, isActive: row.isCurrent) {
+                            select(playlist: row)
+                        }
+                        .focused($focus, equals: .playlist(row.id))
+                    }
+                }
+            }
+            .disabled(playlistSwitch?.isSwitching == true)
+        }
+
+        private func profileColumn(_ rows: [QuickSwitchRow<UserProfile>]) -> some View {
+            column("Profiles", width: TVSettingsMetrics.sideColumnWidth) {
+                if rows.isEmpty {
+                    emptyLabel(
+                        Text(
+                            "No profiles yet",
+                            comment: "Empty state shown in the profiles column of the tvOS quick-switch modal"
+                        )
+                    )
+                } else {
+                    ForEach(rows) { row in
+                        TVProfileSwitchRow(profile: row.item, isActive: row.isCurrent) {
+                            select(profile: row)
+                        }
+                        .focused($focus, equals: .profile(row.id))
+                    }
+                }
+            }
+            .disabled(profileColumnDisabled)
+        }
+
+        /// One column of full-width rows. Its own focus section, so left/right hop
+        /// between the two lists rather than walking row by row.
+        private func column(
+            _ title: LocalizedStringKey,
+            width: CGFloat,
+            @ViewBuilder rows: () -> some View
+        ) -> some View {
+            VStack(alignment: .leading, spacing: 8) {
+                TVSettingsSectionLabel(title)
+
+                ScrollView {
+                    VStack(spacing: 6) {
+                        rows()
+                    }
+                    .padding(.bottom, 24)
+                }
+            }
+            .frame(width: width)
+            .frame(maxHeight: .infinity, alignment: .top)
+            .focusSection()
+        }
+
+        private func emptyLabel(_ text: Text) -> some View {
+            text
+                .tvSettingsSecondaryText()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 8)
+        }
+
+        // MARK: - Rows
+
+        private var resolvedProfileRows: [QuickSwitchRow<UserProfile>] {
+            guard let profileManager else { return [] }
+            return QuickSwitchResolver.profileRows(
+                profileManager.profiles,
+                activeProfileID: profileManager.activeProfileID
+            )
+        }
+
+        /// A switch in flight, or a roster that hasn't resolved yet, would leave
+        /// the catalog half-projected — the playlist column stays open either way,
+        /// including to a child profile.
+        private var profileColumnDisabled: Bool {
+            guard let profileManager else { return true }
+            return profileManager.isSwitching || !profileManager.isReady
+        }
+
+        // MARK: - Focus
+
+        private func initialFocus(
+            playlists: [QuickSwitchRow<Playlist>],
+            profiles: [QuickSwitchRow<UserProfile>]
+        ) -> FocusTarget? {
+            if let first = playlists.first {
+                return .playlist(first.id)
+            }
+            return profiles.first.map { .profile($0.id) }
+        }
+
+        /// Asserts the initial focus once the tree has mounted: the engine picks
+        /// its own target as the rows appear, and a write made in the same turn is
+        /// overwritten. Released first — two assertions in flight leave the engine
+        /// on the incumbent.
+        private func landInitialFocus(_ target: FocusTarget?) {
+            guard let target else { return }
+            Task { @MainActor in
+                focus = nil
+                try? await Task.sleep(for: .milliseconds(150))
+                focus = target
+            }
+        }
+
+        // MARK: - Switching
+
+        /// Dismisses the modal. Always called before a switch is applied, so the
+        /// switch progress overlay never stacks on top of this one.
+        private func close() {
+            router.isQuickSwitchPresented = false
+        }
+
+        /// Picking the active row just closes the modal.
+        private func select(playlist row: QuickSwitchRow<Playlist>) {
+            guard !row.isCurrent else {
+                close()
+                return
+            }
+            let id = row.item.id.uuidString
+            let name = row.item.name
+            close()
+            if let playlistSwitch {
+                // The viewer asked to be somewhere else now: land in the cached
+                // catalog and leave the due sync to the next launch / foreground.
+                playlistSwitch.deferNextDueSync()
+                playlistSwitch.switchTo(name: name) { selectedPlaylistID = id }
+            } else {
+                selectedPlaylistID = id
+            }
+        }
+
+        private func select(profile row: QuickSwitchRow<UserProfile>) {
+            guard let profileManager, !row.isCurrent else {
+                close()
+                return
+            }
+            if parental?.requiresPIN(toSwitchTo: row.item) == true {
+                pendingSwitch = row.item
+                return
+            }
+            close()
+            Task { await profileManager.switchProfile(to: row.item.id) }
+        }
+    }
+
+#endif

--- a/Lume/Views/TV/TVSwitchRows.swift
+++ b/Lume/Views/TV/TVSwitchRows.swift
@@ -1,0 +1,105 @@
+//
+//  TVSwitchRows.swift
+//  Lume
+//
+//  The playlist and profile rows shared by every tvOS switch surface (the
+//  Settings Playlists/Profiles panes and the quick-switch overlay). They draw the
+//  row itself only — the Settings panes compose their pencil affordance alongside
+//  one, so a surface that must not offer editing simply leaves it out.
+//
+
+#if os(tvOS)
+
+    import SwiftUI
+
+    /// A full-width playlist row: name over server URL, with a checkmark on the
+    /// active one. Full width matters for focus — a narrow target won't catch
+    /// "down" from a full-width section above it.
+    struct TVPlaylistSwitchRow: View {
+        let playlist: Playlist
+        let isActive: Bool
+        let action: () -> Void
+
+        var body: some View {
+            Button(action: action) {
+                HStack(spacing: 16) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(playlist.name)
+                        Text(playlist.serverURL)
+                            .font(.system(size: TVSettingsMetrics.secondaryFontSize))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    Spacer(minLength: 0)
+                    if isActive {
+                        TVSwitchRowCheckmark()
+                    }
+                }
+            }
+            .buttonStyle(TVSettingsRowButtonStyle())
+            .modifier(TVSwitchRowActiveState(isActive: isActive))
+        }
+    }
+
+    /// A full-width profile row: avatar and name, with a checkmark on the active
+    /// one.
+    struct TVProfileSwitchRow: View {
+        let profile: UserProfile
+        let isActive: Bool
+        let action: () -> Void
+
+        var body: some View {
+            Button(action: action) {
+                HStack(spacing: 16) {
+                    ProfileAvatarView(profile: profile, size: 44)
+                    Text(profile.name)
+                    Spacer(minLength: 0)
+                    if isActive {
+                        TVSwitchRowCheckmark()
+                    }
+                }
+            }
+            .buttonStyle(TVSettingsRowButtonStyle())
+            .modifier(TVSwitchRowActiveState(isActive: isActive))
+        }
+    }
+
+    /// Announces the active row as selected. The checkmark alone is invisible to
+    /// VoiceOver as state — it reads as another glyph in the label — so it is
+    /// hidden and the state is carried by the value and the trait instead.
+    private struct TVSwitchRowActiveState: ViewModifier {
+        let isActive: Bool
+
+        func body(content: Content) -> some View {
+            if isActive {
+                content
+                    .accessibilityValue(
+                        Text(
+                            "Active",
+                            comment: "Accessibility value on the playlist or profile row that is currently in use"
+                        )
+                    )
+                    .accessibilityAddTraits(.isSelected)
+            } else {
+                content
+            }
+        }
+    }
+
+    /// The active marker. Follows the row's focus treatment the way
+    /// `TVSettingsRowButtonStyle` does — a white glyph would vanish into the
+    /// focused row's near-white fill. Always explicit, never `.accentColor`:
+    /// that resolves to white on tvOS.
+    private struct TVSwitchRowCheckmark: View {
+        @Environment(\.isFocused) private var isFocused
+
+        var body: some View {
+            Image(systemName: "checkmark")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(isFocused ? .black : .white)
+                .accessibilityHidden(true)
+        }
+    }
+
+#endif

--- a/LumeTests/CloudSyncDeletionTests.swift
+++ b/LumeTests/CloudSyncDeletionTests.swift
@@ -16,41 +16,13 @@ import Testing
 
 @MainActor
 struct CloudSyncDeletionTests {
-    private func makeContainer() throws -> ModelContainer {
-        let fullSchema = Schema([
-            Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
-            Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self,
-            SyncedPlaylist.self, UserContentState.self, SyncedEPGSource.self
-        ])
-        // `cloudKitDatabase: .none` is required on both stores: the catalog uses
-        // `@Attribute(.unique)`, which CloudKit forbids, and the default
-        // `.automatic` mirrors to CloudKit on a signed/entitled test host and
-        // fails the load with `loadIssueModelContainer`.
-        let localConfig = ModelConfiguration(
-            "local",
-            schema: Schema([
-                Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
-                Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self
-            ]),
-            isStoredInMemoryOnly: true,
-            cloudKitDatabase: .none
-        )
-        let cloudConfig = ModelConfiguration(
-            "cloud",
-            schema: Schema([SyncedPlaylist.self, UserContentState.self, SyncedEPGSource.self]),
-            isStoredInMemoryOnly: true,
-            cloudKitDatabase: .none
-        )
-        return try ModelContainer(for: fullSchema, configurations: localConfig, cloudConfig)
-    }
-
     private func freshShadow() -> CloudSyncShadow {
         let suite = UserDefaults(suiteName: "cloudsync.deletion.test.\(UUID().uuidString)")!
         return CloudSyncShadow(defaults: suite)
     }
 
     @Test func `deleting the last playlist propagates to the cloud instead of resurrecting`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         let shadow = freshShadow()
 
@@ -89,7 +61,7 @@ struct CloudSyncDeletionTests {
     }
 
     @Test func `deleting one of several playlists leaves the survivor untouched`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
 
         let doomed = Playlist(name: "Doomed", serverURL: "http://a", username: "u", password: "p")
@@ -117,7 +89,7 @@ struct CloudSyncDeletionTests {
     }
 
     @Test func `deleting a never-synced playlist works without a mirror or shadow`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
 
         let playlist = Playlist(name: "Local Only", serverURL: "http://x", username: "u", password: "p")

--- a/LumeTests/CloudSyncTests.swift
+++ b/LumeTests/CloudSyncTests.swift
@@ -181,41 +181,13 @@ struct CloudSyncConflictPolicyTests {
 
 @MainActor
 struct CloudSyncEngineTests {
-    private func makeContainer() throws -> ModelContainer {
-        let fullSchema = Schema([
-            Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
-            Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self,
-            SyncedPlaylist.self, UserContentState.self, SyncedEPGSource.self
-        ])
-        // `cloudKitDatabase: .none` is required on both stores: the catalog uses
-        // `@Attribute(.unique)`, which CloudKit forbids, and the default
-        // `.automatic` mirrors to CloudKit on a signed/entitled test host and
-        // fails the load with `loadIssueModelContainer`.
-        let localConfig = ModelConfiguration(
-            "local",
-            schema: Schema([
-                Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
-                Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self
-            ]),
-            isStoredInMemoryOnly: true,
-            cloudKitDatabase: .none
-        )
-        let cloudConfig = ModelConfiguration(
-            "cloud",
-            schema: Schema([SyncedPlaylist.self, UserContentState.self, SyncedEPGSource.self]),
-            isStoredInMemoryOnly: true,
-            cloudKitDatabase: .none
-        )
-        return try ModelContainer(for: fullSchema, configurations: localConfig, cloudConfig)
-    }
-
     private func freshShadow() -> CloudSyncShadow {
         let suite = UserDefaults(suiteName: "cloudsync.test.\(UUID().uuidString)")!
         return CloudSyncShadow(defaults: suite)
     }
 
     @Test func `local playlist and favorite export to cloud mirrors`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
 
         let playlist = Playlist(name: "My IPTV", serverURL: "http://x", username: "u", password: "p")
@@ -247,7 +219,7 @@ struct CloudSyncEngineTests {
     }
 
     @Test func `cloud playlist creates a local playlist`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         let pid = UUID()
         ctx.insert(SyncedPlaylist(
@@ -268,7 +240,7 @@ struct CloudSyncEngineTests {
     }
 
     @Test func `cloud content state stays pending until its catalog item exists`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         let shadow = freshShadow()
         let pid = UUID()
@@ -301,7 +273,7 @@ struct CloudSyncEngineTests {
     }
 
     @Test func `empty local catalog with a populated shadow never deletes cloud mirrors`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         let shadow = freshShadow()
 
@@ -343,7 +315,7 @@ struct CloudSyncEngineTests {
     @Test func `empty local catalog with an empty shadow still pulls from the cloud`() async throws {
         // A genuinely fresh device (or a clean reinstall) has an empty shadow, so
         // the integrity gate must NOT block it — it has to pull cloud playlists in.
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         let pid = UUID()
         ctx.insert(SyncedPlaylist(
@@ -360,7 +332,7 @@ struct CloudSyncEngineTests {
     }
 
     @Test func `state whose playlist is gone is garbage-collected`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         let pid = UUID() // no playlist (local or cloud) for this id
         ctx.insert(UserContentState(contentId: "\(pid.uuidString)-movie-1", kind: .movie, isFavorite: true))
@@ -375,7 +347,7 @@ struct CloudSyncEngineTests {
     // MARK: - Content Management (hidden categories / channels, category order)
 
     @Test func `a hidden category exports to a cloud mirror`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
 
         let playlist = Playlist(name: "My IPTV", serverURL: "http://x", username: "u", password: "p")
@@ -399,7 +371,7 @@ struct CloudSyncEngineTests {
     }
 
     @Test func `a cloud category state hides the matching local category`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
 
         // The catalog already has the playlist + a visible category (as a fresh
@@ -423,7 +395,7 @@ struct CloudSyncEngineTests {
     }
 
     @Test func `a hidden channel syncs but its per-category order does not`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
 
         let playlist = Playlist(name: "My IPTV", serverURL: "http://x", username: "u", password: "p")
@@ -455,7 +427,7 @@ struct CloudSyncEngineTests {
     // MARK: - EPG sources
 
     @Test func `manual EPG source exports to a cloud mirror`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         let source = EPGSource(name: "Custom", url: "http://x/guide.xml")
         let sid = source.id
@@ -473,7 +445,7 @@ struct CloudSyncEngineTests {
     }
 
     @Test func `cloud EPG source creates a local manual source`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         let sid = UUID()
         ctx.insert(SyncedEPGSource(id: sid, name: "Remote Guide", url: "http://r/epg.xml", isEnabled: true))
@@ -491,7 +463,7 @@ struct CloudSyncEngineTests {
     }
 
     @Test func `a pulled playlist regenerates its linked EPG source locally`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         let pid = UUID()
         ctx.insert(SyncedPlaylist(

--- a/LumeTests/Helpers/TestHelpers.swift
+++ b/LumeTests/Helpers/TestHelpers.swift
@@ -36,3 +36,35 @@ func loadExampleJSON<T: Decodable>(_ filename: String, filePath: String = #fileP
     let decoder = JSONDecoder()
     return try decoder.decode(T.self, from: data)
 }
+
+/// Two-configuration in-memory container: the local catalog plus the CloudKit
+/// mirror's models, matching the app's split containers.
+///
+/// Both configurations pin `cloudKitDatabase: .none`: the catalog uses
+/// `@Attribute(.unique)`, which CloudKit forbids, so the default `.automatic`
+/// fails the load with `loadIssueModelContainer` on an entitled simulator host.
+func makeProfileTestContainer() throws -> ModelContainer {
+    let catalogModels: [any PersistentModel.Type] = [
+        Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
+        Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self
+    ]
+    let cloudModels: [any PersistentModel.Type] = [
+        SyncedPlaylist.self, UserContentState.self, UserProfile.self, SyncedEPGSource.self
+    ]
+    let localConfig = ModelConfiguration(
+        "local",
+        schema: Schema(catalogModels),
+        isStoredInMemoryOnly: true,
+        cloudKitDatabase: .none
+    )
+    let cloudConfig = ModelConfiguration(
+        "cloud",
+        schema: Schema(cloudModels),
+        isStoredInMemoryOnly: true,
+        cloudKitDatabase: .none
+    )
+    return try ModelContainer(
+        for: Schema(catalogModels + cloudModels),
+        configurations: localConfig, cloudConfig
+    )
+}

--- a/LumeTests/ProfileTests.swift
+++ b/LumeTests/ProfileTests.swift
@@ -19,37 +19,13 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct ProfileEngineTests {
-    private func makeContainer() throws -> ModelContainer {
-        let fullSchema = Schema([
-            Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
-            Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self,
-            SyncedPlaylist.self, UserContentState.self, UserProfile.self, SyncedEPGSource.self
-        ])
-        let localConfig = ModelConfiguration(
-            "local",
-            schema: Schema([
-                Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
-                Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self
-            ]),
-            isStoredInMemoryOnly: true,
-            cloudKitDatabase: .none
-        )
-        let cloudConfig = ModelConfiguration(
-            "cloud",
-            schema: Schema([SyncedPlaylist.self, UserContentState.self, UserProfile.self, SyncedEPGSource.self]),
-            isStoredInMemoryOnly: true,
-            cloudKitDatabase: .none
-        )
-        return try ModelContainer(for: fullSchema, configurations: localConfig, cloudConfig)
-    }
-
     private func freshShadow() -> CloudSyncShadow {
         let suite = UserDefaults(suiteName: "profiles.test.\(UUID().uuidString)")!
         return CloudSyncShadow(defaults: suite)
     }
 
     @Test func `bootstrap creates a default profile and claims legacy records`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         ctx.insert(UserContentState(contentId: "pl-movie-1", kind: .movie, isFavorite: true))
         try ctx.save()
@@ -68,7 +44,7 @@ struct ProfileEngineTests {
     }
 
     @Test func `bootstrap collapses duplicate default profiles keeping the earliest`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         ctx.insert(UserProfile(id: UserProfile.defaultProfileID, name: "First", createdAt: Date(timeIntervalSince1970: 100)))
         ctx.insert(UserProfile(id: UserProfile.defaultProfileID, name: "Second", createdAt: Date(timeIntervalSince1970: 200)))
@@ -84,7 +60,7 @@ struct ProfileEngineTests {
     }
 
     @Test func `reconcile collapses a duplicate default profile imported from another device`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         // Simulates a freshly-synced device: its own bootstrap-created default
         // profile, plus the original device's default (same fixed id) that
@@ -113,7 +89,7 @@ struct ProfileEngineTests {
     }
 
     @Test func `switching profiles flushes the old profile and hydrates the new`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         let profileA = UUID()
         let profileB = UUID()
@@ -153,7 +129,7 @@ struct ProfileEngineTests {
     }
 
     @Test func `reconcile only projects the active profile's mirrors`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         let profileA = UUID()
         let profileB = UUID()
@@ -184,7 +160,7 @@ struct ProfileEngineTests {
     }
 
     @Test func `purging a profile deletes only its records`() async throws {
-        let container = try makeContainer()
+        let container = try makeProfileTestContainer()
         let ctx = container.mainContext
         let profileA = UUID()
         let profileB = UUID()
@@ -198,5 +174,190 @@ struct ProfileEngineTests {
         let remaining = try ctx.fetch(FetchDescriptor<UserContentState>())
         #expect(remaining.count == 1)
         #expect(remaining.first?.profileID == profileB)
+    }
+
+    // MARK: - ProfileManager switch contract
+
+    /// A `ProfileManager` over the in-memory two-configuration container (the
+    /// catalog and cloud stores are two configurations of the same container).
+    /// The coordinator runs with `cloudKitEnabled: false`: touching `CKContainer`
+    /// from an un-entitled test binary crashes, and that path still reconciles
+    /// the local store.
+    private func makeManager(_ container: ModelContainer) -> (ProfileManager, CloudSyncCoordinator) {
+        let coordinator = CloudSyncCoordinator(
+            catalogContainer: container,
+            cloudContainer: container,
+            cloudKitContainerIdentifier: "iCloud.lume.tests.invalid",
+            cloudKitEnabled: false
+        )
+        let manager = ProfileManager(
+            catalogContainer: container,
+            cloudContainer: container,
+            coordinator: coordinator
+        )
+        return (manager, coordinator)
+    }
+
+    /// Starts a switch and returns once it has reached its first suspension
+    /// point, so the caller can observe the in-flight state.
+    private func beginSwitch(_ manager: ProfileManager, to id: UUID) async -> Task<Void, Never> {
+        let task = Task { await manager.switchProfile(to: id) }
+        var spins = 0
+        while !manager.isSwitching, spins < 500 {
+            await Task.yield()
+            spins += 1
+        }
+        return task
+    }
+
+    /// A reconcile is debounced by 600 ms and coalesces, so its only observable
+    /// trace is `status.lastReconcile` moving on. Polls rather than sleeping a
+    /// fixed amount; `attempts` is kept short when asserting that none arrives.
+    private func waitForReconcile(
+        _ coordinator: CloudSyncCoordinator,
+        after previous: Date?,
+        attempts: Int = 100
+    ) async -> Date? {
+        for _ in 0 ..< attempts {
+            if let date = coordinator.status.lastReconcile, date != previous {
+                return date
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return nil
+    }
+
+    @Test func `switching to the already-active profile is a no-op`() async throws {
+        let container = try makeProfileTestContainer()
+        let ctx = container.mainContext
+        let active = UUID()
+        ctx.insert(UserProfile(id: active, name: "Me", createdAt: Date(timeIntervalSince1970: 100)))
+        try ctx.save()
+
+        let saved = ActiveProfileStore.current
+        ActiveProfileStore.current = active
+        defer { ActiveProfileStore.current = saved }
+
+        let (manager, coordinator) = makeManager(container)
+        #expect(manager.activeProfileID == active)
+
+        await manager.switchProfile(to: active)
+
+        #expect(manager.isSwitching == false)
+        #expect(manager.pendingProfileName == nil)
+        #expect(manager.activeProfileID == active)
+        // No switch work ran, so the trailing re-baselining reconcile never fired.
+        let reconciled = await waitForReconcile(coordinator, after: nil, attempts: 20)
+        #expect(reconciled == nil)
+    }
+
+    @Test func `a switch already in flight refuses a second target`() async throws {
+        let container = try makeProfileTestContainer()
+        let ctx = container.mainContext
+        let profileA = UUID()
+        let profileB = UUID()
+        let profileC = UUID()
+        ctx.insert(UserProfile(id: profileA, name: "A", createdAt: Date(timeIntervalSince1970: 100)))
+        ctx.insert(UserProfile(id: profileB, name: "B", createdAt: Date(timeIntervalSince1970: 200)))
+        ctx.insert(UserProfile(id: profileC, name: "C", createdAt: Date(timeIntervalSince1970: 300)))
+        try ctx.save()
+
+        let saved = ActiveProfileStore.current
+        ActiveProfileStore.current = profileA
+        defer { ActiveProfileStore.current = saved }
+
+        let (manager, _) = makeManager(container)
+        let switching = await beginSwitch(manager, to: profileB)
+        #expect(manager.isSwitching)
+
+        await manager.switchProfile(to: profileC)
+        #expect(manager.pendingProfileName == "B")
+
+        await switching.value
+        #expect(manager.activeProfileID == profileB)
+        #expect(ActiveProfileStore.current == profileB)
+    }
+
+    @Test func `pendingProfileName holds the target while switching and clears after`() async throws {
+        let container = try makeProfileTestContainer()
+        let ctx = container.mainContext
+        let profileA = UUID()
+        let profileB = UUID()
+        ctx.insert(UserProfile(id: profileA, name: "Grown-ups", createdAt: Date(timeIntervalSince1970: 100)))
+        ctx.insert(UserProfile(id: profileB, name: "Kids", createdAt: Date(timeIntervalSince1970: 200)))
+        try ctx.save()
+
+        let saved = ActiveProfileStore.current
+        ActiveProfileStore.current = profileA
+        defer { ActiveProfileStore.current = saved }
+
+        let (manager, _) = makeManager(container)
+        #expect(manager.pendingProfileName == nil)
+
+        let switching = await beginSwitch(manager, to: profileB)
+        #expect(manager.pendingProfileName == "Kids")
+
+        await switching.value
+        #expect(manager.isSwitching == false)
+        #expect(manager.pendingProfileName == nil)
+    }
+
+    @Test func `a profile switch flushes pending catalog edits before exporting`() async throws {
+        let container = try makeProfileTestContainer()
+        let ctx = container.mainContext
+        // Autosave off so "unsaved" stays unsaved: the only save in this test is
+        // the flush at the top of `switchProfile`, which is what's under test.
+        ctx.autosaveEnabled = false
+        let profileA = UUID()
+        let profileB = UUID()
+        ctx.insert(UserProfile(id: profileA, name: "A", createdAt: Date(timeIntervalSince1970: 100)))
+        ctx.insert(UserProfile(id: profileB, name: "B", createdAt: Date(timeIntervalSince1970: 200)))
+        try ctx.save()
+
+        let saved = ActiveProfileStore.current
+        ActiveProfileStore.current = profileA
+        defer { ActiveProfileStore.current = saved }
+
+        let (manager, _) = makeManager(container)
+
+        // A favorite toggled moments ago that no save has reached yet. Without the
+        // flush the engine's background context exports a stale catalog and this
+        // state is lost instead of landing in profile A's mirror.
+        let movie = Movie(id: "pl-movie-1", streamId: 1, name: "Film")
+        movie.isFavorite = true
+        movie.watchProgress = 100
+        ctx.insert(movie)
+
+        await manager.switchProfile(to: profileB)
+
+        let mirror = try ctx.fetch(FetchDescriptor<UserContentState>()).first { $0.profileID == profileA }
+        #expect(mirror?.isFavorite == true)
+        #expect(mirror?.watchProgress == 100)
+    }
+
+    @Test func `exactly one reconcile follows a profile switch`() async throws {
+        let container = try makeProfileTestContainer()
+        let ctx = container.mainContext
+        let profileA = UUID()
+        let profileB = UUID()
+        ctx.insert(UserProfile(id: profileA, name: "A", createdAt: Date(timeIntervalSince1970: 100)))
+        ctx.insert(UserProfile(id: profileB, name: "B", createdAt: Date(timeIntervalSince1970: 200)))
+        try ctx.save()
+
+        let saved = ActiveProfileStore.current
+        ActiveProfileStore.current = profileA
+        defer { ActiveProfileStore.current = saved }
+
+        let (manager, coordinator) = makeManager(container)
+        #expect(coordinator.status.lastReconcile == nil)
+
+        await manager.switchProfile(to: profileB)
+
+        let first = await waitForReconcile(coordinator, after: nil)
+        #expect(first != nil)
+        // The re-baselining pass is the only one the switch queues; a second
+        // would move `lastReconcile` on again.
+        let second = await waitForReconcile(coordinator, after: first, attempts: 20)
+        #expect(second == nil)
     }
 }

--- a/LumeTests/QuickSwitchResolverTests.swift
+++ b/LumeTests/QuickSwitchResolverTests.swift
@@ -1,0 +1,156 @@
+//
+//  QuickSwitchResolverTests.swift
+//  LumeTests
+//
+//  Covers the shared quick-switch seam every switch surface reads its "which
+//  row is current" answer from: the stored-selection fallbacks of
+//  `[Playlist].active(for:)`, row ordering, and the `isCurrent` tag.
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+/// Serialized: the stored-selection tests read and write
+/// `PlaylistSelectionStore.key` / `ActiveProfileStore.current` in
+/// `UserDefaults.standard`, shared process-wide state.
+@MainActor
+@Suite(.serialized)
+struct QuickSwitchResolverTests {
+    private func makePlaylists(_ names: [String], in context: ModelContext) throws -> [Playlist] {
+        let playlists = names.map { Playlist(name: $0, serverURL: "http://\($0)", username: "u", password: "p") }
+        for playlist in playlists {
+            context.insert(playlist)
+        }
+        try context.save()
+        return playlists
+    }
+
+    private func makeProfiles(_ names: [String], in context: ModelContext) throws -> [UserProfile] {
+        let profiles = names.enumerated().map { UserProfile(name: $0.element, sortOrder: $0.offset) }
+        for profile in profiles {
+            context.insert(profile)
+        }
+        try context.save()
+        return profiles
+    }
+
+    // MARK: - active(for:)
+
+    @Test func `an empty stored selection resolves to the first playlist`() throws {
+        let container = try makeProfileTestContainer()
+        let playlists = try makePlaylists(["First", "Second"], in: container.mainContext)
+
+        #expect(playlists.active(for: "")?.id == playlists[0].id)
+    }
+
+    @Test func `a stored selection naming a deleted playlist falls back to the first`() throws {
+        let container = try makeProfileTestContainer()
+        let playlists = try makePlaylists(["First", "Second"], in: container.mainContext)
+
+        #expect(playlists.active(for: UUID().uuidString)?.id == playlists[0].id)
+    }
+
+    @Test func `a valid stored selection resolves to that playlist`() throws {
+        let container = try makeProfileTestContainer()
+        let playlists = try makePlaylists(["First", "Second", "Third"], in: container.mainContext)
+
+        #expect(playlists.active(for: playlists[2].id.uuidString)?.id == playlists[2].id)
+    }
+
+    @Test func `no playlists resolves to nothing`() {
+        #expect([Playlist]().active(for: UUID().uuidString) == nil)
+    }
+
+    // MARK: - Playlist rows
+
+    @Test func `playlist rows keep the given order and mark the stored selection current`() throws {
+        let container = try makeProfileTestContainer()
+        let playlists = try makePlaylists(["First", "Second", "Third"], in: container.mainContext)
+
+        let rows = QuickSwitchResolver.playlistRows(playlists, storedID: playlists[1].id.uuidString)
+
+        #expect(rows.map(\.item.name) == ["First", "Second", "Third"])
+        #expect(rows.filter(\.isCurrent).map(\.item.name) == ["Second"])
+    }
+
+    @Test func `playlist rows mark the first row current when the stored selection is stale`() throws {
+        let container = try makeProfileTestContainer()
+        let playlists = try makePlaylists(["First", "Second"], in: container.mainContext)
+
+        let rows = QuickSwitchResolver.playlistRows(playlists, storedID: UUID().uuidString)
+
+        #expect(rows.filter(\.isCurrent).map(\.item.name) == ["First"])
+        #expect(playlists.activeID(for: "") == playlists[0].id.uuidString)
+    }
+
+    @Test func `the current playlist follows the value in the selection store`() throws {
+        let container = try makeProfileTestContainer()
+        let playlists = try makePlaylists(["First", "Second"], in: container.mainContext)
+
+        let savedSelection = UserDefaults.standard.string(forKey: PlaylistSelectionStore.key)
+        defer {
+            if let savedSelection {
+                UserDefaults.standard.set(savedSelection, forKey: PlaylistSelectionStore.key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: PlaylistSelectionStore.key)
+            }
+        }
+
+        UserDefaults.standard.set(playlists[1].id.uuidString, forKey: PlaylistSelectionStore.key)
+        let stored = UserDefaults.standard.string(forKey: PlaylistSelectionStore.key) ?? ""
+
+        #expect(playlists.active(for: stored)?.id == playlists[1].id)
+    }
+
+    // MARK: - Profile rows
+
+    @Test func `profile rows keep the roster order and mark the active profile current`() throws {
+        let container = try makeProfileTestContainer()
+        let profiles = try makeProfiles(["Me", "Kids", "Guest"], in: container.mainContext)
+
+        let rows = QuickSwitchResolver.profileRows(profiles, activeProfileID: profiles[2].id)
+
+        #expect(rows.map(\.item.name) == ["Me", "Kids", "Guest"])
+        #expect(rows.filter(\.isCurrent).map(\.item.name) == ["Guest"])
+        #expect(QuickSwitchResolver.currentProfile(in: profiles, activeProfileID: profiles[2].id)?.id == profiles[2].id)
+    }
+
+    @Test func `an unknown active profile id makes no row current`() throws {
+        let container = try makeProfileTestContainer()
+        let profiles = try makeProfiles(["Me", "Kids"], in: container.mainContext)
+
+        let rows = QuickSwitchResolver.profileRows(profiles, activeProfileID: UUID())
+
+        #expect(rows.allSatisfy { !$0.isCurrent })
+        #expect(QuickSwitchResolver.currentProfile(in: profiles, activeProfileID: UUID()) == nil)
+    }
+
+    @Test func `the current profile follows the active profile store`() throws {
+        let container = try makeProfileTestContainer()
+        let profiles = try makeProfiles(["Me", "Kids"], in: container.mainContext)
+
+        let saved = ActiveProfileStore.current
+        defer { ActiveProfileStore.current = saved }
+
+        ActiveProfileStore.current = profiles[1].id
+        let active = ActiveProfileStore.current ?? UserProfile.defaultProfileID
+
+        #expect(QuickSwitchResolver.currentProfile(in: profiles, activeProfileID: active)?.name == "Kids")
+    }
+
+    // MARK: - Row identity
+
+    @Test func `row ids are the item ids the focus targets key on`() throws {
+        let container = try makeProfileTestContainer()
+        let playlists = try makePlaylists(["First", "Second"], in: container.mainContext)
+        let profiles = try makeProfiles(["Me", "Kids"], in: container.mainContext)
+
+        let playlistRows = QuickSwitchResolver.playlistRows(playlists, storedID: "")
+        let profileRows = QuickSwitchResolver.profileRows(profiles, activeProfileID: profiles[0].id)
+
+        #expect(playlistRows.map(\.id) == playlists.map(\.id))
+        #expect(profileRows.map(\.id) == profiles.map(\.id))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ adapted per size class
 
 #### 👤 Profiles
 - Multiple **user profiles**, each with its own watch history, progress, and favorites
-- Switch profiles from the top-left of Home (iOS / macOS) or in Settings (tvOS)
+- Switch profiles from the top-left of Home (iOS / macOS), on tvOS with the Siri Remote's **Play/Pause** button, which opens a quick-switch overlay for playlists and profiles, or from Settings on visionOS — Settings stays the place to add, edit and delete them
 - Profiles and their state **sync across your devices** via iCloud
 - **Parental controls**: mark profiles as child profiles, restrict categories (hidden from browsing and search), and protect them with a PIN required to leave a child profile or open Content Management
 


### PR DESCRIPTION
## Summary

On tvOS, switching the active playlist or the active profile meant a trip into Settings — three levels deep, twice, for something people do casually. This adds a **Quick Switch** overlay: press **Play/Pause** on any browse tab and pick from two columns (Playlists | Profiles). Press it again, or Menu, to close.

Because a hidden gesture nobody knows about is not a feature, a **one-time hint** appears on Home teaching it, then never again.

Deliberately **switch-only** — no add, manage, delete or paywall. The Settings panes remain the management surface.

## Implementation

**Presentation.** A plain `.overlay` from `MainTabView`, never a `fullScreenCover` — a tvOS cover always self-dismisses on Menu and neither `onExitCommand` nor `interactiveDismissDisabled` stops it. The `TabView` is `.disabled` behind it, because tvOS focus is not clipped by z-order; without that, the tab bar and the cards behind keep taking remote presses. Built only while presented, so the focus/AX responder walk that `activeOnly(_:selection:)` exists to contain doesn't regrow.

**Invocation.** `.onPlayPauseCommand` attached *outside* the `.disabled(...)`, so the same button closes what it opened. The engines' players are `fullScreenCover`s presented from inside a tab, so their own `onPlayPauseCommand` sits above this one in the focused chain — pausing inside the player is unaffected (verified on device, see Testing). Gated off while Multi-View or the sync cover owns the screen, and while neither column would have a focusable row.

**Playlist switch defers the auto-sync.** Writing `selectedPlaylistID` normally fires `enqueueDueSyncs` → the blocking full-screen `SyncProgressView`, which is minutes on a large M3U and competes with the launch EPG refresh on the one-connection cap. A one-press "quick" switch landing in that cover reads as a hang, so a switch from this overlay lands in the cached catalog and leaves the due sync to the next launch/foreground. Scoped strictly to overlay-originated switches via a one-shot on `PlaylistSwitchModel` — Settings and the iOS/macOS `PlaylistSwitcher` keep today's behaviour exactly.

**Profile switch gets progress.** It had none anywhere in the app, despite being the heaviest operation there is (export → `resetCatalogUserState` → import → `shadow.resetContent()` → save both stores → `reconcile()`). `ProfileManager` now stores a single `switchingToProfileID` with `isSwitching` and `pendingProfileName` derived from it, so the two can't drift; the overlay is held until the await returns rather than for the playlist path's fixed settle. `switchProfile`'s ordering and its trailing `reconcile()` — which rebuilds the shadow baseline `resetContent()` just cleared — are untouched, as is `ActiveProfileStore.current` inside the engine's actor-isolated critical section.

**Shared seam.** `QuickSwitchResolver` is view-free and carries no `#if os(...)`, so the test targets (which exclude `appletvos`) can see it. `PlaylistSwitcher` and `SettingsView+Playlists` now read their "which row is current" answer from it, and the tvOS rows were extracted into `TVSwitchRows` and composed back into both Settings panes rather than becoming a third variant.

**No new state.** No `@Model`, no container, nothing new mirrored to CloudKit, no migration. Profiles come from `ProfileManager.profiles` (never a `@Query<UserProfile>` — it lives in the other container); the current playlist resolves through the existing `[Playlist].active(for:)` fallback. The only new persisted value in the whole feature is the hint flag.

**Docs.** Four comments and `README.md` asserted that tvOS deliberately has no quick switcher ("it would disturb the immersive home's focus"). Left alone, that's how this gets deleted later as a regression — all five are updated.

## Testing

- [x] Acceptance criteria met
- [x] Builds clean — tvOS, iOS, macOS
- [x] Tests pass — **836/836** `LumeTests`
- [x] SwiftLint clean (`--strict`, 21 files); `check-translations.swift` → OK
- [x] Tests added — `QuickSwitchResolverTests` (resolver rows, current-row resolution, the empty/deleted-id fallback) plus `ProfileEngineTests` cases pinning the re-entrancy guard, the pre-switch catalog flush, exactly-one-reconcile, and `pendingProfileName` set-during/cleared-after. `makeProfileTestContainer()` was promoted into `TestHelpers` and two stale private copies in the CloudSync suites deleted.
- [x] UI verified on simulator — Apple TV 4K, tvOS 26.5

Verified by hand on the tvOS simulator: hint shows once and is non-focusable; Play/Pause opens *and* closes; left/right hops between the two `.focusSection()`s; the focused row's checkmark flips to black; a playlist switch applies, persists, and **does not** raise the sync cover; a profile switch applies and the per-profile projection is correct (the Favorites rail correctly disappears under the child profile); presses do not leak to the tab bar behind; Menu closes and hands focus back to the Home rail.

The Play/Pause conflict was measured, not reasoned about: inside the player, one press left two frames 3s apart **byte-identical** (paused), a second press made them differ (resumed), and no overlay appeared either time.

**Not verified on device:** the PIN gate — `requiresPIN(toSwitchTo:)` needs a PIN set *and* a child active, which the test fixture didn't have. It routes through the existing `pinPrompt(target:onVerified:)` flow with no new gate logic (same as `ProfileMenu.attemptSwitch(to:using:)`), so it's covered by reuse rather than by test.

`LumeTests` needs `-parallel-testing-enabled NO` on this machine — the default cloned-simulator run hits a host SIGTRAP that marks ~770 tests as crashed at 0.000s. Pre-existing infrastructure, unrelated to this diff (836/836 sequentially on both iOS 26.4 and 26.5).

## Platforms

- [x] iOS / iPadOS — builds and behaves unchanged; only the shared seam touches it
- [x] tvOS — the feature
- [x] macOS — builds and behaves unchanged
- [ ] visionOS — **not built**: no visionOS runtime installed on this machine (`xcodebuild` exit 70 on every destination spec). Forcing `-sdk xrsimulator26.5` fails at link time inside LumeEngine (missing `x86_64` / `sws_*` slices in the FFmpeg xcframework) — pre-existing and unrelated to this diff. All new code is behind `#if os(tvOS)` except the seam, which visionOS compiles through the iOS paths.

## Related

Localization: 7 new keys, all 9 locales at `state:"translated"`, hand-spliced and hook-normalized — nothing left to translate.