### PR TITLE
fix(series): refresh cached episodes when the playlist syncs past them

### DIFF
--- a/Lume/Models/Series.swift
+++ b/Lume/Models/Series.swift
@@ -85,6 +85,17 @@ final class Series {
     var categoryId: String?
     @Relationship(deleteRule: .cascade) var episodes: [Episode] = []
 
+    // MARK: Episode cache (Xtream / Stalker — lazy-fetched on the detail screen)
+
+    /// When this series' episode list was last pulled from the provider; nil
+    /// means never. Playlist sync doesn't touch episodes for the lazy pipelines,
+    /// so without a stamp a device that already cached a season would never see
+    /// a newly added episode. See `episodesAreStale(lastSyncedAt:)`.
+    var episodesFetchedAt: Date?
+    /// The provider's `lastModified` at the time of that fetch, so a bumped
+    /// value invalidates the cache immediately.
+    var episodesFetchedLastModified: String?
+
     var isFavorite: Bool = false
     /// A user-defined order for the unified Favorites collection, spanning movies,
     /// series and live channels. `nil` means "follow the default order"; once the
@@ -167,5 +178,24 @@ extension Series {
     var recommendationVote: RecommendationVote? {
         get { RecommendationVote(rawValue: recommendationVoteRaw) }
         set { recommendationVoteRaw = newValue?.rawValue ?? 0 }
+    }
+
+    /// Whether the lazily-fetched episode list should be pulled again.
+    ///
+    /// Xtream and Stalker episodes are fetched per-series on the detail screen
+    /// and are never swept by playlist sync, so a cached season would otherwise
+    /// stick forever — an episode the provider added shows up on whichever
+    /// device happened to open the series afterwards and stays missing on the
+    /// others. Sync is what reopens the question: a `lastModified` the provider
+    /// bumped is the exact signal, and a playlist that has synced since the
+    /// fetch covers portals that don't maintain the field.
+    ///
+    /// - Parameter lastSyncedAt: the owning playlist's `lastSyncDate`, stamped
+    ///   only when a sync finishes successfully.
+    func episodesAreStale(lastSyncedAt: Date?) -> Bool {
+        guard let episodesFetchedAt else { return true }
+        if episodesFetchedLastModified != lastModified { return true }
+        guard let lastSyncedAt else { return false }
+        return lastSyncedAt > episodesFetchedAt
     }
 }

--- a/Lume/Services/Sync/ContentSyncManager.swift
+++ b/Lume/Services/Sync/ContentSyncManager.swift
@@ -35,6 +35,12 @@ extension Series {
     /// de-duping against any already present (Episode.id is unique). Mutating the
     /// `episodes` relationship directly updates any observing SwiftUI view, so the
     /// caller must run this on the same context the view renders from.
+    ///
+    /// Additive on purpose: a refresh merges in episodes the provider has added
+    /// since the last fetch and never deletes, so a provider hiccup (a short or
+    /// empty `get_series_info` response) can't wipe rows that carry watch
+    /// progress. Call only after a *successful* fetch — it stamps the episode
+    /// cache, which suppresses further refreshes until it goes stale again.
     func insertEpisodes(_ parsed: [ParsedEpisode], into context: ModelContext) {
         let existingIds = Set(episodes.map(\.id))
         for parsed in parsed where !existingIds.contains(parsed.id) {
@@ -56,6 +62,8 @@ extension Series {
             context.insert(episode)
             episodes.append(episode)
         }
+        episodesFetchedAt = Date()
+        episodesFetchedLastModified = lastModified
         try? context.save()
     }
 }

--- a/Lume/Views/Series/SeriesDetailView.swift
+++ b/Lume/Views/Series/SeriesDetailView.swift
@@ -90,6 +90,10 @@ struct SeriesDetailView: View {
                         isLoadingTMDB = false
                     }
                 }
+                // Separate task so a stale-cache refresh runs alongside the
+                // enrichment chain above instead of delaying the first paint,
+                // and still gets cancelled when the screen goes away.
+                .task(id: series.id) { await refreshEpisodesIfStale() }
                 .onChange(of: series.similarTMDBIds) { resolveSimilar() }
                 .onChange(of: refreshToken) { resolveSimilar() }
                 .onChange(of: series.episodes.count) { recomputeSeasons() }
@@ -428,16 +432,35 @@ struct SeriesDetailView: View {
         selectedSeason = determineDefaultSeason()
     }
 
+    /// Re-pulls a cached episode list once the playlist has synced past it. The
+    /// cached episodes stay on screen while it runs and new ones merge in, so
+    /// this is silent unless something actually changed. The empty case is the
+    /// blocking `loadEpisodesIfNeeded` path's job.
+    ///
+    /// m3u is skipped: it imports and prunes episodes alongside the rest of the
+    /// catalog on every sync, so there is nothing to pull per-series there.
+    private func refreshEpisodesIfStale() async {
+        guard !series.episodes.isEmpty,
+              let playlist = seriesPlaylist,
+              playlist.sourceType != .m3u,
+              series.episodesAreStale(lastSyncedAt: playlist.lastSyncDate)
+        else { return }
+        await loadEpisodes()
+    }
+
     private func loadEpisodes() async {
         guard let playlist = seriesPlaylist, !isLoadingEpisodes else { return }
         isLoadingEpisodes = true
         defer { isLoadingEpisodes = false }
         let manager = ContentSyncManager(modelContainer: modelContext.container)
-        let parsed = await (try? manager.fetchEpisodes(
+        // A failed fetch must not reach `insertEpisodes`: it stamps the episode
+        // cache, which would call the list fresh until the staleness window
+        // reopens — the exact thing keeping a device an episode behind.
+        guard let parsed = try? await manager.fetchEpisodes(
             seriesId: series.seriesId,
             seriesElementId: series.id,
             playlist: playlist
-        )) ?? []
+        ) else { return }
         // Insert through the view's own context, attaching to `series`, so its
         // episodes relationship — and this view — update synchronously.
         await MainActor.run { series.insertEpisodes(parsed, into: modelContext) }

--- a/Lume/Views/TV/TVSeriesDetailView.swift
+++ b/Lume/Views/TV/TVSeriesDetailView.swift
@@ -87,6 +87,10 @@
                 // by the focus engine while the button is disabled).
                 focus = .play
             }
+            // Separate task so a stale-cache refresh runs alongside the
+            // enrichment chain above instead of delaying the first paint, and
+            // still gets cancelled when the screen goes away.
+            .task(id: series.id) { await refreshEpisodesIfStale() }
             .onChange(of: series.similarTMDBIds) { resolveSimilar() }
             .onChange(of: refreshToken) { resolveSimilar() }
         }
@@ -409,22 +413,46 @@
             selectedSeason = determineDefaultSeason()
         }
 
-        private func loadEpisodes() async {
+        /// Re-pulls a cached episode list once the playlist has synced past it. The
+        /// cached episodes stay on screen while it runs and new ones merge in, so
+        /// this is silent unless something actually changed. The empty case is the
+        /// blocking `loadEpisodesIfNeeded` path's job.
+        ///
+        /// m3u is skipped: it imports and prunes episodes alongside the rest of the
+        /// catalog on every sync, so there is nothing to pull per-series there.
+        private func refreshEpisodesIfStale() async {
+            guard !series.episodes.isEmpty,
+                  let playlist = seriesPlaylist,
+                  playlist.sourceType != .m3u,
+                  series.episodesAreStale(lastSyncedAt: playlist.lastSyncDate)
+            else { return }
+            await loadEpisodes(resetsSeason: false)
+        }
+
+        /// - Parameter resetsSeason: whether to re-pick the season to open on.
+        ///   False for a background refresh, which must not yank the selector
+        ///   out from under someone browsing a season.
+        private func loadEpisodes(resetsSeason: Bool = true) async {
             guard let playlist = seriesPlaylist, !isLoadingEpisodes else { return }
             isLoadingEpisodes = true
             defer { isLoadingEpisodes = false }
             let manager = ContentSyncManager(modelContainer: modelContext.container)
-            let parsed = await (try? manager.fetchEpisodes(
+            // A failed fetch must not reach `insertEpisodes`: it stamps the episode
+            // cache, which would call the list fresh until the staleness window
+            // reopens — the exact thing keeping a device an episode behind.
+            guard let parsed = try? await manager.fetchEpisodes(
                 seriesId: series.seriesId,
                 seriesElementId: series.id,
                 playlist: playlist
-            )) ?? []
+            ) else { return }
             // Insert through the view's own context, attaching to `series`, so its
             // episodes relationship — and this view — update synchronously. Writing
             // through a background context left the relationship stale until a later
             // cross-context merge, so episodes only appeared after navigating back.
             await MainActor.run { series.insertEpisodes(parsed, into: modelContext) }
-            selectedSeason = determineDefaultSeason()
+            if resetsSeason {
+                selectedSeason = determineDefaultSeason()
+            }
         }
 
         private func enrichIfNeeded() async {

--- a/LumeTests/Models/SeriesEpisodeCacheTests.swift
+++ b/LumeTests/Models/SeriesEpisodeCacheTests.swift
@@ -1,0 +1,126 @@
+//
+//  SeriesEpisodeCacheTests.swift
+//  LumeTests
+//
+//  Covers the episode cache behind the series detail screens. Xtream and
+//  Stalker episodes are fetched lazily per series and are never swept by
+//  playlist sync, so a cached season used to stick forever — a device that had
+//  opened a show before the provider added an episode kept showing the short
+//  list no matter how often the playlist synced. Sync is now what reopens the
+//  question: a bumped `lastModified`, or a playlist that synced past the fetch.
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+@MainActor
+struct SeriesEpisodeCacheTests {
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([Series.self, Episode.self])
+        // `cloudKitDatabase: .none`: the catalog uses `@Attribute(.unique)`,
+        // which CloudKit forbids and fails the load on a signed test host.
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true, cloudKitDatabase: .none)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    private func parsed(season: Int, number: Int) -> ParsedEpisode {
+        ParsedEpisode(
+            id: "s\(season)e\(number)",
+            episodeId: "\(season)-\(number)",
+            title: "S\(season)E\(number)",
+            containerExtension: "mkv",
+            seasonNum: season,
+            episodeNum: number,
+            added: nil,
+            directSource: nil,
+            durationSecs: nil,
+            movieImage: nil,
+            rating: nil,
+            airDate: nil,
+            plot: nil
+        )
+    }
+
+    @Test func `a series that never fetched episodes is stale`() {
+        let series = Series(id: "p-series-1", seriesId: 1, name: "Show")
+        #expect(series.episodesAreStale(lastSyncedAt: nil))
+    }
+
+    @Test func `a fresh fetch is not stale`() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+        let series = Series(id: "p-series-1", seriesId: 1, name: "Show", lastModified: "1700000000")
+        context.insert(series)
+
+        series.insertEpisodes([parsed(season: 1, number: 1)], into: context)
+
+        #expect(series.episodesFetchedAt != nil)
+        // A sync that ran before the fetch settles nothing new.
+        #expect(!series.episodesAreStale(lastSyncedAt: Date().addingTimeInterval(-60)))
+    }
+
+    @Test func `a bumped provider lastModified invalidates the cache`() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+        let series = Series(id: "p-series-1", seriesId: 1, name: "Show", lastModified: "1700000000")
+        context.insert(series)
+        series.insertEpisodes([parsed(season: 1, number: 1)], into: context)
+
+        // What a sync does when the provider adds an episode.
+        series.lastModified = "1700009999"
+
+        #expect(series.episodesAreStale(lastSyncedAt: nil))
+    }
+
+    @Test func `a sync since the fetch invalidates the cache`() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+        // Portals that don't maintain `last_modified` leave it nil forever, so
+        // the playlist's own sync date is the only signal left.
+        let series = Series(id: "p-series-1", seriesId: 1, name: "Show")
+        context.insert(series)
+        series.insertEpisodes([parsed(season: 1, number: 1)], into: context)
+
+        #expect(series.episodesAreStale(lastSyncedAt: Date().addingTimeInterval(60)))
+    }
+
+    @Test func `a never-synced playlist leaves a fetched list alone`() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+        let series = Series(id: "p-series-1", seriesId: 1, name: "Show")
+        context.insert(series)
+        series.insertEpisodes([parsed(season: 1, number: 1)], into: context)
+
+        #expect(!series.episodesAreStale(lastSyncedAt: nil))
+    }
+
+    @Test func `a refresh merges in the newly added episode`() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+        let series = Series(id: "p-series-1", seriesId: 1, name: "Show")
+        context.insert(series)
+        series.insertEpisodes([1, 2, 3, 4].map { parsed(season: 1, number: $0) }, into: context)
+
+        // The refresh re-fetches the whole season, now five episodes long.
+        series.insertEpisodes([1, 2, 3, 4, 5].map { parsed(season: 1, number: $0) }, into: context)
+
+        #expect(series.episodes.count == 5)
+        #expect(series.episodes.count(where: { $0.episodeNum == 5 }) == 1)
+    }
+
+    @Test func `a short provider response never drops cached episodes`() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+        let series = Series(id: "p-series-1", seriesId: 1, name: "Show")
+        context.insert(series)
+        series.insertEpisodes([1, 2, 3, 4, 5].map { parsed(season: 1, number: $0) }, into: context)
+
+        // A hiccuping portal answering with a truncated season must not take
+        // watched episodes with it — the merge is additive on purpose.
+        series.insertEpisodes([parsed(season: 1, number: 1)], into: context)
+
+        #expect(series.episodes.count == 5)
+    }
+}


### PR DESCRIPTION
## The bug

Same show, two devices: 5 episodes on iPhone, 4 on Apple TV — and syncing the playlist on the Apple TV changed nothing.

Xtream and Stalker episodes are pulled per-series on the detail screen and are never touched by playlist sync (`ContentSyncManager+Prune.swift` says so outright: *"the Xtream pipeline pulls episodes lazily per-series and so isn't swept here"*). Both detail screens gated that fetch on `series.episodes.isEmpty`, so **the first visit decided the list forever**:

- open a show *before* the provider adds an episode → that device is stuck at 4
- open it *after* → that device sees 5
- the only `Retry` lives inside the empty-state placeholder, so once a list is non-empty there is no way to refresh it short of deleting and re-adding the playlist

m3u never had this bug — it imports episodes alongside the rest of the catalog on every sync and prunes stale ones.

## The fix

Stamp the fetch on `Series`, and let **sync** decide when it's worth pulling again:

```swift
var episodesFetchedAt: Date?
var episodesFetchedLastModified: String?

func episodesAreStale(lastSyncedAt: Date?) -> Bool
```

Two signals, both owned by sync:

1. **`lastModified` changed** — the exact signal. Every sync refreshes it (`ContentSyncManager+Helpers.swift:168` for Xtream, `+Stalker.swift:342`) and providers bump it when a series gains an episode.
2. **The playlist synced past the fetch** — `lastSyncDate` is newer than `episodesFetchedAt`. Covers portals that don't maintain `last_modified` at all.

No timer and no manual refresh control: episodes refresh when the catalog does, and a series whose playlist has never synced is left alone.

Both detail screens get a second `.task(id: series.id) { await refreshEpisodesIfStale() }`. Running it separately from the enrichment chain keeps it off the first-paint path; cached episodes stay on screen while it runs and new ones merge in, so it's invisible unless something actually changed. m3u is skipped.

Two details that matter more than they look:

- **The merge stays additive.** A refresh never deletes, so a hiccuping portal answering with a truncated `get_series_info` can't take rows carrying watch progress with it.
- **`loadEpisodes` no longer collapses a thrown error into `[]`.** With the stamp in place, a failed fetch reaching `insertEpisodes` would have marked the cache fresh and suppressed retries until the next sync — the exact failure mode this PR exists to kill.

On tvOS, a background refresh no longer re-picks the season (`loadEpisodes(resetsSeason:)`), so it can't yank the selector out from under someone browsing one.

## Migration

Both new attributes are optional, so SwiftData's automatic lightweight migration covers them (this project has no `VersionedSchema`). Every existing series has `episodesFetchedAt == nil` → stale → the first open after updating refreshes it. That's what un-sticks an already-affected device.

## Verification

- Builds: iOS Simulator, tvOS Simulator, macOS — all succeed
- `LumeTests`: 911/911 pass (`-parallel-testing-enabled NO`), including 7 new `SeriesEpisodeCacheTests` covering both staleness signals, the never-synced case, the merge, and the truncated-response guard
- SwiftFormat + SwiftLint (strict) clean
- No user-facing strings added, so no String Catalog change

**Not verified:** no Xtream/Stalker credentials in the dev environment, so the refresh has not been watched against a live portal.

## Known gap (follow-up)

This refreshes when you open the series detail screen after a sync. A device that never opens a show still won't know about a new episode, so its Next Up / continue-watching rails stay behind. Folding a targeted episode refresh for in-progress series into playlist sync itself would close that; deliberately out of scope here.
