### PR TITLE
fix(trakt): import watched shows that have no local episodes yet

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -1016,6 +1016,64 @@
         }
       }
     },
+    "%lld show%@ will be marked the first time you open them." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld Serien werden beim ersten Öffnen markiert."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld show%2$@ will be marked the first time you open them."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld serie%2$@ se marcarán la primera vez que las abras."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld série%2$@ seront marquées à la première ouverture."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld serie verranno contrassegnate alla prima apertura."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld件の番組は、最初に開いたときにマークされます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld개 시리즈는 처음 열 때 표시됩니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld série%2$@ serão marcadas na primeira vez que as abrir."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld 部剧集将在首次打开时标记。"
+          }
+        }
+      }
+    },
     "%lld subtitle downloads left today." : {
       "localizations" : {
         "de" : {

--- a/Lume/Services/Network/Trakt/TraktClient.swift
+++ b/Lume/Services/Network/Trakt/TraktClient.swift
@@ -39,10 +39,15 @@ nonisolated struct TraktClient {
 
     private let baseURL = "https://api.trakt.tv"
 
-    /// Requested page size for paginated collections. Trakt's documented maximum;
-    /// endpoints that cap lower (watched shows with `extended=progress`) simply
-    /// return fewer items and a larger page count.
+    /// Requested page size for paginated collections. Trakt's documented maximum.
     private static let pageSize = 250
+
+    /// Page size for `extended=progress`, which Trakt caps at 100 because it
+    /// carries the season/episode progress. Asking for more doesn't just return
+    /// fewer items: `X-Pagination-Page-Count` is computed against the *applied*
+    /// limit, so a mismatched request risks a page walk that ends early and
+    /// silently imports a fraction of the history. Request what will be applied.
+    private static let progressPageSize = 100
 
     /// Hard stop on the page walk so a server that keeps reporting more pages
     /// can't spin the import forever.
@@ -188,6 +193,7 @@ nonisolated struct TraktClient {
         try await allPages(
             "/sync/watched/shows",
             query: [URLQueryItem(name: "extended", value: "progress")],
+            pageSize: Self.progressPageSize,
             accessToken: accessToken
         )
     }
@@ -207,6 +213,7 @@ nonisolated struct TraktClient {
     private func allPages<T: Decodable>(
         _ path: String,
         query: [URLQueryItem] = [],
+        pageSize: Int = TraktClient.pageSize,
         accessToken: String
     ) async throws -> [T] {
         var items: [T] = []
@@ -216,12 +223,14 @@ nonisolated struct TraktClient {
         while page <= pageCount, page <= Self.pageWalkLimit {
             let pageQuery = query + [
                 URLQueryItem(name: "page", value: String(page)),
-                URLQueryItem(name: "limit", value: String(Self.pageSize))
+                URLQueryItem(name: "limit", value: String(pageSize))
             ]
             var request = try makeRequest(path: path, method: "GET", query: pageQuery, accessToken: accessToken)
             request.setValue("application/json", forHTTPHeaderField: "Accept")
             let (batch, response): ([T], HTTPURLResponse) = try await send(request)
-            if batch.isEmpty { break }
+            if batch.isEmpty {
+                break
+            }
             items += batch
 
             if let header = response.value(forHTTPHeaderField: "X-Pagination-Page-Count"),
@@ -274,7 +283,9 @@ nonisolated struct TraktClient {
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw TraktError.invalidResponse }
         guard (200 ... 299).contains(http.statusCode) else {
-            if http.statusCode == 401 { throw TraktError.notAuthenticated }
+            if http.statusCode == 401 {
+                throw TraktError.notAuthenticated
+            }
             throw TraktError.server(http.statusCode)
         }
 
@@ -389,8 +400,12 @@ struct TraktSyncItems: Encodable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        if !movies.isEmpty { try container.encode(movies, forKey: .movies) }
-        if !shows.isEmpty { try container.encode(shows, forKey: .shows) }
+        if !movies.isEmpty {
+            try container.encode(movies, forKey: .movies)
+        }
+        if !shows.isEmpty {
+            try container.encode(shows, forKey: .shows)
+        }
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Lume/Services/Network/Trakt/TraktPendingWatched.swift
+++ b/Lume/Services/Network/Trakt/TraktPendingWatched.swift
@@ -1,0 +1,128 @@
+//
+//  TraktPendingWatched.swift
+//  Lume
+//
+//  Holds the watched episodes a Trakt import could not apply yet.
+//
+//  Xtream and Stalker only expose episodes through a per-series
+//  `get_series_info` call that the series detail screen makes on first open, so
+//  a show the user has never opened has a `Series` row and no `Episode` rows.
+//  Fetching them all at import time would mean one request per watched show —
+//  roughly 250 KB each, so tens of megabytes and minutes of waiting for a
+//  hundred shows — to populate episodes nobody is looking at yet.
+//
+//  Instead the import parks that state here, keyed by the show's TMDB id, and
+//  `Series.insertEpisodes` applies it when the detail screen materializes the
+//  episodes anyway. Zero extra provider requests; the ticks are simply in place
+//  the first time the user opens the series.
+//
+//  Derived state, not user data: it is rebuilt by the next import, excluded from
+//  backup, and an entry is pruned once it has been applied.
+//
+
+import Foundation
+import OSLog
+
+/// The watched episodes of one show, as `season × episode → last watched`.
+/// Dates are epoch seconds so the on-disk form stays compact — a hundred shows
+/// of a long-running series is ~120 KB rather than ~1 MB of ISO-8601 strings.
+nonisolated struct TraktPendingShow: Codable, Equatable {
+    /// Keys are `"<season>x<episode>"`; values are epoch seconds, or nil when
+    /// Trakt reported no timestamp for that episode.
+    var episodes: [String: Int?]
+
+    static func key(season: Int, episode: Int) -> String {
+        "\(season)x\(episode)"
+    }
+}
+
+/// The parked watched state, keyed by the show's TMDB id (as a string, so the
+/// whole thing is a plain JSON object).
+nonisolated struct TraktPendingWatched: Codable, Equatable {
+    var shows: [String: TraktPendingShow] = [:]
+
+    static let empty = TraktPendingWatched()
+
+    var isEmpty: Bool {
+        shows.isEmpty
+    }
+
+    subscript(tmdbID: Int) -> TraktPendingShow? {
+        get { shows[String(tmdbID)] }
+        set { shows[String(tmdbID)] = newValue }
+    }
+}
+
+/// Reads and writes ``TraktPendingWatched`` on disk, caching it in memory so the
+/// per-series lookup in `insertEpisodes` costs nothing after the first hit.
+enum TraktPendingWatchedStore {
+    private nonisolated(unsafe) static var cached: TraktPendingWatched?
+    private static let lock = NSLock()
+
+    /// Where the parked state lives. Excluded from backup — the next import
+    /// rebuilds it from Trakt.
+    static var fileURL: URL? {
+        guard let support = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask
+        ).first else { return nil }
+        return support.appendingPathComponent("TraktPendingWatched.json")
+    }
+
+    static func load() -> TraktPendingWatched {
+        lock.withLock {
+            if let cached {
+                return cached
+            }
+            guard let url = fileURL, let data = try? Data(contentsOf: url),
+                  let decoded = try? JSONDecoder().decode(TraktPendingWatched.self, from: data)
+            else {
+                cached = .empty
+                return .empty
+            }
+            cached = decoded
+            return decoded
+        }
+    }
+
+    static func save(_ state: TraktPendingWatched) {
+        lock.withLock {
+            cached = state
+            guard let url = fileURL else { return }
+            // Nothing left to apply — drop the file rather than leaving an empty
+            // object behind.
+            guard !state.isEmpty else {
+                try? FileManager.default.removeItem(at: url)
+                return
+            }
+            do {
+                try JSONEncoder().encode(state).write(to: url, options: .atomic)
+                var resourceValues = URLResourceValues()
+                resourceValues.isExcludedFromBackup = true
+                var mutable = url
+                try? mutable.setResourceValues(resourceValues)
+            } catch {
+                let reason = error.localizedDescription
+                Logger.database.error("Trakt pending watched save failed: \(reason, privacy: .public)")
+            }
+        }
+    }
+
+    /// Removes one show's parked state, after its episodes have been marked.
+    static func clear(tmdbID: Int) {
+        var state = load()
+        guard state[tmdbID] != nil else { return }
+        state[tmdbID] = nil
+        save(state)
+    }
+
+    /// Drops everything — used when disconnecting the Trakt account, so a
+    /// stale import can't keep marking episodes for a signed-out user.
+    static func clearAll() {
+        save(.empty)
+    }
+
+    /// Test seam: forgets the in-memory copy so the next `load()` re-reads disk.
+    static func resetCacheForTesting() {
+        lock.withLock { cached = nil }
+    }
+}

--- a/Lume/Services/Network/Trakt/TraktService.swift
+++ b/Lume/Services/Network/Trakt/TraktService.swift
@@ -167,10 +167,13 @@ final class TraktService {
             try? await client.revokeToken(accessToken)
         }
         TraktTokenStore.clear()
+        // Parked watched state belongs to the account that was just signed out.
+        TraktPendingWatchedStore.clearAll()
         tokens = nil
         username = nil
         pendingCode = nil
         isConnecting = false
+        lastImport = nil
     }
 
     // MARK: - Watched sync (fire-and-forget)
@@ -241,32 +244,9 @@ final class TraktService {
         do {
             let movies = try await client.watchedMovies(accessToken: accessToken)
             let shows = try await client.watchedShows(accessToken: accessToken)
-            lastImport = await TraktWatchedImporter.apply(
-                movies: movies,
-                shows: shows,
-                in: context,
-                hydrate: episodeHydrator(for: context)
-            )
+            lastImport = TraktWatchedImporter.apply(movies: movies, shows: shows, in: context)
         } catch {
             lastImport = .failure
-        }
-    }
-
-    /// Pulls a series' episodes from its provider, mirroring what the series
-    /// detail screen does on first open. Xtream and Stalker only expose episodes
-    /// through a per-series call, so a show the user has never opened has no
-    /// local episodes for the import to mark. Returns nothing for m3u, whose
-    /// episodes already arrive with the catalog sync.
-    private func episodeHydrator(for context: ModelContext) -> (Series) async -> [ParsedEpisode] {
-        let playlists = (try? context.fetch(FetchDescriptor<Playlist>())) ?? []
-        let manager = ContentSyncManager(modelContainer: context.container)
-        return { series in
-            guard let playlist = playlists.first(where: { series.id.hasPrefix($0.id.uuidString) }) else { return [] }
-            return await (try? manager.fetchEpisodes(
-                seriesId: series.seriesId,
-                seriesElementId: series.id,
-                playlist: playlist
-            )) ?? []
         }
     }
 

--- a/Lume/Services/Network/Trakt/TraktService.swift
+++ b/Lume/Services/Network/Trakt/TraktService.swift
@@ -107,7 +107,9 @@ final class TraktService {
 
             while !Task.isCancelled, Date() < deadline {
                 try await Task.sleep(for: .seconds(interval))
-                if Task.isCancelled { return }
+                if Task.isCancelled {
+                    return
+                }
 
                 do {
                     let response = try await client.pollForToken(deviceCode: code.deviceCode)
@@ -239,9 +241,32 @@ final class TraktService {
         do {
             let movies = try await client.watchedMovies(accessToken: accessToken)
             let shows = try await client.watchedShows(accessToken: accessToken)
-            lastImport = TraktWatchedImporter.apply(movies: movies, shows: shows, in: context)
+            lastImport = await TraktWatchedImporter.apply(
+                movies: movies,
+                shows: shows,
+                in: context,
+                hydrate: episodeHydrator(for: context)
+            )
         } catch {
             lastImport = .failure
+        }
+    }
+
+    /// Pulls a series' episodes from its provider, mirroring what the series
+    /// detail screen does on first open. Xtream and Stalker only expose episodes
+    /// through a per-series call, so a show the user has never opened has no
+    /// local episodes for the import to mark. Returns nothing for m3u, whose
+    /// episodes already arrive with the catalog sync.
+    private func episodeHydrator(for context: ModelContext) -> (Series) async -> [ParsedEpisode] {
+        let playlists = (try? context.fetch(FetchDescriptor<Playlist>())) ?? []
+        let manager = ContentSyncManager(modelContainer: context.container)
+        return { series in
+            guard let playlist = playlists.first(where: { series.id.hasPrefix($0.id.uuidString) }) else { return [] }
+            return await (try? manager.fetchEpisodes(
+                seriesId: series.seriesId,
+                seriesElementId: series.id,
+                playlist: playlist
+            )) ?? []
         }
     }
 
@@ -251,9 +276,13 @@ final class TraktService {
     /// concurrent refreshes into a single request.
     private func validAccessToken() async -> String? {
         guard let current = tokens else { return nil }
-        if !current.needsRefresh { return current.accessToken }
+        if !current.needsRefresh {
+            return current.accessToken
+        }
 
-        if let refreshTask { return await refreshTask.value }
+        if let refreshTask {
+            return await refreshTask.value
+        }
 
         let task = Task { [weak self] () -> String? in
             guard let self else { return nil }

--- a/Lume/Services/Network/Trakt/TraktWatchedImporter.swift
+++ b/Lume/Services/Network/Trakt/TraktWatchedImporter.swift
@@ -14,9 +14,12 @@
 //
 //  Series need one extra step. Xtream and Stalker episodes are fetched lazily by
 //  the series detail screen, so a show the user has never opened has a `Series`
-//  row but no `Episode` rows — nothing for the import to mark. The importer
-//  therefore hydrates those series through `hydrate` before matching, which is
-//  the same `ContentSyncManager.fetchEpisodes` call the detail screen makes.
+//  row but no `Episode` rows — nothing for the import to mark. Rather than pull
+//  every watched show's episodes here (one ~250 KB provider request each), the
+//  import parks that state in `TraktPendingWatchedStore` and
+//  `Series.insertEpisodes` applies it when the detail screen fetches the
+//  episodes anyway. The series' `lastWatchedDate` is stamped immediately either
+//  way, so Home's Recently Watched row is right the moment the import finishes.
 //
 
 import Foundation
@@ -26,38 +29,47 @@ import SwiftData
 struct TraktImportSummary: Equatable {
     var moviesMarked = 0
     var episodesMarked = 0
+    /// Shows whose watched episodes were parked because the catalog has no
+    /// episodes for them yet. They are applied on first open of the series.
+    var showsQueued = 0
     var failed = false
 
     static let failure = TraktImportSummary(failed: true)
 
     var markedNothing: Bool {
-        !failed && moviesMarked == 0 && episodesMarked == 0
+        !failed && moviesMarked == 0 && episodesMarked == 0 && showsQueued == 0
     }
 }
 
 enum TraktWatchedImporter {
     /// Marks the local movies and episodes that Trakt reports as watched, writing
     /// through the given catalog context. Returns what changed.
-    /// - Parameter hydrate: Fetches a series' episodes from its provider when the
-    ///   catalog has none yet. Defaults to "no episodes available", which keeps
-    ///   the importer a pure function over the context for tests.
     static func apply(
         movies: [TraktWatchedMovie],
         shows: [TraktWatchedShow],
-        in context: ModelContext,
-        hydrate: (Series) async -> [ParsedEpisode] = { _ in [] }
-    ) async -> TraktImportSummary {
+        in context: ModelContext
+    ) -> TraktImportSummary {
         let moviesMarked = importMovies(movies, in: context)
-        let episodesMarked = await importShows(shows, in: context, hydrate: hydrate)
+        let shows = importShows(shows, in: context)
 
         if context.hasChanges {
             do {
                 try context.save()
             } catch {
-                return TraktImportSummary(moviesMarked: moviesMarked, episodesMarked: episodesMarked, failed: true)
+                return TraktImportSummary(
+                    moviesMarked: moviesMarked,
+                    episodesMarked: shows.marked,
+                    showsQueued: shows.queued,
+                    failed: true
+                )
             }
         }
-        return TraktImportSummary(moviesMarked: moviesMarked, episodesMarked: episodesMarked, failed: false)
+        return TraktImportSummary(
+            moviesMarked: moviesMarked,
+            episodesMarked: shows.marked,
+            showsQueued: shows.queued,
+            failed: false
+        )
     }
 
     // MARK: - Movies
@@ -92,80 +104,140 @@ enum TraktWatchedImporter {
 
     // MARK: - Shows
 
-    private struct SeasonEpisode: Hashable {
+    struct SeasonEpisode: Hashable {
         let season: Int
         let episode: Int
     }
 
     private static func importShows(
         _ watched: [TraktWatchedShow],
-        in context: ModelContext,
-        hydrate: (Series) async -> [ParsedEpisode]
-    ) async -> Int {
+        in context: ModelContext
+    ) -> (marked: Int, queued: Int) {
         var showsByTMDB: [Int: TraktWatchedShow] = [:]
         for show in watched {
             // A show Trakt reports without any season progress has nothing to
-            // mark, and skipping it here keeps the hydration below to the series
-            // that can actually gain something.
+            // apply, now or later.
             guard let tmdb = show.show.ids.tmdb, !show.seasons.isEmpty else { continue }
             showsByTMDB[tmdb] = show
         }
-        guard !showsByTMDB.isEmpty else { return 0 }
+        guard !showsByTMDB.isEmpty else { return (0, 0) }
 
         let descriptor = FetchDescriptor<Series>(predicate: #Predicate { $0.tmdbId != nil })
         let candidates = (try? context.fetch(descriptor)) ?? []
 
-        var count = 0
+        var pending = TraktPendingWatchedStore.load()
+        var pendingChanged = false
+        var marked = 0
+        var queued = 0
+
         for series in candidates {
             guard let tmdb = series.tmdbId, let show = showsByTMDB[tmdb] else { continue }
-            // Sequential on purpose: providers cap concurrent connections, and a
-            // burst of `get_series_info` calls is what starves the rest of the app.
+            let progress = Progress(show: show)
+
+            // Home's Recently Watched row queries this column, and playback
+            // stamps it too (`WatchProgressWriter`). Set it whether or not the
+            // episodes exist yet, so an imported show surfaces right away.
+            if let newest = progress.newest, newest > (series.lastWatchedDate ?? .distantPast) {
+                series.lastWatchedDate = newest
+            }
+
             if series.episodes.isEmpty {
-                let parsed = await hydrate(series)
-                if !parsed.isEmpty {
-                    series.insertEpisodes(parsed, into: context)
+                // Nothing to mark yet. Park it for `Series.insertEpisodes`, which
+                // runs when the detail screen fetches the episodes anyway.
+                pending[tmdb] = progress.parked
+                pendingChanged = true
+                queued += 1
+            } else {
+                marked += markEpisodes(of: series, using: progress)
+                // Episodes are present, so anything parked by an earlier import
+                // has just been superseded.
+                if pending[tmdb] != nil {
+                    pending[tmdb] = nil
+                    pendingChanged = true
                 }
             }
-            count += markEpisodes(of: series, against: show)
         }
-        return count
+
+        if pendingChanged {
+            TraktPendingWatchedStore.save(pending)
+        }
+        return (marked, queued)
     }
 
-    /// Marks the episodes of `series` that `show` reports as watched, returning
-    /// how many changed.
-    private static func markEpisodes(of series: Series, against show: TraktWatchedShow) -> Int {
-        var watchedKeys = Set<SeasonEpisode>()
-        var dates: [SeasonEpisode: Date] = [:]
-        for season in show.seasons {
-            for episode in season.episodes {
-                let key = SeasonEpisode(season: season.number, episode: episode.number)
-                watchedKeys.insert(key)
-                if let date = parse(episode.lastWatchedAt) {
+    // MARK: - Trakt-side progress
+
+    /// One show's watched episodes, in both the form the marking loop wants and
+    /// the form that gets parked on disk.
+    struct Progress {
+        var dates: [SeasonEpisode: Date?] = [:]
+        var newest: Date?
+
+        init(show: TraktWatchedShow) {
+            for season in show.seasons {
+                for episode in season.episodes {
+                    let key = SeasonEpisode(season: season.number, episode: episode.number)
+                    let date = parse(episode.lastWatchedAt)
                     dates[key] = date
+                    if let date, date > (newest ?? .distantPast) {
+                        newest = date
+                    }
                 }
             }
         }
 
-        var count = 0
-        var newest: Date?
-        for episode in series.episodes where !episode.isWatched {
-            let key = SeasonEpisode(season: episode.seasonNum, episode: episode.episodeNum)
-            guard watchedKeys.contains(key) else { continue }
-            episode.isWatched = true
-            episode.watchProgress = Double(episode.durationSecs ?? 0)
-            if let date = dates[key] {
-                episode.lastWatchedDate = date
-                if date > (newest ?? .distantPast) {
+        init(parked: TraktPendingShow) {
+            for (key, seconds) in parked.episodes {
+                let parts = key.split(separator: "x")
+                guard parts.count == 2, let season = Int(parts[0]), let episode = Int(parts[1]) else { continue }
+                let date = seconds.map { Date(timeIntervalSince1970: TimeInterval($0)) }
+                dates[SeasonEpisode(season: season, episode: episode)] = date
+                if let date, date > (newest ?? .distantPast) {
                     newest = date
                 }
             }
-            count += 1
         }
-        // Playback stamps the parent series too (`WatchProgressWriter`), and
-        // Home's Recently Watched row queries that column — without it an
-        // imported show marks its episodes but never surfaces anywhere.
-        if let newest, newest > (series.lastWatchedDate ?? .distantPast) {
+
+        var parked: TraktPendingShow {
+            var episodes: [String: Int?] = [:]
+            for (key, date) in dates {
+                episodes[TraktPendingShow.key(season: key.season, episode: key.episode)] =
+                    date.map { Int($0.timeIntervalSince1970) }
+            }
+            return TraktPendingShow(episodes: episodes)
+        }
+    }
+
+    /// Applies parked Trakt progress to episodes that have just been fetched from
+    /// the provider, and drops the entry once it has been used. Called from
+    /// `Series.insertEpisodes`, the single place episodes ever materialize.
+    @discardableResult
+    static func applyPending(to series: Series) -> Int {
+        guard let tmdb = series.tmdbId, !series.episodes.isEmpty else { return 0 }
+        let pending = TraktPendingWatchedStore.load()
+        guard let parked = pending[tmdb] else { return 0 }
+
+        let progress = Progress(parked: parked)
+        let marked = markEpisodes(of: series, using: progress)
+        if let newest = progress.newest, newest > (series.lastWatchedDate ?? .distantPast) {
             series.lastWatchedDate = newest
+        }
+        TraktPendingWatchedStore.clear(tmdbID: tmdb)
+        return marked
+    }
+
+    /// Marks the episodes of `series` that Trakt reports watched, returning how
+    /// many changed.
+    private static func markEpisodes(of series: Series, using progress: Progress) -> Int {
+        var count = 0
+        for episode in series.episodes where !episode.isWatched {
+            let key = SeasonEpisode(season: episode.seasonNum, episode: episode.episodeNum)
+            guard let date = progress.dates[key] else { continue }
+            episode.isWatched = true
+            episode.watchProgress = Double(episode.durationSecs ?? 0)
+            if let date {
+                episode.lastWatchedDate = date
+            }
+            count += 1
         }
         return count
     }

--- a/Lume/Services/Network/Trakt/TraktWatchedImporter.swift
+++ b/Lume/Services/Network/Trakt/TraktWatchedImporter.swift
@@ -12,6 +12,12 @@
 //  untouched so the import is idempotent and the returned counts reflect only
 //  what actually changed.
 //
+//  Series need one extra step. Xtream and Stalker episodes are fetched lazily by
+//  the series detail screen, so a show the user has never opened has a `Series`
+//  row but no `Episode` rows — nothing for the import to mark. The importer
+//  therefore hydrates those series through `hydrate` before matching, which is
+//  the same `ContentSyncManager.fetchEpisodes` call the detail screen makes.
+//
 
 import Foundation
 import SwiftData
@@ -32,13 +38,17 @@ struct TraktImportSummary: Equatable {
 enum TraktWatchedImporter {
     /// Marks the local movies and episodes that Trakt reports as watched, writing
     /// through the given catalog context. Returns what changed.
+    /// - Parameter hydrate: Fetches a series' episodes from its provider when the
+    ///   catalog has none yet. Defaults to "no episodes available", which keeps
+    ///   the importer a pure function over the context for tests.
     static func apply(
         movies: [TraktWatchedMovie],
         shows: [TraktWatchedShow],
-        in context: ModelContext
-    ) -> TraktImportSummary {
+        in context: ModelContext,
+        hydrate: (Series) async -> [ParsedEpisode] = { _ in [] }
+    ) async -> TraktImportSummary {
         let moviesMarked = importMovies(movies, in: context)
-        let episodesMarked = importShows(shows, in: context)
+        let episodesMarked = await importShows(shows, in: context, hydrate: hydrate)
 
         if context.hasChanges {
             do {
@@ -58,7 +68,9 @@ enum TraktWatchedImporter {
         for item in watched {
             guard let tmdb = item.movie.ids.tmdb else { continue }
             watchedIDs.insert(tmdb)
-            if let date = parse(item.lastWatchedAt) { dates[tmdb] = date }
+            if let date = parse(item.lastWatchedAt) {
+                dates[tmdb] = date
+            }
         }
         guard !watchedIDs.isEmpty else { return 0 }
 
@@ -70,7 +82,9 @@ enum TraktWatchedImporter {
             guard let tmdb = movie.tmdbId, watchedIDs.contains(tmdb) else { continue }
             movie.isWatched = true
             movie.watchProgress = Double(movie.durationSecs ?? 0)
-            if let date = dates[tmdb] { movie.lastWatchedDate = date }
+            if let date = dates[tmdb] {
+                movie.lastWatchedDate = date
+            }
             count += 1
         }
         return count
@@ -83,10 +97,17 @@ enum TraktWatchedImporter {
         let episode: Int
     }
 
-    private static func importShows(_ watched: [TraktWatchedShow], in context: ModelContext) -> Int {
+    private static func importShows(
+        _ watched: [TraktWatchedShow],
+        in context: ModelContext,
+        hydrate: (Series) async -> [ParsedEpisode]
+    ) async -> Int {
         var showsByTMDB: [Int: TraktWatchedShow] = [:]
         for show in watched {
-            guard let tmdb = show.show.ids.tmdb else { continue }
+            // A show Trakt reports without any season progress has nothing to
+            // mark, and skipping it here keeps the hydration below to the series
+            // that can actually gain something.
+            guard let tmdb = show.show.ids.tmdb, !show.seasons.isEmpty else { continue }
             showsByTMDB[tmdb] = show
         }
         guard !showsByTMDB.isEmpty else { return 0 }
@@ -97,6 +118,14 @@ enum TraktWatchedImporter {
         var count = 0
         for series in candidates {
             guard let tmdb = series.tmdbId, let show = showsByTMDB[tmdb] else { continue }
+            // Sequential on purpose: providers cap concurrent connections, and a
+            // burst of `get_series_info` calls is what starves the rest of the app.
+            if series.episodes.isEmpty {
+                let parsed = await hydrate(series)
+                if !parsed.isEmpty {
+                    series.insertEpisodes(parsed, into: context)
+                }
+            }
             count += markEpisodes(of: series, against: show)
         }
         return count
@@ -111,18 +140,32 @@ enum TraktWatchedImporter {
             for episode in season.episodes {
                 let key = SeasonEpisode(season: season.number, episode: episode.number)
                 watchedKeys.insert(key)
-                if let date = parse(episode.lastWatchedAt) { dates[key] = date }
+                if let date = parse(episode.lastWatchedAt) {
+                    dates[key] = date
+                }
             }
         }
 
         var count = 0
+        var newest: Date?
         for episode in series.episodes where !episode.isWatched {
             let key = SeasonEpisode(season: episode.seasonNum, episode: episode.episodeNum)
             guard watchedKeys.contains(key) else { continue }
             episode.isWatched = true
             episode.watchProgress = Double(episode.durationSecs ?? 0)
-            if let date = dates[key] { episode.lastWatchedDate = date }
+            if let date = dates[key] {
+                episode.lastWatchedDate = date
+                if date > (newest ?? .distantPast) {
+                    newest = date
+                }
+            }
             count += 1
+        }
+        // Playback stamps the parent series too (`WatchProgressWriter`), and
+        // Home's Recently Watched row queries that column — without it an
+        // imported show marks its episodes but never surfaces anywhere.
+        if let newest, newest > (series.lastWatchedDate ?? .distantPast) {
+            series.lastWatchedDate = newest
         }
         return count
     }

--- a/Lume/Services/Sync/ContentSyncManager.swift
+++ b/Lume/Services/Sync/ContentSyncManager.swift
@@ -56,6 +56,10 @@ extension Series {
             context.insert(episode)
             episodes.append(episode)
         }
+        // A Trakt import can only mark episodes that exist, so anything it
+        // parked for this series is applied here — the one place episodes ever
+        // materialize for Xtream and Stalker.
+        TraktWatchedImporter.applyPending(to: self)
         try? context.save()
     }
 }

--- a/Lume/Views/Settings/TVTraktIntegrationView.swift
+++ b/Lume/Views/Settings/TVTraktIntegrationView.swift
@@ -157,19 +157,22 @@
             }
         }
 
-        @ViewBuilder
         private func importStatus(_ summary: TraktImportSummary) -> some View {
-            let text = if summary.failed {
-                Text("Couldn't import from Trakt. Please try again.")
-            } else if summary.markedNothing {
-                Text("Your watched history is already up to date.")
-            } else {
-                Text("Imported \(summary.moviesMarked) movie\(summary.moviesMarked == 1 ? "" : "s") and \(summary.episodesMarked) episode\(summary.episodesMarked == 1 ? "" : "s").")
+            VStack(alignment: .leading, spacing: 4) {
+                if summary.failed {
+                    Text("Couldn't import from Trakt. Please try again.")
+                } else if summary.markedNothing {
+                    Text("Your watched history is already up to date.")
+                } else {
+                    Text("Imported \(summary.moviesMarked) movie\(summary.moviesMarked == 1 ? "" : "s") and \(summary.episodesMarked) episode\(summary.episodesMarked == 1 ? "" : "s").")
+                    if summary.showsQueued > 0 {
+                        Text("\(summary.showsQueued) show\(summary.showsQueued == 1 ? "" : "s") will be marked the first time you open them.")
+                    }
+                }
             }
-            text
-                .font(.system(size: 22))
-                .foregroundStyle(summary.failed ? .red : .green)
-                .padding(.horizontal, TVSettingsMetrics.rowHPadding)
+            .font(.system(size: 22))
+            .foregroundStyle(summary.failed ? .red : .green)
+            .padding(.horizontal, TVSettingsMetrics.rowHPadding)
         }
     }
 

--- a/Lume/Views/Settings/TraktIntegrationView.swift
+++ b/Lume/Views/Settings/TraktIntegrationView.swift
@@ -34,7 +34,9 @@
             .paywall(isPresented: $showPaywall, highlight: .trakt)
             .onDisappear {
                 // Stop polling if the user backs out mid-connect.
-                if !trakt.isConnected { trakt.cancelConnect() }
+                if !trakt.isConnected {
+                    trakt.cancelConnect()
+                }
             }
         }
 
@@ -167,8 +169,13 @@
                 Text("Your watched history is already up to date.")
                     .foregroundStyle(.green)
             } else {
-                Text("Imported \(summary.moviesMarked) movie\(summary.moviesMarked == 1 ? "" : "s") and \(summary.episodesMarked) episode\(summary.episodesMarked == 1 ? "" : "s").")
-                    .foregroundStyle(.green)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Imported \(summary.moviesMarked) movie\(summary.moviesMarked == 1 ? "" : "s") and \(summary.episodesMarked) episode\(summary.episodesMarked == 1 ? "" : "s").")
+                    if summary.showsQueued > 0 {
+                        Text("\(summary.showsQueued) show\(summary.showsQueued == 1 ? "" : "s") will be marked the first time you open them.")
+                    }
+                }
+                .foregroundStyle(.green)
             }
         }
     }

--- a/LumeTests/Services/TraktClientPagingTests.swift
+++ b/LumeTests/Services/TraktClientPagingTests.swift
@@ -125,8 +125,12 @@ struct TraktClientPagingTests {
 
         #expect(shows.count == 1)
         #expect(shows.first?.seasons.first?.episodes.first?.number == 1)
-        // Without `extended=progress` Trakt returns no season progress at all.
-        #expect(TraktStubProtocol.requestedQueries(host: "api.trakt.tv").first?["extended"] == "progress")
+        // Without `extended=progress` Trakt returns no season progress at all,
+        // and that mode is capped at 100 items per page — asking for 250 would
+        // make the reported page count disagree with the applied limit.
+        let query = TraktStubProtocol.requestedQueries(host: "api.trakt.tv").first
+        #expect(query?["extended"] == "progress")
+        #expect(query?["limit"] == "100")
     }
 
     @Test func `a show without seasons decodes as no progress`() async throws {

--- a/LumeTests/Services/TraktWatchedImporterTests.swift
+++ b/LumeTests/Services/TraktWatchedImporterTests.swift
@@ -4,9 +4,39 @@ import SwiftData
 import Testing
 
 @MainActor
+@Suite(.serialized)
 struct TraktWatchedImporterTests {
+    init() {
+        // The parked-progress store is a file plus an in-memory cache; every test
+        // starts from empty so they can't leak into one another.
+        TraktPendingWatchedStore.clearAll()
+        TraktPendingWatchedStore.resetCacheForTesting()
+    }
+
     private func makeContext() throws -> ModelContext {
         try ModelContext(makeTestContainer())
+    }
+
+    private let watchedDate = ISO8601DateFormatter().date(from: "2014-10-11T17:00:54Z")
+
+    /// A Trakt show reporting season 1 episode 2 as watched.
+    private func showProgress() -> TraktWatchedShow {
+        TraktWatchedShow(
+            show: TraktWatchedMedia(ids: TraktIDs(tmdb: 300, trakt: nil)),
+            seasons: [TraktWatchedSeason(
+                number: 1,
+                episodes: [TraktWatchedEpisode(number: 2, lastWatchedAt: "2014-10-11T17:00:54.000Z")]
+            )]
+        )
+    }
+
+    private func parsedEpisode(_ number: Int) -> ParsedEpisode {
+        ParsedEpisode(
+            id: "s1-\(number)", episodeId: "\(number)", title: "E\(number)",
+            containerExtension: "mkv", seasonNum: 1, episodeNum: number,
+            added: nil, directSource: nil, durationSecs: 1200,
+            movieImage: nil, rating: nil, airDate: nil, plot: nil
+        )
     }
 
     private func makeMovie(id: String, tmdbId: Int?, duration: Int? = 7200) -> Movie {
@@ -20,14 +50,14 @@ struct TraktWatchedImporterTests {
         TraktWatchedMovie(movie: TraktWatchedMedia(ids: TraktIDs(tmdb: tmdb, trakt: nil)), lastWatchedAt: lastWatchedAt)
     }
 
-    @Test func `marks matching movies watched and leaves the rest untouched`() async throws {
+    @Test func `marks matching movies watched and leaves the rest untouched`() throws {
         let context = try makeContext()
         let match = makeMovie(id: "a", tmdbId: 100)
         let other = makeMovie(id: "b", tmdbId: 200)
         context.insert(match)
         context.insert(other)
 
-        let summary = await TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
+        let summary = TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
 
         #expect(summary.moviesMarked == 1)
         #expect(match.isWatched == true)
@@ -35,12 +65,12 @@ struct TraktWatchedImporterTests {
         #expect(other.isWatched == false)
     }
 
-    @Test func `applies the trakt last-watched date when present`() async throws {
+    @Test func `applies the trakt last-watched date when present`() throws {
         let context = try makeContext()
         let movie = makeMovie(id: "a", tmdbId: 100)
         context.insert(movie)
 
-        let summary = await TraktWatchedImporter.apply(
+        let summary = TraktWatchedImporter.apply(
             movies: [watchedMovie(tmdb: 100, lastWatchedAt: "2014-10-11T17:00:54.000Z")],
             shows: [],
             in: context
@@ -51,19 +81,19 @@ struct TraktWatchedImporterTests {
         #expect(movie.lastWatchedDate == expected)
     }
 
-    @Test func `already-watched movies are not re-counted`() async throws {
+    @Test func `already-watched movies are not re-counted`() throws {
         let context = try makeContext()
         let movie = makeMovie(id: "a", tmdbId: 100)
         movie.isWatched = true
         context.insert(movie)
 
-        let summary = await TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
+        let summary = TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
 
         #expect(summary.moviesMarked == 0)
         #expect(summary.markedNothing == true)
     }
 
-    @Test func `marks only the episodes trakt reports watched`() async throws {
+    @Test func `marks only the episodes trakt reports watched`() throws {
         let context = try makeContext()
         let series = Series(id: "s1", seriesId: 1, name: "Show")
         series.tmdbId = 300
@@ -79,7 +109,7 @@ struct TraktWatchedImporterTests {
             show: TraktWatchedMedia(ids: TraktIDs(tmdb: 300, trakt: nil)),
             seasons: [TraktWatchedSeason(number: 1, episodes: [TraktWatchedEpisode(number: 1, lastWatchedAt: nil)])]
         )
-        let summary = await TraktWatchedImporter.apply(movies: [], shows: [show], in: context)
+        let summary = TraktWatchedImporter.apply(movies: [], shows: [show], in: context)
 
         #expect(summary.episodesMarked == 1)
         #expect(ep1.isWatched == true)
@@ -87,45 +117,64 @@ struct TraktWatchedImporterTests {
         #expect(ep2.isWatched == false)
     }
 
-    @Test func `a series with no local episodes is hydrated from its provider`() async throws {
+    @Test func `a series with no local episodes parks its progress for later`() throws {
         let context = try makeContext()
         // Xtream and Stalker series arrive with no episodes until the detail
-        // screen fetches them — the state the import used to silently skip.
+        // screen fetches them. Pulling them here would cost one ~250 KB provider
+        // request per watched show, so the import parks the progress instead.
         let series = Series(id: "s1", seriesId: 1, name: "Show")
         series.tmdbId = 300
         context.insert(series)
 
-        let show = TraktWatchedShow(
-            show: TraktWatchedMedia(ids: TraktIDs(tmdb: 300, trakt: nil)),
-            seasons: [TraktWatchedSeason(number: 1, episodes: [TraktWatchedEpisode(number: 2, lastWatchedAt: nil)])]
-        )
-        let summary = await TraktWatchedImporter.apply(movies: [], shows: [show], in: context) { _ in
-            [1, 2].map { number in
-                ParsedEpisode(
-                    id: "s1-\(number)",
-                    episodeId: "\(number)",
-                    title: "E\(number)",
-                    containerExtension: "mkv",
-                    seasonNum: 1,
-                    episodeNum: number,
-                    added: nil,
-                    directSource: nil,
-                    durationSecs: 1200,
-                    movieImage: nil,
-                    rating: nil,
-                    airDate: nil,
-                    plot: nil
-                )
-            }
-        }
+        let summary = TraktWatchedImporter.apply(movies: [], shows: [showProgress()], in: context)
 
-        #expect(summary.episodesMarked == 1)
-        #expect(series.episodes.count == 2)
-        #expect(series.episodes.first { $0.episodeNum == 2 }?.isWatched == true)
-        #expect(series.episodes.first { $0.episodeNum == 1 }?.isWatched == false)
+        #expect(summary.episodesMarked == 0)
+        #expect(summary.showsQueued == 1)
+        #expect(summary.markedNothing == false)
+        // Home's Recently Watched row works straight away, without the episodes.
+        #expect(series.lastWatchedDate == watchedDate)
+        #expect(TraktPendingWatchedStore.load()[300]?.episodes["1x2"] != nil)
     }
 
-    @Test func `an imported show stamps the series last-watched date`() async throws {
+    @Test func `parked progress is applied when the episodes arrive`() throws {
+        let context = try makeContext()
+        let series = Series(id: "s1", seriesId: 1, name: "Show")
+        series.tmdbId = 300
+        context.insert(series)
+        _ = TraktWatchedImporter.apply(movies: [], shows: [showProgress()], in: context)
+
+        // What the detail screen does on first open.
+        series.insertEpisodes([parsedEpisode(1), parsedEpisode(2)], into: context)
+
+        #expect(series.episodes.first { $0.episodeNum == 2 }?.isWatched == true)
+        #expect(series.episodes.first { $0.episodeNum == 2 }?.watchProgress == 1200)
+        #expect(series.episodes.first { $0.episodeNum == 1 }?.isWatched == false)
+        // The entry is consumed, so a later fetch can't re-apply it.
+        #expect(TraktPendingWatchedStore.load()[300] == nil)
+    }
+
+    @Test func `a series that already has episodes is marked without parking`() throws {
+        let context = try makeContext()
+        let series = Series(id: "s1", seriesId: 1, name: "Show")
+        series.tmdbId = 300
+        for number in 1 ... 2 {
+            let episode = Episode(
+                id: "s1-\(number)", episodeId: "\(number)", title: "E\(number)",
+                containerExtension: "mkv", seasonNum: 1, episodeNum: number
+            )
+            episode.series = series
+            series.episodes.append(episode)
+        }
+        context.insert(series)
+
+        let summary = TraktWatchedImporter.apply(movies: [], shows: [showProgress()], in: context)
+
+        #expect(summary.episodesMarked == 1)
+        #expect(summary.showsQueued == 0)
+        #expect(TraktPendingWatchedStore.load()[300] == nil)
+    }
+
+    @Test func `an imported show stamps the series last-watched date`() throws {
         let context = try makeContext()
         let series = Series(id: "s1", seriesId: 1, name: "Show")
         series.tmdbId = 300
@@ -141,19 +190,19 @@ struct TraktWatchedImporterTests {
                 episodes: [TraktWatchedEpisode(number: 1, lastWatchedAt: "2014-10-11T17:00:54.000Z")]
             )]
         )
-        let summary = await TraktWatchedImporter.apply(movies: [], shows: [show], in: context)
+        let summary = TraktWatchedImporter.apply(movies: [], shows: [show], in: context)
 
         #expect(summary.episodesMarked == 1)
         // Home's Recently Watched row queries `Series.lastWatchedDate`.
         #expect(series.lastWatchedDate == ISO8601DateFormatter().date(from: "2014-10-11T17:00:54Z"))
     }
 
-    @Test func `titles without a tmdb id are skipped`() async throws {
+    @Test func `titles without a tmdb id are skipped`() throws {
         let context = try makeContext()
         let movie = makeMovie(id: "a", tmdbId: nil)
         context.insert(movie)
 
-        let summary = await TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
+        let summary = TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
 
         #expect(summary.moviesMarked == 0)
         #expect(movie.isWatched == false)

--- a/LumeTests/Services/TraktWatchedImporterTests.swift
+++ b/LumeTests/Services/TraktWatchedImporterTests.swift
@@ -20,14 +20,14 @@ struct TraktWatchedImporterTests {
         TraktWatchedMovie(movie: TraktWatchedMedia(ids: TraktIDs(tmdb: tmdb, trakt: nil)), lastWatchedAt: lastWatchedAt)
     }
 
-    @Test func `marks matching movies watched and leaves the rest untouched`() throws {
+    @Test func `marks matching movies watched and leaves the rest untouched`() async throws {
         let context = try makeContext()
         let match = makeMovie(id: "a", tmdbId: 100)
         let other = makeMovie(id: "b", tmdbId: 200)
         context.insert(match)
         context.insert(other)
 
-        let summary = TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
+        let summary = await TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
 
         #expect(summary.moviesMarked == 1)
         #expect(match.isWatched == true)
@@ -35,12 +35,12 @@ struct TraktWatchedImporterTests {
         #expect(other.isWatched == false)
     }
 
-    @Test func `applies the trakt last-watched date when present`() throws {
+    @Test func `applies the trakt last-watched date when present`() async throws {
         let context = try makeContext()
         let movie = makeMovie(id: "a", tmdbId: 100)
         context.insert(movie)
 
-        let summary = TraktWatchedImporter.apply(
+        let summary = await TraktWatchedImporter.apply(
             movies: [watchedMovie(tmdb: 100, lastWatchedAt: "2014-10-11T17:00:54.000Z")],
             shows: [],
             in: context
@@ -51,19 +51,19 @@ struct TraktWatchedImporterTests {
         #expect(movie.lastWatchedDate == expected)
     }
 
-    @Test func `already-watched movies are not re-counted`() throws {
+    @Test func `already-watched movies are not re-counted`() async throws {
         let context = try makeContext()
         let movie = makeMovie(id: "a", tmdbId: 100)
         movie.isWatched = true
         context.insert(movie)
 
-        let summary = TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
+        let summary = await TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
 
         #expect(summary.moviesMarked == 0)
         #expect(summary.markedNothing == true)
     }
 
-    @Test func `marks only the episodes trakt reports watched`() throws {
+    @Test func `marks only the episodes trakt reports watched`() async throws {
         let context = try makeContext()
         let series = Series(id: "s1", seriesId: 1, name: "Show")
         series.tmdbId = 300
@@ -79,7 +79,7 @@ struct TraktWatchedImporterTests {
             show: TraktWatchedMedia(ids: TraktIDs(tmdb: 300, trakt: nil)),
             seasons: [TraktWatchedSeason(number: 1, episodes: [TraktWatchedEpisode(number: 1, lastWatchedAt: nil)])]
         )
-        let summary = TraktWatchedImporter.apply(movies: [], shows: [show], in: context)
+        let summary = await TraktWatchedImporter.apply(movies: [], shows: [show], in: context)
 
         #expect(summary.episodesMarked == 1)
         #expect(ep1.isWatched == true)
@@ -87,12 +87,73 @@ struct TraktWatchedImporterTests {
         #expect(ep2.isWatched == false)
     }
 
-    @Test func `titles without a tmdb id are skipped`() throws {
+    @Test func `a series with no local episodes is hydrated from its provider`() async throws {
+        let context = try makeContext()
+        // Xtream and Stalker series arrive with no episodes until the detail
+        // screen fetches them — the state the import used to silently skip.
+        let series = Series(id: "s1", seriesId: 1, name: "Show")
+        series.tmdbId = 300
+        context.insert(series)
+
+        let show = TraktWatchedShow(
+            show: TraktWatchedMedia(ids: TraktIDs(tmdb: 300, trakt: nil)),
+            seasons: [TraktWatchedSeason(number: 1, episodes: [TraktWatchedEpisode(number: 2, lastWatchedAt: nil)])]
+        )
+        let summary = await TraktWatchedImporter.apply(movies: [], shows: [show], in: context) { _ in
+            [1, 2].map { number in
+                ParsedEpisode(
+                    id: "s1-\(number)",
+                    episodeId: "\(number)",
+                    title: "E\(number)",
+                    containerExtension: "mkv",
+                    seasonNum: 1,
+                    episodeNum: number,
+                    added: nil,
+                    directSource: nil,
+                    durationSecs: 1200,
+                    movieImage: nil,
+                    rating: nil,
+                    airDate: nil,
+                    plot: nil
+                )
+            }
+        }
+
+        #expect(summary.episodesMarked == 1)
+        #expect(series.episodes.count == 2)
+        #expect(series.episodes.first { $0.episodeNum == 2 }?.isWatched == true)
+        #expect(series.episodes.first { $0.episodeNum == 1 }?.isWatched == false)
+    }
+
+    @Test func `an imported show stamps the series last-watched date`() async throws {
+        let context = try makeContext()
+        let series = Series(id: "s1", seriesId: 1, name: "Show")
+        series.tmdbId = 300
+        let episode = Episode(id: "s1-1", episodeId: "1", title: "E1", containerExtension: "mkv", seasonNum: 1, episodeNum: 1)
+        episode.series = series
+        series.episodes = [episode]
+        context.insert(series)
+
+        let show = TraktWatchedShow(
+            show: TraktWatchedMedia(ids: TraktIDs(tmdb: 300, trakt: nil)),
+            seasons: [TraktWatchedSeason(
+                number: 1,
+                episodes: [TraktWatchedEpisode(number: 1, lastWatchedAt: "2014-10-11T17:00:54.000Z")]
+            )]
+        )
+        let summary = await TraktWatchedImporter.apply(movies: [], shows: [show], in: context)
+
+        #expect(summary.episodesMarked == 1)
+        // Home's Recently Watched row queries `Series.lastWatchedDate`.
+        #expect(series.lastWatchedDate == ISO8601DateFormatter().date(from: "2014-10-11T17:00:54Z"))
+    }
+
+    @Test func `titles without a tmdb id are skipped`() async throws {
         let context = try makeContext()
         let movie = makeMovie(id: "a", tmdbId: nil)
         context.insert(movie)
 
-        let summary = TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
+        let summary = await TraktWatchedImporter.apply(movies: [watchedMovie(tmdb: 100)], shows: [], in: context)
 
         #expect(summary.moviesMarked == 0)
         #expect(movie.isWatched == false)


### PR DESCRIPTION
Follow-up to #182. That PR fixed the Trakt pagination and the `extended=progress` change, but shows still didn't import.

### Root cause

`TraktWatchedImporter` matched series by TMDB id and then walked `series.episodes`. Xtream and Stalker only expose episodes through a per-series `get_series_info` call that `SeriesDetailView` makes on first open — so a show the user has never opened has a `Series` row and **no `Episode` rows**. The import found its match and marked nothing.

Movies were unaffected because the whole movie catalog is synced up front, which is exactly why only shows looked broken. (m3u playlists were fine too — their episodes arrive with the catalog sync.)

The existing test passed because it pre-populated `series.episodes`, i.e. it asserted a state the real app never reaches for Xtream/Stalker.

### Approach: apply deferred, don't fetch

Fetching the missing episodes at import time would cost one provider request per watched show. Measured against this repo's own `ExampleData/SeriesInfo.json`, that's **~250 KB and 62 episodes per call** — roughly **100 requests, 25 MB, and 1–3 minutes** behind a settings spinner for a user with 100 watched shows, to materialize episodes nobody is looking at yet.

Almost none of those episodes are needed at import time:

- Home's *Recently Watched* row only reads `Series.lastWatchedDate`, which Trakt's own payload provides.
- Episode ticks only matter on the series detail screen — which **already fetches the episodes itself** on open.

So the import parks the watched map and applies it when the episodes materialize anyway:

| | before | after |
|---|---|---|
| Extra provider requests | ~1 per watched show | **0** |
| Import wall-clock | +1–3 min | unchanged |
| Recently Watched row | broken | correct immediately |
| Episode ticks | after a long import | on first open of the series |

### Changes

- **`TraktPendingWatchedStore`** (new): parks `TMDB id → season×episode → epoch seconds`. ~120 KB for 100 shows, in Application Support, excluded from backup, cached in memory so the per-series lookup is free. Cleared on disconnect.
- **`Series.insertEpisodes`** — the single place episodes ever materialize for Xtream/Stalker — applies the parked state and prunes the entry.
- **Stamp `Series.lastWatchedDate`** during the import, whether or not episodes exist. Playback does this via `WatchProgressWriter` and Home queries that column, so previously an imported show marked its episodes but surfaced nowhere.
- Series that already have episodes (m3u, or previously opened) are marked inline as before.
- **`TraktImportSummary.showsQueued`** so Settings says what's waiting instead of reporting "0 episodes". Localized across all nine languages.
- **`limit=100` for the `extended=progress` walk.** Trakt [caps that mode at 100](https://github.com/trakt/trakt-api/discussions/775) and computes `X-Pagination-Page-Count` against the *applied* limit, so asking for 250 risked a walk that ended early and imported a fraction of the history.

### Testing

- `xcodebuild test -only-testing:LumeTests` → **829/829 pass**, including new cases for parking, deferred apply on `insertEpisodes`, and the inline path.
- Builds clean on iOS, tvOS and macOS. SwiftFormat + SwiftLint clean.

### Not verified

I couldn't run this against a live Trakt account. The `extended=progress` behavior comes from Trakt's API-change discussion; the exact episode-object fields in that mode aren't documented there, so if the response carries a `completed` flag with unwatched episodes included, the importer would over-mark. Worth one real import to confirm.