### PR TITLE
feat(ui): long-press a movie or series card to favorite it

### DIFF
--- a/Lume/Models/ContentOrganizing.swift
+++ b/Lume/Models/ContentOrganizing.swift
@@ -106,6 +106,16 @@ extension LiveStream: FavoriteOrderable {}
 extension Movie: FavoriteOrderable {}
 extension Series: FavoriteOrderable {}
 
+/// Favoritable content that also carries a watchlist stamp: movies and series.
+/// A `LiveStream` has no `addedToWatchlistDate`, which is the whole reason the
+/// VOD favorite semantic (`MediaFavorites`) is separate from the live one.
+protocol WatchlistFavoritable: FavoriteOrderable {
+    var addedToWatchlistDate: Date? { get set }
+}
+
+extension Movie: WatchlistFavoritable {}
+extension Series: WatchlistFavoritable {}
+
 extension ContentOrganizer {
     /// Applies a SwiftUI `.onMove` to an already-sorted favorites list and stamps
     /// a dense `favoriteOrder` so the arrangement persists. The list is

--- a/Lume/Services/Player/MediaFavorites.swift
+++ b/Lume/Services/Player/MediaFavorites.swift
@@ -1,0 +1,56 @@
+//
+//  MediaFavorites.swift
+//  Lume
+//
+//  The one VOD favorite semantic, shared by the card menus, the detail screens,
+//  the favorites manager and `PlayerFavorites`: a movie or series also stamps
+//  `addedToWatchlistDate`, unlike a live stream which toggles the flag alone
+//  (`LiveChannelFavorites`). An episode routes to its parent — episodes have no
+//  `isFavorite` of their own.
+//
+
+import Foundation
+import SwiftData
+
+/// Flips the favorite state of a movie or series.
+///
+/// A new favorite deliberately leaves `favoriteOrder` alone. Both surfaces that
+/// render favorites sort on `favoriteOrder ?? Int.max` (`HomeView.favoriteItems`
+/// and `FavoriteManagementView`), so an unstamped favorite already sorts *after*
+/// every hand-ordered one — stamping a next-highest slot here would instead put
+/// it ahead of the whole unordered block for anyone who never opened the
+/// favorites manager.
+enum MediaFavorites {
+    @discardableResult
+    static func toggle(_ model: some WatchlistFavoritable, in context: ModelContext) -> Bool {
+        let favorited = !model.isFavorite
+        if favorited {
+            model.isFavorite = true
+            model.addedToWatchlistDate = Date()
+        } else {
+            clearFavoriteState(model)
+        }
+        try? context.save()
+        return favorited
+    }
+
+    @discardableResult
+    static func toggle(_ episode: Episode, in context: ModelContext) -> Bool {
+        guard let series = episode.series else { return false }
+        return toggle(series, in: context)
+    }
+
+    /// The single unfavorite semantic, shared with `FavoriteManagementView`.
+    ///
+    /// All three fields have to go: `ContentStateValues.isEmpty` requires
+    /// `!isFavorite && addedToWatchlistDate == nil && favoriteOrder == nil`
+    /// before `CloudSyncEngine` deletes the iCloud mirror record — leave the
+    /// watchlist stamp behind and the record survives with `isFavorite == false`.
+    /// Saving is the caller's business, since the favorites manager mutates
+    /// under its own `@Query` context.
+    static func clearFavoriteState(_ model: any FavoriteOrderable) {
+        model.isFavorite = false
+        model.favoriteOrder = nil
+        (model as? any WatchlistFavoritable)?.addedToWatchlistDate = nil
+    }
+}

--- a/Lume/Services/Player/PlayerFavorites.swift
+++ b/Lume/Services/Player/PlayerFavorites.swift
@@ -7,9 +7,8 @@
 //  and the iOS / macOS KSPlayer and VLCKit overlays) so the favorite control
 //  sitting beside the audio / subtitle track menus behaves identically on
 //  every engine. Series are favorited via their parent (episodes have no
-//  `isFavorite` of their own); movies and series also stamp
-//  `addedToWatchlistDate`, live streams toggle the flag alone — mirroring the
-//  detail screens.
+//  `isFavorite` of their own). Movies and series share the one VOD favorite
+//  semantic in `MediaFavorites`; live streams toggle the flag alone.
 //
 
 import Foundation
@@ -34,19 +33,15 @@ enum PlayerFavorites {
     static func toggle(for ref: PlayableMedia.ContentRef, in context: ModelContext) -> Bool {
         switch ref {
         case let .episode(id):
-            guard let series = episode(id, in: context)?.series else { return false }
-            series.isFavorite.toggle()
-            series.addedToWatchlistDate = series.isFavorite ? Date() : nil
+            guard let resolved = episode(id, in: context) else { return false }
+            return MediaFavorites.toggle(resolved, in: context)
         case let .movie(id):
-            guard let movie = movie(id, in: context) else { return false }
-            movie.isFavorite.toggle()
-            movie.addedToWatchlistDate = movie.isFavorite ? Date() : nil
+            guard let resolved = movie(id, in: context) else { return false }
+            return MediaFavorites.toggle(resolved, in: context)
         case let .live(id):
             guard let stream = liveStream(id, in: context) else { return false }
-            stream.isFavorite.toggle()
+            return LiveChannelFavorites.toggle(stream, in: context)
         }
-        try? context.save()
-        return isFavorite(for: ref, in: context)
     }
 
     // MARK: - Resolution

--- a/Lume/Views/Components/CategoryContentGrid.swift
+++ b/Lume/Views/Components/CategoryContentGrid.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 // MARK: - Full Category Content Grid ("Show All")
 
-struct CategoryContentGrid<Item: Identifiable & Hashable, Card: View>: View {
+struct CategoryContentGrid<Item: Identifiable & Hashable & WatchlistFavoritable, Card: View>: View {
     let title: String
     let items: [Item]
     let animationNamespace: Namespace.ID?
@@ -26,6 +26,7 @@ struct CategoryContentGrid<Item: Identifiable & Hashable, Card: View>: View {
     /// Called when the last item appears, so a paginating caller can fetch the
     /// next page. Nil callers load their full set up front (unchanged behavior).
     var onLoadMore: (() -> Void)?
+    @Environment(\.modelContext) private var modelContext
     @ViewBuilder let card: (Item) -> Card
 
     private let columns = [GridItem(.adaptive(minimum: PosterCardMetrics.gridMinimum), spacing: PosterCardMetrics.gridSpacing)]
@@ -62,6 +63,10 @@ struct CategoryContentGrid<Item: Identifiable & Hashable, Card: View>: View {
                         .onAppear {
                             if let onLoadMore, item.id == items.last?.id { onLoadMore() }
                         }
+                        .mediaFavoriteMenu(
+                            isFavorite: { item.isFavorite },
+                            onToggleFavorite: { MediaFavorites.toggle(item, in: modelContext) }
+                        )
                     }
                 }
                 .padding()
@@ -193,7 +198,7 @@ enum CategoryTileMetrics {
 
 // MARK: - Category Preview Row
 
-struct CategoryPreviewRow<Item: Identifiable & Hashable, Card: View>: View {
+struct CategoryPreviewRow<Item: Identifiable & Hashable & WatchlistFavoritable, Card: View>: View {
     let category: Category
     let items: [Item]
     /// Whether the category holds more items than this preview shows. When false,
@@ -201,6 +206,7 @@ struct CategoryPreviewRow<Item: Identifiable & Hashable, Card: View>: View {
     let hasMore: Bool
     let animationNamespace: Namespace.ID?
     let emptyMessage: LocalizedStringKey
+    @Environment(\.modelContext) private var modelContext
     @ViewBuilder let card: (Item) -> Card
 
     var body: some View {
@@ -235,6 +241,10 @@ struct CategoryPreviewRow<Item: Identifiable & Hashable, Card: View>: View {
                                     .matchedTransitionSourceIfAvailable(id: item.id, in: animationNamespace)
                             }
                             .posterCardButtonStyle()
+                            .mediaFavoriteMenu(
+                                isFavorite: { item.isFavorite },
+                                onToggleFavorite: { MediaFavorites.toggle(item, in: modelContext) }
+                            )
                         }
                     }
                     .padding(.horizontal)
@@ -429,181 +439,6 @@ struct MovieCategoryPreview: View {
     }
 }
 
-// MARK: - Series Category View
-
-struct SeriesCategoryView: View {
-    let category: Category
-    var animationNamespace: Namespace.ID?
-    @Environment(\.modelContext) private var modelContext
-
-    @AppStorage(SortStorageKey.seriesContent) private var contentSortRaw: String = ContentSortOption.playlist.rawValue
-
-    @State private var series: [Series] = []
-    @State private var canLoadMore = true
-    @State private var isLoadingPage = false
-    /// True while a Stalker category's content is being fetched from the portal
-    /// on first open — drives the loading overlay.
-    @State private var isImporting = false
-    /// Sort the current pages were loaded for; reload only on change so a pop
-    /// back from a detail keeps the loaded pages and scroll position intact.
-    @State private var loadedSort: String?
-
-    /// A category in a large IPTV playlist can hold thousands of titles; fetch a
-    /// page at a time and load the next as the grid nears the end, rather than
-    /// hydrating the whole category into memory at once.
-    private let pageSize = 100
-
-    private var contentSort: ContentSortOption {
-        ContentSortOption(rawValue: contentSortRaw) ?? .playlist
-    }
-
-    /// The playlist when it's a Stalker portal, whose categories are imported
-    /// on demand rather than synced whole.
-    private var stalkerPlaylist: Playlist? {
-        guard let playlist = category.playlist, playlist.sourceType == .stalker else { return nil }
-        return playlist
-    }
-
-    var body: some View {
-        grid
-            .overlay {
-                if isImporting, series.isEmpty {
-                    ProgressView("Loading…")
-                }
-            }
-            .task(id: contentSortRaw) {
-                guard loadedSort != contentSortRaw else { return }
-                loadedSort = contentSortRaw
-                series = []
-                canLoadMore = true
-                await importStalkerContentIfNeeded()
-                loadNextPage()
-                await revalidateStalkerContentIfStale()
-            }
-    }
-
-    @ViewBuilder
-    private var grid: some View {
-        let base = CategoryContentGrid(
-            title: category.name,
-            items: series,
-            animationNamespace: animationNamespace,
-            emptyTitle: "No Series",
-            emptyIcon: "tv.fill",
-            emptyDescription: "This category has no series",
-            sortRaw: $contentSortRaw,
-            onLoadMore: { loadNextPage() },
-            card: { SeriesCardView(series: $0, fillsWidth: true) }
-        )
-        // Pull-to-refresh re-imports a Stalker category — see `MovieCategoryView`.
-        #if !os(tvOS)
-            if stalkerPlaylist != nil {
-                base.refreshable { await reimportStalkerContent() }
-            } else {
-                base
-            }
-        #else
-            base
-        #endif
-    }
-
-    private func loadNextPage() {
-        guard canLoadMore, !isLoadingPage else { return }
-        isLoadingPage = true
-        defer { isLoadingPage = false }
-        let categoryId = category.id
-        var descriptor = FetchDescriptor<Series>(
-            predicate: #Predicate { $0.categoryId == categoryId },
-            sortBy: contentSort.seriesDescriptors
-        )
-        descriptor.fetchOffset = series.count
-        descriptor.fetchLimit = pageSize
-        let page = (try? modelContext.fetch(descriptor)) ?? []
-        series.append(contentsOf: page)
-        if page.count < pageSize { canLoadMore = false }
-    }
-
-    /// Imports the category from the portal the first time it's opened (Stalker
-    /// only; other sources are already fully synced).
-    private func importStalkerContentIfNeeded() async {
-        guard let playlist = stalkerPlaylist, category.contentImportedAt == nil else { return }
-        await runStalkerImport(playlist: playlist)
-    }
-
-    /// Background revalidation of content older than `Category.stalkerContentTTL`
-    /// — see `MovieCategoryView.revalidateStalkerContentIfStale`.
-    private func revalidateStalkerContentIfStale() async {
-        guard let playlist = stalkerPlaylist,
-              category.contentImportedAt != nil, category.stalkerContentStale else { return }
-        await runStalkerImport(playlist: playlist)
-        reloadLoadedPages()
-    }
-
-    private func reimportStalkerContent() async {
-        guard let playlist = stalkerPlaylist else { return }
-        await runStalkerImport(playlist: playlist)
-        series = []
-        canLoadMore = true
-        loadNextPage()
-    }
-
-    /// Re-fetches the already-loaded window in place — see
-    /// `MovieCategoryView.reloadLoadedPages`.
-    private func reloadLoadedPages() {
-        let categoryId = category.id
-        var descriptor = FetchDescriptor<Series>(
-            predicate: #Predicate { $0.categoryId == categoryId },
-            sortBy: contentSort.seriesDescriptors
-        )
-        let window = max(series.count, pageSize)
-        descriptor.fetchLimit = window
-        let rows = (try? modelContext.fetch(descriptor)) ?? []
-        canLoadMore = rows.count == window
-        series = rows
-    }
-
-    private func runStalkerImport(playlist: Playlist) async {
-        isImporting = true
-        defer { isImporting = false }
-        let manager = ContentSyncManager(modelContainer: modelContext.container)
-        _ = try? await manager.importStalkerCategory(apiId: category.apiId, type: .series, playlist: playlist)
-    }
-}
-
-// MARK: - Series Category Preview
-
-struct SeriesCategoryPreview: View {
-    let category: Category
-    private let limit: Int
-    @Query private var series: [Series]
-    var animationNamespace: Namespace.ID?
-
-    init(category: Category, limit: Int, sort: ContentSortOption, animationNamespace: Namespace.ID? = nil) {
-        self.category = category
-        self.limit = limit
-        self.animationNamespace = animationNamespace
-        let categoryId = category.id
-        var descriptor = FetchDescriptor<Series>(
-            predicate: #Predicate<Series> { $0.categoryId == categoryId },
-            sortBy: sort.seriesDescriptors
-        )
-        // Fetch one extra so we can tell whether a full grid would show more.
-        descriptor.fetchLimit = limit + 1
-        _series = Query(descriptor)
-    }
-
-    var body: some View {
-        CategoryPreviewRow(
-            category: category,
-            items: Array(series.prefix(limit)),
-            hasMore: series.count > limit,
-            animationNamespace: animationNamespace,
-            emptyMessage: "No series in this category",
-            card: { SeriesCardView(series: $0) }
-        )
-    }
-}
-
 // MARK: - Previews
 
 #Preview("Movie Category Grid") {
@@ -621,25 +456,6 @@ struct SeriesCategoryPreview: View {
     let emptyCategory = Category(apiId: "999", name: "Empty Category", parentId: 0, type: .vod, playlist: PreviewData.samplePlaylist)
     return NavigationStack {
         MovieCategoryView(category: emptyCategory, animationNamespace: nil)
-    }
-    .modelContainer(container)
-}
-
-#Preview("Series Category Grid") {
-    let container = previewContainer()
-    let categories = (try? container.mainContext.fetch(FetchDescriptor<Category>())) ?? []
-    let category = categories.first { $0.typeRaw == "series" } ?? categories[0]
-    return NavigationStack {
-        SeriesCategoryView(category: category, animationNamespace: nil)
-    }
-    .modelContainer(container)
-}
-
-#Preview("Series Category Empty") {
-    let container = previewContainer()
-    let emptyCategory = Category(apiId: "998", name: "Empty Series", parentId: 0, type: .series, playlist: PreviewData.samplePlaylist)
-    return NavigationStack {
-        SeriesCategoryView(category: emptyCategory, animationNamespace: nil)
     }
     .modelContainer(container)
 }

--- a/Lume/Views/Components/LibraryCollectionRows.swift
+++ b/Lume/Views/Components/LibraryCollectionRows.swift
@@ -64,7 +64,7 @@ private let recentlyAddedFetchLimit = 200
 /// A titled horizontal rail with a trailing "Show All" link into the full
 /// collection grid. Mirrors `CategoryPreviewRow`, but its header is a plain
 /// title plus a `LibraryCollection` destination rather than a `Category`.
-private struct CollectionPreviewRow<Item: Identifiable & Hashable, Card: View>: View {
+private struct CollectionPreviewRow<Item: Identifiable & Hashable & WatchlistFavoritable, Card: View>: View {
     let title: LocalizedStringKey
     let collection: LibraryCollection
     let items: [Item]
@@ -76,6 +76,7 @@ private struct CollectionPreviewRow<Item: Identifiable & Hashable, Card: View>: 
     /// context menu (a long-press on the focused card on tvOS). Nil for rows
     /// where removal doesn't apply, e.g. Favorites.
     var removeAction: ((Item) -> Void)?
+    @Environment(\.modelContext) private var modelContext
     @ViewBuilder let card: (Item) -> Card
 
     var body: some View {
@@ -105,7 +106,11 @@ private struct CollectionPreviewRow<Item: Identifiable & Hashable, Card: View>: 
                                 .matchedTransitionSourceIfAvailable(id: item.id, in: animationNamespace)
                         }
                         .posterCardButtonStyle()
-                        .recentlyWatchedRemoveMenu(removeAction.map { action in { action(item) } })
+                        .mediaFavoriteMenu(
+                            isFavorite: { item.isFavorite },
+                            onToggleFavorite: { MediaFavorites.toggle(item, in: modelContext) },
+                            onRemoveFromRecents: removeAction.map { action in { action(item) } }
+                        )
                     }
                 }
                 .padding(.horizontal)
@@ -329,27 +334,6 @@ private enum SeriesCollectionQuery {
         }
         if kind == .recentlyAdded { descriptor.fetchLimit = recentlyAddedFetchLimit }
         return descriptor
-    }
-}
-
-// MARK: - Remove-from-recents menu
-
-extension View {
-    /// Attaches a destructive "Remove from Recently Watched" context menu when an
-    /// action is provided, otherwise leaves the view untouched. Surfaced by a
-    /// long-press on the focused card on tvOS (and on iOS), or a right-click on
-    /// macOS — the standard cross-platform secondary-action gesture.
-    @ViewBuilder
-    func recentlyWatchedRemoveMenu(_ remove: (() -> Void)?) -> some View {
-        if let remove {
-            contextMenu {
-                Button(role: .destructive, action: remove) {
-                    Label("Remove from Recently Watched", systemImage: "clock.badge.xmark")
-                }
-            }
-        } else {
-            self
-        }
     }
 }
 

--- a/Lume/Views/Components/MediaDetailComponents.swift
+++ b/Lume/Views/Components/MediaDetailComponents.swift
@@ -9,6 +9,7 @@
 //  SeriesDetailView compose these so the two screens stay visually identical.
 //
 
+import SwiftData
 import SwiftUI
 
 extension View {
@@ -351,26 +352,31 @@ struct SimilarRow: View {
     let items: [HomeMediaItem]
     var animationNamespace: Namespace.ID?
 
+    @Environment(\.modelContext) private var modelContext
+
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 16) {
                 ForEach(items) { item in
-                    switch item {
-                    case let .movie(movie):
-                        NavigationLink(value: movie) {
-                            DetailPosterCard(title: item.title, imageURL: item.imageURL)
-                                .matchedTransitionSourceIfAvailable(id: movie.id, in: animationNamespace)
+                    Group {
+                        switch item {
+                        case let .movie(movie):
+                            NavigationLink(value: movie) {
+                                DetailPosterCard(title: item.title, imageURL: item.imageURL)
+                                    .matchedTransitionSourceIfAvailable(id: movie.id, in: animationNamespace)
+                            }
+                            .buttonStyle(.plain)
+                        case let .series(series):
+                            NavigationLink(value: series) {
+                                DetailPosterCard(title: item.title, imageURL: item.imageURL)
+                                    .matchedTransitionSourceIfAvailable(id: series.id, in: animationNamespace)
+                            }
+                            .buttonStyle(.plain)
+                        case .live:
+                            EmptyView()
                         }
-                        .buttonStyle(.plain)
-                    case let .series(series):
-                        NavigationLink(value: series) {
-                            DetailPosterCard(title: item.title, imageURL: item.imageURL)
-                                .matchedTransitionSourceIfAvailable(id: series.id, in: animationNamespace)
-                        }
-                        .buttonStyle(.plain)
-                    case .live:
-                        EmptyView()
                     }
+                    .mediaFavoriteMenu(item, in: modelContext)
                 }
             }
             .padding(.horizontal, DetailMetrics.contentPadding)
@@ -561,6 +567,7 @@ enum DetailFormat {
     let movie1 = Movie(id: "preview-sim-1", streamId: 1, name: "Similar Movie 1")
     let movie2 = Movie(id: "preview-sim-2", streamId: 2, name: "Similar Movie 2")
     SimilarRow(items: [.movie(movie1), .movie(movie2)])
+        .modelContainer(previewContainer())
 }
 
 #Preview("DetailPosterCard") {

--- a/Lume/Views/Components/MediaFavoriteMenu.swift
+++ b/Lume/Views/Components/MediaFavoriteMenu.swift
@@ -1,0 +1,148 @@
+//
+//  MediaFavoriteMenu.swift
+//  Lume
+//
+//  The VOD twin of `LiveChannelMenu`: the secondary actions on a movie or
+//  series card — long-press on iOS, iPadOS and tvOS, right-click on macOS,
+//  pinch-and-hold on visionOS. One menu rather than several stacked modifiers:
+//  only the outermost `contextMenu` survives on a view, so every action a card
+//  offers has to be built here, which is why the recents-removal and
+//  recommendation-vote items are parameters rather than separate modifiers.
+//
+//  Attach it to the `NavigationLink` / `Button` *after* the card button style,
+//  never inside the card's label view — a label is invisible to the tvOS focus
+//  engine and gets shadowed by the outer menu at grid call sites.
+//
+
+import SwiftData
+import SwiftUI
+#if os(iOS)
+    import UIKit
+#endif
+
+extension View {
+    /// - Parameters:
+    ///   - isFavorite: drives the favorite item's wording and glyph. A closure,
+    ///     not a value, so the read happens inside the `contextMenu` builder
+    ///     when the menu is presented. Read eagerly at a rail or grid call site
+    ///     it would make the *container* observe every cell's `isFavorite`, so
+    ///     one toggle would invalidate the whole lazy grid's body — the cost
+    ///     class that drives tvOS focus and accessibility responder walks.
+    ///   - onRemoveFromRecents: only in the Recently Watched collections.
+    ///   - onVote: only on "For You" recommendations.
+    func mediaFavoriteMenu(
+        isFavorite: @escaping () -> Bool,
+        onToggleFavorite: @escaping () -> Void,
+        onRemoveFromRecents: (() -> Void)? = nil,
+        onVote: ((RecommendationVote) -> Void)? = nil
+    ) -> some View {
+        contextMenu {
+            FavoriteMenuItems.favorite(isFavorite: isFavorite()) {
+                onToggleFavorite()
+                favoriteToggleFeedback()
+            }
+
+            if let onVote {
+                Button {
+                    onVote(.upvote)
+                } label: {
+                    Label("More Like This", systemImage: "hand.thumbsup")
+                }
+                Button(role: .destructive) {
+                    onVote(.downvote)
+                } label: {
+                    Label("Not Interested", systemImage: "hand.thumbsdown")
+                }
+            }
+
+            if let onRemoveFromRecents {
+                FavoriteMenuItems.removeFromRecents(onRemoveFromRecents)
+            }
+        }
+    }
+}
+
+extension View {
+    /// The favorite menu for a `HomeMediaItem` entry: the home rows and the
+    /// detail-screen poster rails. Live channels keep `liveChannelMenu` and are
+    /// left untouched here.
+    @ViewBuilder
+    func mediaFavoriteMenu(
+        _ item: HomeMediaItem,
+        in context: ModelContext,
+        onRemoveFromRecents: (() -> Void)? = nil,
+        onVote: ((RecommendationVote) -> Void)? = nil
+    ) -> some View {
+        switch item {
+        case let .movie(movie):
+            mediaFavoriteMenu(
+                isFavorite: { movie.isFavorite },
+                onToggleFavorite: { MediaFavorites.toggle(movie, in: context) },
+                onRemoveFromRecents: onRemoveFromRecents,
+                onVote: onVote
+            )
+        case let .series(series):
+            mediaFavoriteMenu(
+                isFavorite: { series.isFavorite },
+                onToggleFavorite: { MediaFavorites.toggle(series, in: context) },
+                onRemoveFromRecents: onRemoveFromRecents,
+                onVote: onVote
+            )
+        case .live:
+            self
+        }
+    }
+}
+
+extension View {
+    /// The favorite menu for a downloaded episode row. Favoriting an episode
+    /// favorites its show — episodes have no `isFavorite` of their own, the same
+    /// routing `PlayerFavorites` uses. An orphan episode gets no menu rather
+    /// than one whose favorite item would silently do nothing.
+    @ViewBuilder
+    func episodeFavoriteMenu(_ episode: Episode, in context: ModelContext) -> some View {
+        if let series = episode.series {
+            mediaFavoriteMenu(
+                isFavorite: { series.isFavorite },
+                onToggleFavorite: { MediaFavorites.toggle(series, in: context) }
+            )
+        } else {
+            self
+        }
+    }
+}
+
+extension View {
+    /// The favorite menu for the home hero. The hero's Details affordance is
+    /// the only element it owns — on tvOS the only focusable one, and the one
+    /// the hero-collapse behaviour depends on — so the menu attaches there
+    /// rather than to the carousel surface, which owns swipe paging.
+    ///
+    /// Deliberately NOT a `@ViewBuilder` branching on movie⇄series: the tvOS
+    /// hero pill is one structurally stable Button across every slide, and a
+    /// conditional branch here would hand it a new identity on the pages that
+    /// switch kind — focus falls to the first row and the whole home jumps.
+    func heroFavoriteMenu(_ hero: HeroItem, in context: ModelContext) -> some View {
+        mediaFavoriteMenu(
+            isFavorite: { hero.movie?.isFavorite ?? hero.series?.isFavorite ?? false },
+            onToggleFavorite: {
+                if let movie = hero.movie {
+                    MediaFavorites.toggle(movie, in: context)
+                } else if let series = hero.series {
+                    MediaFavorites.toggle(series, in: context)
+                }
+            }
+        )
+    }
+}
+
+/// Confirmation for the favorite toggle. iPhone / iPad only by product
+/// decision — visionOS is `os(visionOS)` and deliberately gets nothing. Fired
+/// imperatively from the menu action rather than through `sensoryFeedback`,
+/// which would put trigger state on every VOD card for a one-shot response to a
+/// discrete tap.
+private func favoriteToggleFeedback() {
+    #if os(iOS)
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+    #endif
+}

--- a/Lume/Views/Components/OtherSourcesRow.swift
+++ b/Lume/Views/Components/OtherSourcesRow.swift
@@ -7,6 +7,12 @@
 //  with the owning playlist's name. The badge overlay is shared with the tvOS
 //  rails via `posterBadge(_:)`.
 //
+//  Deliberately no favorite menu, unlike the sibling "You May Also Like" rail:
+//  an entry here can be the same title on a *different* playlist, while the
+//  Favorites rail is scoped to the active playlist, so favoriting that copy
+//  would create a favorite the user can neither see nor undo on the rail they
+//  were just looking at.
+//
 
 import SwiftUI
 

--- a/Lume/Views/Downloads/DownloadsView.swift
+++ b/Lume/Views/Downloads/DownloadsView.swift
@@ -104,6 +104,10 @@ import SwiftUI
                         } onDelete: {
                             itemToDelete = DeletionTarget(id: movie.id, name: movie.name)
                         }
+                        .mediaFavoriteMenu(
+                            isFavorite: { movie.isFavorite },
+                            onToggleFavorite: { MediaFavorites.toggle(movie, in: modelContext) }
+                        )
                     }
                 }
             }
@@ -119,6 +123,7 @@ import SwiftUI
                         } onDelete: {
                             itemToDelete = DeletionTarget(id: episode.id, name: episode.title)
                         }
+                        .episodeFavoriteMenu(episode, in: modelContext)
                     }
                 }
             }

--- a/Lume/Views/Home/HeroInfo.swift
+++ b/Lume/Views/Home/HeroInfo.swift
@@ -7,6 +7,7 @@
 //  inside `TVHomeScreen`.)
 //
 
+import SwiftData
 import SwiftUI
 
 // MARK: - Title / overview / buttons
@@ -14,6 +15,8 @@ import SwiftUI
 struct HeroInfo: View {
     let hero: HeroItem
     let isCompact: Bool
+
+    @Environment(\.modelContext) private var modelContext
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -54,7 +57,11 @@ struct HeroInfo: View {
 
     private var actionButtons: some View {
         // Full-width when compact so the button spans the stacked layout.
+        // The Details button is the hero's only affordance, so it also carries
+        // the favorite menu — the carousel surface below owns swipe paging and
+        // the info crossfade, and a menu there would fight both.
         detailsButton(fullWidth: isCompact)
+            .heroFavoriteMenu(hero, in: modelContext)
     }
 
     @ViewBuilder

--- a/Lume/Views/Home/HomeHeroCarousel.swift
+++ b/Lume/Views/Home/HomeHeroCarousel.swift
@@ -13,6 +13,7 @@
 //  to the view width instead of the scroll view's unbounded-width proposal.
 //
 
+import SwiftData
 import SwiftUI
 
 struct HomeHeroCarousel: View {
@@ -334,6 +335,7 @@ private struct HeroSlot: Identifiable {
         )
     ]
     HomeHeroCarousel(items: items)
+        .modelContainer(previewContainer())
 }
 
 #Preview("Single Item") {
@@ -345,6 +347,7 @@ private struct HeroSlot: Identifiable {
         )
     ]
     HomeHeroCarousel(items: items)
+        .modelContainer(previewContainer())
 }
 
 #Preview("Empty") {

--- a/Lume/Views/Home/HomeRows.swift
+++ b/Lume/Views/Home/HomeRows.swift
@@ -63,8 +63,6 @@ private struct HomeItemCell: View {
     var onVote: ((HomeMediaItem, RecommendationVote) -> Void)?
     var onStartMultiView: ((LiveStream) -> Void)?
     var animationNamespace: Namespace.ID?
-    /// For the channel menu's favourite toggle.
-    @Environment(\.modelContext) private var modelContext
 
     var body: some View {
         Group {
@@ -93,33 +91,44 @@ private struct HomeItemCell: View {
         .modifier(HomeItemMenu(
             item: item,
             onRemove: onRemove,
-            onStartMultiView: onStartMultiView,
-            onToggleFavorite: { stream in LiveChannelFavorites.toggle(stream, in: modelContext) }
+            onVote: onVote,
+            onStartMultiView: onStartMultiView
         ))
-        .recommendationVoteMenu(onVote.map { action in { vote in action(item, vote) } })
     }
 }
 
 /// The card's long-press menu. A channel gets the full channel menu — the same
-/// one its row in Live TV carries — while a movie or series keeps the remove
-/// action alone. One modifier rather than two stacked: only the outermost
-/// `contextMenu` on a view survives.
+/// one its row in Live TV carries, and the live favorite semantic (the flag
+/// alone, no watchlist date) — while a movie or series gets the VOD one. Every
+/// action a card offers is built here, in a single menu: only the outermost
+/// `contextMenu` on a view survives, so a stacked second modifier would silently
+/// replace the first.
 private struct HomeItemMenu: ViewModifier {
     let item: HomeMediaItem
     let onRemove: ((HomeMediaItem) -> Void)?
+    let onVote: ((HomeMediaItem, RecommendationVote) -> Void)?
     let onStartMultiView: ((LiveStream) -> Void)?
-    let onToggleFavorite: (LiveStream) -> Void
+    @Environment(\.modelContext) private var modelContext
 
     func body(content: Content) -> some View {
-        if case let .live(stream) = item {
+        let removeFromRecents = onRemove.map { action in { action(item) } }
+        let voteAction = onVote.map { action in { (vote: RecommendationVote) in action(item, vote) } }
+
+        switch item {
+        case let .live(stream):
             content.liveChannelMenu(
                 isFavorite: stream.isFavorite,
-                onToggleFavorite: { onToggleFavorite(stream) },
+                onToggleFavorite: { LiveChannelFavorites.toggle(stream, in: modelContext) },
                 onStartMultiView: onStartMultiView.map { action in { action(stream) } },
-                onRemoveFromRecents: onRemove.map { action in { action(item) } }
+                onRemoveFromRecents: removeFromRecents
             )
-        } else {
-            content.recentlyWatchedRemoveMenu(onRemove.map { action in { action(item) } })
+        default:
+            content.mediaFavoriteMenu(
+                item,
+                in: modelContext,
+                onRemoveFromRecents: removeFromRecents,
+                onVote: voteAction
+            )
         }
     }
 }
@@ -168,34 +177,6 @@ struct ForYouRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
-    }
-}
-
-// MARK: - Recommendation vote menu
-
-extension View {
-    /// Attaches thumbs up / thumbs down actions for a "For You" recommendation
-    /// when an action is provided, otherwise leaves the view untouched. Surfaced
-    /// by the same secondary-action gesture as the remove menu (long-press on
-    /// iOS/tvOS, right-click on macOS).
-    @ViewBuilder
-    func recommendationVoteMenu(_ vote: ((RecommendationVote) -> Void)?) -> some View {
-        if let vote {
-            contextMenu {
-                Button {
-                    vote(.upvote)
-                } label: {
-                    Label("More Like This", systemImage: "hand.thumbsup")
-                }
-                Button(role: .destructive) {
-                    vote(.downvote)
-                } label: {
-                    Label("Not Interested", systemImage: "hand.thumbsdown")
-                }
-            }
-        } else {
-            self
-        }
     }
 }
 

--- a/Lume/Views/Home/TVHomeScreen.swift
+++ b/Lume/Views/Home/TVHomeScreen.swift
@@ -18,6 +18,7 @@
 
 #if os(tvOS)
 
+    import SwiftData
     import SwiftUI
 
     // MARK: - Hero model
@@ -300,6 +301,7 @@
         let model: TVHeroModel
         let onSelect: (HeroItem) -> Void
 
+        @Environment(\.modelContext) private var modelContext
         @FocusState private var heroFocused: Bool
 
         var body: some View {
@@ -432,6 +434,10 @@
                         default: break
                         }
                     }
+                    // On the pill, never on the band or the slot: the menu's
+                    // owner has to be focusable, and the band's sizing and
+                    // section ordering are what keep the hero collapse working.
+                    .heroFavoriteMenu(hero, in: modelContext)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .focusSection()
@@ -523,6 +529,7 @@
                 }
             )
         }
+        .modelContainer(previewContainer())
     }
 
 #endif

--- a/Lume/Views/LiveTV/LiveChannelMenu.swift
+++ b/Lume/Views/LiveTV/LiveChannelMenu.swift
@@ -23,12 +23,7 @@ extension View {
         onRemoveFromRecents: (() -> Void)? = nil
     ) -> some View {
         contextMenu {
-            Button(action: onToggleFavorite) {
-                Label(
-                    isFavorite ? "Remove from Favorites" : "Add to Favorites",
-                    systemImage: isFavorite ? "heart.slash" : "heart"
-                )
-            }
+            FavoriteMenuItems.favorite(isFavorite: isFavorite, action: onToggleFavorite)
 
             if let onStartMultiView {
                 Button(action: onStartMultiView) {
@@ -37,10 +32,29 @@ extension View {
             }
 
             if let onRemoveFromRecents {
-                Button(role: .destructive, action: onRemoveFromRecents) {
-                    Label("Remove from Recently Watched", systemImage: "clock.badge.xmark")
-                }
+                FavoriteMenuItems.removeFromRecents(onRemoveFromRecents)
             }
+        }
+    }
+}
+
+/// The items `liveChannelMenu` and `mediaFavoriteMenu` both offer. The two menus
+/// are twins by design, so their shared wording and glyphs live in one place —
+/// a rename that only lands in one of them would create a fresh untranslated key
+/// (see `MediaFavoriteMenuStringsTests`).
+enum FavoriteMenuItems {
+    static func favorite(isFavorite: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Label(
+                isFavorite ? "Remove from Favorites" : "Add to Favorites",
+                systemImage: isFavorite ? "heart.slash" : "heart"
+            )
+        }
+    }
+
+    static func removeFromRecents(_ action: @escaping () -> Void) -> some View {
+        Button(role: .destructive, action: action) {
+            Label("Remove from Recently Watched", systemImage: "clock.badge.xmark")
         }
     }
 }
@@ -49,8 +63,10 @@ extension View {
 /// movies and series, which also stamp `addedToWatchlistDate` — mirroring
 /// `PlayerFavorites` and the detail screens.
 enum LiveChannelFavorites {
-    static func toggle(_ stream: LiveStream, in context: ModelContext) {
+    @discardableResult
+    static func toggle(_ stream: LiveStream, in context: ModelContext) -> Bool {
         stream.isFavorite.toggle()
         try? context.save()
+        return stream.isFavorite
     }
 }

--- a/Lume/Views/Movies/MovieDetailView.swift
+++ b/Lume/Views/Movies/MovieDetailView.swift
@@ -392,8 +392,7 @@ struct MovieDetailView: View {
     }
 
     private func toggleFavorite() {
-        movie.isFavorite.toggle()
-        movie.addedToWatchlistDate = movie.isFavorite ? Date() : nil
+        MediaFavorites.toggle(movie, in: modelContext)
     }
 
     private func toggleWatched() {

--- a/Lume/Views/Player/TVPlayerControlsOverlay+Data.swift
+++ b/Lume/Views/Player/TVPlayerControlsOverlay+Data.swift
@@ -292,15 +292,12 @@
 
         func toggleFavorite() {
             if isSeries, let series = episode?.series {
-                series.isFavorite.toggle()
-                series.addedToWatchlistDate = series.isFavorite ? Date() : nil
+                MediaFavorites.toggle(series, in: modelContext)
             } else if media.isLive, let liveStream {
-                liveStream.isFavorite.toggle()
+                LiveChannelFavorites.toggle(liveStream, in: modelContext)
             } else if let movie {
-                movie.isFavorite.toggle()
-                movie.addedToWatchlistDate = movie.isFavorite ? Date() : nil
+                MediaFavorites.toggle(movie, in: modelContext)
             }
-            try? modelContext.save()
             onResetHideTimer()
         }
 

--- a/Lume/Views/SearchView.swift
+++ b/Lume/Views/SearchView.swift
@@ -69,11 +69,19 @@ struct SearchView: View {
                                         SearchResultRow(result: result)
                                             .matchedTransitionSourceIfAvailable(id: movie.id, in: animationNamespace)
                                     }
+                                    .mediaFavoriteMenu(
+                                        isFavorite: { movie.isFavorite },
+                                        onToggleFavorite: { MediaFavorites.toggle(movie, in: modelContext) }
+                                    )
                                 case let .series(series):
                                     NavigationLink(value: series) {
                                         SearchResultRow(result: result)
                                             .matchedTransitionSourceIfAvailable(id: series.id, in: animationNamespace)
                                     }
+                                    .mediaFavoriteMenu(
+                                        isFavorite: { series.isFavorite },
+                                        onToggleFavorite: { MediaFavorites.toggle(series, in: modelContext) }
+                                    )
                                 case let .liveStream(stream):
                                     Button {
                                         playChannel(stream)
@@ -81,6 +89,10 @@ struct SearchView: View {
                                         SearchResultRow(result: result)
                                     }
                                     .buttonStyle(.plain)
+                                    .liveChannelMenu(
+                                        isFavorite: stream.isFavorite,
+                                        onToggleFavorite: { LiveChannelFavorites.toggle(stream, in: modelContext) }
+                                    )
                                 }
                             }
                         } header: {

--- a/Lume/Views/Series/SeriesCategoryView.swift
+++ b/Lume/Views/Series/SeriesCategoryView.swift
@@ -1,0 +1,207 @@
+//
+//  SeriesCategoryView.swift
+//  Lume
+//
+//  The concrete Series category screens — the full "Show All" grid and the
+//  home-screen preview row — built on the shared components in
+//  CategoryContentGrid.swift.
+//
+
+import SwiftData
+import SwiftUI
+
+// MARK: - Series Category View
+
+struct SeriesCategoryView: View {
+    let category: Category
+    var animationNamespace: Namespace.ID?
+    @Environment(\.modelContext) private var modelContext
+
+    @AppStorage(SortStorageKey.seriesContent) private var contentSortRaw: String = ContentSortOption.playlist.rawValue
+
+    @State private var series: [Series] = []
+    @State private var canLoadMore = true
+    @State private var isLoadingPage = false
+    /// True while a Stalker category's content is being fetched from the portal
+    /// on first open — drives the loading overlay.
+    @State private var isImporting = false
+    /// Sort the current pages were loaded for; reload only on change so a pop
+    /// back from a detail keeps the loaded pages and scroll position intact.
+    @State private var loadedSort: String?
+
+    /// A category in a large IPTV playlist can hold thousands of titles; fetch a
+    /// page at a time and load the next as the grid nears the end, rather than
+    /// hydrating the whole category into memory at once.
+    private let pageSize = 100
+
+    private var contentSort: ContentSortOption {
+        ContentSortOption(rawValue: contentSortRaw) ?? .playlist
+    }
+
+    /// The playlist when it's a Stalker portal, whose categories are imported
+    /// on demand rather than synced whole.
+    private var stalkerPlaylist: Playlist? {
+        guard let playlist = category.playlist, playlist.sourceType == .stalker else { return nil }
+        return playlist
+    }
+
+    var body: some View {
+        grid
+            .overlay {
+                if isImporting, series.isEmpty {
+                    ProgressView("Loading…")
+                }
+            }
+            .task(id: contentSortRaw) {
+                guard loadedSort != contentSortRaw else { return }
+                loadedSort = contentSortRaw
+                series = []
+                canLoadMore = true
+                await importStalkerContentIfNeeded()
+                loadNextPage()
+                await revalidateStalkerContentIfStale()
+            }
+    }
+
+    @ViewBuilder
+    private var grid: some View {
+        let base = CategoryContentGrid(
+            title: category.name,
+            items: series,
+            animationNamespace: animationNamespace,
+            emptyTitle: "No Series",
+            emptyIcon: "tv.fill",
+            emptyDescription: "This category has no series",
+            sortRaw: $contentSortRaw,
+            onLoadMore: { loadNextPage() },
+            card: { SeriesCardView(series: $0, fillsWidth: true) }
+        )
+        // Pull-to-refresh re-imports a Stalker category — see `MovieCategoryView`.
+        #if !os(tvOS)
+            if stalkerPlaylist != nil {
+                base.refreshable { await reimportStalkerContent() }
+            } else {
+                base
+            }
+        #else
+            base
+        #endif
+    }
+
+    private func loadNextPage() {
+        guard canLoadMore, !isLoadingPage else { return }
+        isLoadingPage = true
+        defer { isLoadingPage = false }
+        let categoryId = category.id
+        var descriptor = FetchDescriptor<Series>(
+            predicate: #Predicate { $0.categoryId == categoryId },
+            sortBy: contentSort.seriesDescriptors
+        )
+        descriptor.fetchOffset = series.count
+        descriptor.fetchLimit = pageSize
+        let page = (try? modelContext.fetch(descriptor)) ?? []
+        series.append(contentsOf: page)
+        if page.count < pageSize { canLoadMore = false }
+    }
+
+    /// Imports the category from the portal the first time it's opened (Stalker
+    /// only; other sources are already fully synced).
+    private func importStalkerContentIfNeeded() async {
+        guard let playlist = stalkerPlaylist, category.contentImportedAt == nil else { return }
+        await runStalkerImport(playlist: playlist)
+    }
+
+    /// Background revalidation of content older than `Category.stalkerContentTTL`
+    /// — see `MovieCategoryView.revalidateStalkerContentIfStale`.
+    private func revalidateStalkerContentIfStale() async {
+        guard let playlist = stalkerPlaylist,
+              category.contentImportedAt != nil, category.stalkerContentStale else { return }
+        await runStalkerImport(playlist: playlist)
+        reloadLoadedPages()
+    }
+
+    private func reimportStalkerContent() async {
+        guard let playlist = stalkerPlaylist else { return }
+        await runStalkerImport(playlist: playlist)
+        series = []
+        canLoadMore = true
+        loadNextPage()
+    }
+
+    /// Re-fetches the already-loaded window in place — see
+    /// `MovieCategoryView.reloadLoadedPages`.
+    private func reloadLoadedPages() {
+        let categoryId = category.id
+        var descriptor = FetchDescriptor<Series>(
+            predicate: #Predicate { $0.categoryId == categoryId },
+            sortBy: contentSort.seriesDescriptors
+        )
+        let window = max(series.count, pageSize)
+        descriptor.fetchLimit = window
+        let rows = (try? modelContext.fetch(descriptor)) ?? []
+        canLoadMore = rows.count == window
+        series = rows
+    }
+
+    private func runStalkerImport(playlist: Playlist) async {
+        isImporting = true
+        defer { isImporting = false }
+        let manager = ContentSyncManager(modelContainer: modelContext.container)
+        _ = try? await manager.importStalkerCategory(apiId: category.apiId, type: .series, playlist: playlist)
+    }
+}
+
+// MARK: - Series Category Preview
+
+struct SeriesCategoryPreview: View {
+    let category: Category
+    private let limit: Int
+    @Query private var series: [Series]
+    var animationNamespace: Namespace.ID?
+
+    init(category: Category, limit: Int, sort: ContentSortOption, animationNamespace: Namespace.ID? = nil) {
+        self.category = category
+        self.limit = limit
+        self.animationNamespace = animationNamespace
+        let categoryId = category.id
+        var descriptor = FetchDescriptor<Series>(
+            predicate: #Predicate<Series> { $0.categoryId == categoryId },
+            sortBy: sort.seriesDescriptors
+        )
+        // Fetch one extra so we can tell whether a full grid would show more.
+        descriptor.fetchLimit = limit + 1
+        _series = Query(descriptor)
+    }
+
+    var body: some View {
+        CategoryPreviewRow(
+            category: category,
+            items: Array(series.prefix(limit)),
+            hasMore: series.count > limit,
+            animationNamespace: animationNamespace,
+            emptyMessage: "No series in this category",
+            card: { SeriesCardView(series: $0) }
+        )
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Series Category Grid") {
+    let container = previewContainer()
+    let categories = (try? container.mainContext.fetch(FetchDescriptor<Category>())) ?? []
+    let category = categories.first { $0.typeRaw == "series" } ?? categories[0]
+    return NavigationStack {
+        SeriesCategoryView(category: category, animationNamespace: nil)
+    }
+    .modelContainer(container)
+}
+
+#Preview("Series Category Empty") {
+    let container = previewContainer()
+    let emptyCategory = Category(apiId: "998", name: "Empty Series", parentId: 0, type: .series, playlist: PreviewData.samplePlaylist)
+    return NavigationStack {
+        SeriesCategoryView(category: emptyCategory, animationNamespace: nil)
+    }
+    .modelContainer(container)
+}

--- a/Lume/Views/Series/SeriesDetailView.swift
+++ b/Lume/Views/Series/SeriesDetailView.swift
@@ -538,8 +538,7 @@ private extension SeriesDetailView {
     }
 
     func toggleFavorite() {
-        series.isFavorite.toggle()
-        series.addedToWatchlistDate = series.isFavorite ? Date() : nil
+        MediaFavorites.toggle(series, in: modelContext)
     }
 
     func toggleWatched(_ episode: Episode) {

--- a/Lume/Views/Settings/FavoriteManagementView.swift
+++ b/Lume/Views/Settings/FavoriteManagementView.swift
@@ -128,8 +128,7 @@ struct FavoriteManagementView: View {
     }
 
     private func remove(_ entry: FavoriteEntry) {
-        entry.model.isFavorite = false
-        entry.model.favoriteOrder = nil
+        MediaFavorites.clearFavoriteState(entry.model)
     }
 
     private func reset() {

--- a/Lume/Views/TV/TVMovieDetailView.swift
+++ b/Lume/Views/TV/TVMovieDetailView.swift
@@ -107,17 +107,22 @@
                     if !similar.isEmpty {
                         TVRail(title: "You May Also Like", items: similar) { item in
                             posterLink(for: item)
+                                .mediaFavoriteMenu(item, in: modelContext)
                         }
                     }
 
                     if !collectionMovies.isEmpty, let name = movie.collectionName {
                         TVRail(title: "\(name) Collection", items: collectionMovies) { item in
                             posterLink(for: item)
+                                .mediaFavoriteMenu(item, in: modelContext)
                         }
                     }
 
                     if !otherSources.isEmpty {
                         TVRail(title: "Other Sources", items: otherSources) { source in
+                            // No favorite menu: an entry here is the same title on
+                            // a *different* playlist, so favoriting it would create a
+                            // favorite the playlist-scoped Favorites rail never shows.
                             posterLink(for: source.item, badge: source.playlistName)
                         }
                     }
@@ -361,8 +366,7 @@
         }
 
         private func toggleFavorite() {
-            movie.isFavorite.toggle()
-            movie.addedToWatchlistDate = movie.isFavorite ? Date() : nil
+            MediaFavorites.toggle(movie, in: modelContext)
         }
 
         private func toggleWatched() {

--- a/Lume/Views/TV/TVSeriesDetailView.swift
+++ b/Lume/Views/TV/TVSeriesDetailView.swift
@@ -121,11 +121,15 @@
                     if !similar.isEmpty {
                         TVRail(title: "You May Also Like", items: similar) { item in
                             posterLink(for: item)
+                                .mediaFavoriteMenu(item, in: modelContext)
                         }
                     }
 
                     if !otherSources.isEmpty {
                         TVRail(title: "Other Sources", items: otherSources) { source in
+                            // No favorite menu: an entry here is the same title on
+                            // a *different* playlist, so favoriting it would create a
+                            // favorite the playlist-scoped Favorites rail never shows.
                             posterLink(for: source.item, badge: source.playlistName)
                         }
                     }
@@ -479,8 +483,7 @@
         }
 
         func toggleFavorite() {
-            series.isFavorite.toggle()
-            series.addedToWatchlistDate = series.isFavorite ? Date() : nil
+            MediaFavorites.toggle(series, in: modelContext)
         }
 
         func toggleWatched(_ episode: Episode) {

--- a/LumeTests/Helpers/TestHelpers.swift
+++ b/LumeTests/Helpers/TestHelpers.swift
@@ -21,13 +21,19 @@ func makeTestContainer() throws -> ModelContainer {
     return try ModelContainer(for: schema, configurations: [config])
 }
 
-func exampleDataURL(_ filename: String, filePath: String = #filePath) -> URL {
+/// The repo root, walked up from a test file's own path: neither the JSON
+/// fixtures nor the string catalog are copied into the test bundle.
+func repoRootURL(filePath: String = #filePath) -> URL {
     var url = URL(fileURLWithPath: filePath)
-    while url.lastPathComponent != "LumeTests", url.lastPathComponent != "LumeUITests" {
+    while url.lastPathComponent != "LumeTests", url.lastPathComponent != "LumeUITests", url.pathComponents.count > 1 {
         url.deleteLastPathComponent()
     }
     url.deleteLastPathComponent()
-    return url.appendingPathComponent("ExampleData/\(filename)")
+    return url
+}
+
+func exampleDataURL(_ filename: String, filePath: String = #filePath) -> URL {
+    repoRootURL(filePath: filePath).appendingPathComponent("ExampleData/\(filename)")
 }
 
 func loadExampleJSON<T: Decodable>(_ filename: String, filePath: String = #filePath) throws -> T {
@@ -68,4 +74,34 @@ func makeProfileTestContainer() throws -> ModelContainer {
         for: Schema(catalogModels + cloudModels),
         configurations: localConfig, cloudConfig
     )
+}
+
+/// Minimal reader for `Lume/Localizable.xcstrings`. The catalog is asserted
+/// directly because runtime resolution can't tell a translated key from an
+/// English one that resolves to itself.
+struct StringCatalog {
+    let sourceLanguage: String
+    private let strings: [String: Any]
+
+    static func localizable(filePath: String = #filePath) throws -> Self {
+        let url = repoRootURL(filePath: filePath).appendingPathComponent("Lume/Localizable.xcstrings")
+        let root = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
+        return Self(
+            sourceLanguage: root?["sourceLanguage"] as? String ?? "en",
+            strings: root?["strings"] as? [String: Any] ?? [:]
+        )
+    }
+
+    /// Every non-source-language translation of `key`, or `nil` when the key is
+    /// absent from the catalog entirely.
+    func localizations(for key: String) -> [String: String]? {
+        guard let entry = strings[key] as? [String: Any] else { return nil }
+        let localizations = entry["localizations"] as? [String: Any] ?? [:]
+        var resolved: [String: String] = [:]
+        for (language, value) in localizations where language != sourceLanguage {
+            let unit = (value as? [String: Any])?["stringUnit"] as? [String: Any]
+            resolved[language] = unit?["value"] as? String ?? ""
+        }
+        return resolved
+    }
 }

--- a/LumeTests/Services/MediaFavoritesTests.swift
+++ b/LumeTests/Services/MediaFavoritesTests.swift
@@ -1,0 +1,243 @@
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+struct MediaFavoritesTests {
+    // MARK: - Favoriting
+
+    @Test func `favorite stamps the flag and date and leaves the order unstamped`() throws {
+        let container = try makeTestContainer()
+        let context = ModelContext(container)
+        let movie = Movie(id: "m-1", streamId: 1, name: "Target")
+        context.insert(movie)
+        try context.save()
+
+        let favorited = MediaFavorites.toggle(movie, in: context)
+
+        #expect(favorited)
+        #expect(movie.isFavorite)
+        #expect(movie.favoriteOrder == nil)
+        let stamped = try #require(movie.addedToWatchlistDate)
+        #expect(abs(stamped.timeIntervalSinceNow) < 5)
+    }
+
+    /// The reason a new favorite must NOT be stamped, asserted through the real
+    /// comparator rather than through `favoriteOrder` alone.
+    ///
+    /// Both surfaces that render favorites sort on `favoriteOrder ?? Int.max`
+    /// (`HomeView.favoriteItems` and `FavoriteManagementView.favorites`), so an
+    /// unstamped favorite sorts last on its own. Stamping a next-highest slot
+    /// would instead place it ahead of every favorite the user never reordered.
+    @Test func `a new favorite sorts after the favorites already on screen`() throws {
+        let container = try makeTestContainer()
+        let context = ModelContext(container)
+
+        let handOrdered = Movie(id: "m-hand", streamId: 1, name: "Hand ordered")
+        handOrdered.isFavorite = true
+        handOrdered.favoriteOrder = 0
+        context.insert(handOrdered)
+
+        // The common case: favorited, never reordered, so still unstamped.
+        let untouched = Series(id: "s-untouched", seriesId: 2, name: "Untouched")
+        untouched.isFavorite = true
+        context.insert(untouched)
+
+        let movie = Movie(id: "m-new", streamId: 3, name: "New")
+        context.insert(movie)
+        try context.save()
+
+        MediaFavorites.toggle(movie, in: context)
+
+        // The production comparator, verbatim.
+        let ordered: [any FavoriteOrderable] = [handOrdered, untouched, movie]
+            .sorted { ($0.favoriteOrder ?? Int.max) < ($1.favoriteOrder ?? Int.max) }
+        #expect(ordered.last?.id == movie.id)
+        #expect(ordered.first?.id == handOrdered.id)
+    }
+
+    // MARK: - Unfavoriting
+
+    /// All three fields have to clear: `ContentStateValues.isEmpty` requires
+    /// `!isFavorite && addedToWatchlistDate == nil && favoriteOrder == nil`
+    /// before `CloudSyncEngine` deletes the mirror record.
+    @Test func `unfavorite clears flag date and order`() throws {
+        let container = try makeTestContainer()
+        let context = ModelContext(container)
+        let movie = Movie(id: "m-1", streamId: 1, name: "Target")
+        movie.isFavorite = true
+        movie.addedToWatchlistDate = Date()
+        movie.favoriteOrder = 4
+        context.insert(movie)
+        try context.save()
+
+        let favorited = MediaFavorites.toggle(movie, in: context)
+
+        #expect(!favorited)
+        #expect(!movie.isFavorite)
+        #expect(movie.addedToWatchlistDate == nil)
+        #expect(movie.favoriteOrder == nil)
+    }
+
+    @Test func `unfavorite clears a series the same way`() throws {
+        let container = try makeTestContainer()
+        let context = ModelContext(container)
+        let series = Series(id: "s-1", seriesId: 1, name: "Target")
+        series.isFavorite = true
+        series.addedToWatchlistDate = Date()
+        series.favoriteOrder = 4
+        context.insert(series)
+        try context.save()
+
+        MediaFavorites.toggle(series, in: context)
+
+        #expect(!series.isFavorite)
+        #expect(series.addedToWatchlistDate == nil)
+        #expect(series.favoriteOrder == nil)
+    }
+
+    /// The favorites manager removes through the same primitive, so its removals
+    /// clear the watchlist stamp too and stop leaving a mirror record behind.
+    @Test func `clearing favorite state drops the watchlist stamp as well`() throws {
+        let container = try makeTestContainer()
+        let context = ModelContext(container)
+        let movie = Movie(id: "m-1", streamId: 1, name: "Movie")
+        movie.isFavorite = true
+        movie.addedToWatchlistDate = Date()
+        movie.favoriteOrder = 2
+        context.insert(movie)
+        let series = Series(id: "s-1", seriesId: 1, name: "Series")
+        series.isFavorite = true
+        series.addedToWatchlistDate = Date()
+        series.favoriteOrder = 3
+        context.insert(series)
+        try context.save()
+
+        MediaFavorites.clearFavoriteState(movie)
+        MediaFavorites.clearFavoriteState(series)
+
+        #expect(!movie.isFavorite)
+        #expect(movie.favoriteOrder == nil)
+        #expect(movie.addedToWatchlistDate == nil)
+        #expect(!series.isFavorite)
+        #expect(series.favoriteOrder == nil)
+        #expect(series.addedToWatchlistDate == nil)
+    }
+
+    // MARK: - Parity between movie and series
+
+    @Test func `series favorite matches movie favorite`() throws {
+        let container = try makeTestContainer()
+        let context = ModelContext(container)
+        let movie = Movie(id: "m-1", streamId: 1, name: "Movie")
+        let series = Series(id: "s-1", seriesId: 1, name: "Series")
+        context.insert(movie)
+        context.insert(series)
+        try context.save()
+
+        #expect(MediaFavorites.toggle(movie, in: context))
+        #expect(MediaFavorites.toggle(series, in: context))
+
+        #expect(movie.isFavorite == series.isFavorite)
+        #expect((movie.addedToWatchlistDate != nil) == (series.addedToWatchlistDate != nil))
+        #expect(movie.favoriteOrder == nil)
+        #expect(series.favoriteOrder == nil)
+    }
+
+    // MARK: - Episodes
+
+    @Test func `episode routes to its parent series`() throws {
+        let container = try makeTestContainer()
+        let context = ModelContext(container)
+        let series = Series(id: "s-1", seriesId: 1, name: "Parent")
+        context.insert(series)
+        let episode = Episode(
+            id: "e-1", episodeId: "1", title: "Ep 1",
+            containerExtension: "mp4", seasonNum: 1, episodeNum: 1, series: series
+        )
+        context.insert(episode)
+        try context.save()
+
+        let favorited = MediaFavorites.toggle(episode, in: context)
+
+        #expect(favorited)
+        #expect(series.isFavorite)
+        #expect(series.addedToWatchlistDate != nil)
+        #expect(series.favoriteOrder == nil)
+    }
+
+    @Test func `episode without a parent series is a no op`() throws {
+        let container = try makeTestContainer()
+        let context = ModelContext(container)
+        let episode = Episode(
+            id: "e-orphan", episodeId: "1", title: "Ep 1",
+            containerExtension: "mp4", seasonNum: 1, episodeNum: 1
+        )
+        context.insert(episode)
+        try context.save()
+
+        #expect(!MediaFavorites.toggle(episode, in: context))
+        #expect(episode.series == nil)
+    }
+
+    // MARK: - Round trip
+
+    /// A re-favorite must not inherit the slot it held before, which would
+    /// silently jump the user's hand-ordering.
+    @Test func `re favorite does not inherit its old order`() throws {
+        let container = try makeTestContainer()
+        let context = ModelContext(container)
+
+        let movie = Movie(id: "m-1", streamId: 1, name: "Target")
+        movie.isFavorite = true
+        movie.favoriteOrder = 3
+        context.insert(movie)
+        try context.save()
+
+        MediaFavorites.toggle(movie, in: context)
+        #expect(!movie.isFavorite)
+        #expect(movie.favoriteOrder == nil)
+
+        MediaFavorites.toggle(movie, in: context)
+
+        #expect(movie.isFavorite)
+        #expect(movie.favoriteOrder == nil)
+        #expect(movie.addedToWatchlistDate != nil)
+    }
+}
+
+// MARK: - Menu literals
+
+/// Locks the wording of the context-menu items. The menu reuses literals that
+/// are already translated in all eight non-source locales; any rename or
+/// recapitalization creates a brand-new key with eight empty locales, which
+/// `Scripts/check-translations.swift` rejects. Runtime resolution alone can't
+/// catch that — an English key resolves to itself whether or not the catalog
+/// knows it — so the catalog is asserted directly.
+struct MediaFavoriteMenuStringsTests {
+    private static let menuKeys = [
+        "Add to Favorites",
+        "Remove from Favorites",
+        "Remove from Recently Watched",
+        "More Like This",
+        "Not Interested"
+    ]
+
+    @Test func `menu literals resolve to a non empty string`() {
+        for key in Self.menuKeys {
+            let resolved = String(localized: String.LocalizationValue(key))
+            #expect(!resolved.isEmpty, "\(key) resolved to an empty string")
+        }
+    }
+
+    @Test func `menu literals are translated in every locale`() throws {
+        let catalog = try StringCatalog.localizable()
+        for key in Self.menuKeys {
+            let localizations = try #require(catalog.localizations(for: key), "\(key) is not in the catalog")
+            #expect(!localizations.isEmpty, "\(key) has no translations")
+            for (language, value) in localizations {
+                #expect(!value.isEmpty, "\(key) is untranslated in \(language)")
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ adapted per size class
 - Configurable sort options per category and content type
 - Hide and reorder categories to taste
 - Favorites and watched markers across every content type
+- **Long-press to favorite** — hold a movie or series card anywhere in the app (right-click on macOS, pinch-and-hold on visionOS) to add or remove a favorite without opening its detail screen
 - **Deep links** — open a title straight from a URL: `lume://movie/{tmdbId}` and `lume://series/{tmdbId}`
 
 #### ⏱️ Watch tracking


### PR DESCRIPTION
## Summary
Favoriting a movie or series required opening its detail screen, while Live TV
has had a long-press channel menu since #169. This adds the VOD twin of that
menu — long-press on iOS/iPadOS/tvOS, right-click on macOS, pinch-and-hold on
visionOS — on every surface a movie or series is rendered: browse rails and
grids, genre grids, all Home rails (Recently Watched, Favorites, Trending,
Trakt Watchlist, For You), the detail-screen "You May Also Like" rails, search
results, downloaded movie and episode rows, and the hero.

No model, schema, container, migration or CloudKit change — `isFavorite`,
`addedToWatchlistDate` and `favoriteOrder` already existed and already mirrored
to `UserContentState`. This adds an entry point, not new state.

## Implementation
`.contextMenu` is the single mechanism on all five platforms, so there is no
`#if` for the menu itself and no custom `LongPressGesture` (which never fires
for a macOS pointer and would swallow the `NavigationLink` tap). It attaches to
the link/button after `.posterCardButtonStyle()`, never inside the card's label
view — a label is invisible to the tvOS focus engine and gets shadowed by the
outer menu at grid call sites.

**One merged menu per surface.** Only the outermost `contextMenu` on a view
survives, and there is no compiler error when one clobbers another. The Home
rows previously chained `recommendationVoteMenu` *outside*
`.modifier(HomeItemMenu(...))`, which silently shadowed the channel menu on the
For You rail — that pre-existing bug is fixed here, and `HomeItemMenu` now
builds movie/series/live into a single menu. Library rails likewise merge into
what was `recentlyWatchedRemoveMenu` rather than stacking, so a Recently
Watched card shows `[Remove from Favorites, Remove from Recently Watched]`
together.

**One favorite semantic.** The mutation had drifted across six call sites (four
detail screens, `PlayerFavorites`, and an unlisted one in
`TVPlayerControlsOverlay+Data`); all now route through `MediaFavorites`, so a
card toggle, a detail toggle and the in-player control are indistinguishable to
the sync layer. Unfavoriting now also clears `addedToWatchlistDate` —
`ContentStateValues.isEmpty` requires all three fields nil before
`CloudSyncEngine` deletes the iCloud mirror record, so previously every
unfavorite (including Settings › Favorites removals) left a record behind with
`isFavorite == false`.

**Ordering.** A new favorite deliberately leaves `favoriteOrder` unstamped.
Both surfaces that render favorites sort on `favoriteOrder ?? Int.max`
(`HomeView.favoriteItems`, `FavoriteManagementView.favorites`), so nil already
sorts after every hand-ordered favorite. An earlier revision stamped
`max + 1` and thereby pushed new favorites *ahead* of the whole unordered block
for anyone who had never opened the favorites manager; removing it also took
three fetches off the mid-playback favorite path. `MediaFavoritesTests` asserts
placement through that same production comparator rather than through
`favoriteOrder` alone.

Deliberate scope decisions: no heart badge on cards (menu-only); an
iOS-only success haptic, fired imperatively from the menu action so it cannot
misfire when the hero carousel advances or an iCloud import flips state;
un-favorite is allowed on the Favorites rail and the card animates out; and the
"Other Sources" strip opts out, because favoriting there writes another
playlist's copy that the active-playlist Favorites rail would never show.

Zero new localization keys — all five menu literals already existed, translated
in all nine locales, so `Localizable.xcstrings` is untouched.

## Testing
- [x] Acceptance criteria met
- [x] Builds clean — iOS, iPadOS, tvOS, macOS
- [x] Tests pass — `LumeTests` 926/926 (iPhone 17 Pro / iOS 26.4)
- [x] SwiftLint clean
- [x] Tests added — `MediaFavoritesTests` (favorite/unfavorite field semantics, ordering via the production comparator, episode→parent-series routing, re-favorite not inheriting a stale order, `clearFavoriteState`) plus `MediaFavoriteMenuStringsTests` guarding the reused literals against a rename
- [x] UI verified on simulator — browse rail, Home Trending rail, Home Favorites rail (un-favorite removes the card cleanly), Home Recently Watched rail showing **both** merged items, search row, detail-screen button and in-player control all agreeing on state, and a second favorite appending after the first

## Platforms
- [x] iOS / iPadOS
- [x] tvOS
- [x] macOS
- [ ] visionOS

<!--
tvOS: builds clean and the hero menu attaches to the Details pill only, leaving
TVHeroShowcase's sizing, onMoveCommand paging and .focusSection() band
untouched — but verified by build and code review, not by driving tvOS focus.
Worth a manual pass on the hero given how fragile the collapse behaviour is.

visionOS: not built — visionOS 26.5 is not installed on the dev machine and
every visionOS destination is ineligible. Nothing in the diff is
visionOS-specific; the only platform gate is #if os(iOS) on the haptic.
-->

## Related
Adds the VOD counterpart to the Live TV channel menu from #169.