### PR TITLE
fix(search): play cross-playlist results from their own playlist

### DIFF
--- a/Lume/Services/Profiles/QuickSwitchResolver.swift
+++ b/Lume/Services/Profiles/QuickSwitchResolver.swift
@@ -35,6 +35,18 @@ extension [Playlist] {
         first(where: { $0.id.uuidString == storedID }) ?? first
     }
 
+    /// The playlist that synced a piece of content. Every catalog id is
+    /// prefixed with its playlist's UUID (see `ContentSyncManager`), and that
+    /// prefix is the only thing tying a row back to the server and credentials
+    /// that can actually play it. Callers that surface content from more than
+    /// one playlist — search with "Search All Playlists" on — must resolve the
+    /// owner this way rather than reaching for the active playlist. Returns
+    /// `nil` for an id no current playlist owns, so callers pick their own
+    /// fallback.
+    func owner(ofContentID contentID: String) -> Playlist? {
+        first { contentID.hasPrefix($0.id.uuidString) }
+    }
+
     /// The in-effect playlist's `id.uuidString`, or an empty string when there is
     /// no playlist at all. Never compare a raw stored value instead — it can name
     /// a deleted playlist.

--- a/Lume/Views/SearchView.swift
+++ b/Lume/Views/SearchView.swift
@@ -66,7 +66,7 @@ struct SearchView: View {
                                 switch result {
                                 case let .movie(movie):
                                     NavigationLink(value: movie) {
-                                        SearchResultRow(result: result)
+                                        SearchResultRow(result: result, playlistName: playlistName(for: result))
                                             .matchedTransitionSourceIfAvailable(id: movie.id, in: animationNamespace)
                                     }
                                     .mediaFavoriteMenu(
@@ -75,7 +75,7 @@ struct SearchView: View {
                                     )
                                 case let .series(series):
                                     NavigationLink(value: series) {
-                                        SearchResultRow(result: result)
+                                        SearchResultRow(result: result, playlistName: playlistName(for: result))
                                             .matchedTransitionSourceIfAvailable(id: series.id, in: animationNamespace)
                                     }
                                     .mediaFavoriteMenu(
@@ -86,7 +86,7 @@ struct SearchView: View {
                                     Button {
                                         playChannel(stream)
                                     } label: {
-                                        SearchResultRow(result: result)
+                                        SearchResultRow(result: result, playlistName: playlistName(for: result))
                                     }
                                     .buttonStyle(.plain)
                                     .liveChannelMenu(
@@ -150,8 +150,23 @@ struct SearchView: View {
         playlists.active(for: selectedPlaylistID)
     }
 
+    /// The owning playlist's name, for rows that could have come from any of
+    /// them. Only while searching across several playlists: with one playlist
+    /// in play it's the same badge on every row, and the point of it is telling
+    /// two identically-named rows from different providers apart.
+    private func playlistName(for result: SearchResult) -> String? {
+        guard searchAllPlaylists, playlists.count > 1 else { return nil }
+        return playlists.owner(ofContentID: result.contentID)?.name
+    }
+
     private func playChannel(_ stream: LiveStream) {
-        guard let playlist = activePlaylist,
+        // Cross-playlist search surfaces channels the active playlist can't
+        // stream: a live URL is built from its playlist's server, credentials
+        // and portal, so playing a foreign channel with the active playlist
+        // asks the wrong provider for it. Stream ids are per-provider integers,
+        // so that doesn't reliably fail — it can quietly play whichever channel
+        // holds the same id over there.
+        guard let playlist = playlists.owner(ofContentID: stream.id) ?? activePlaylist,
               let media = PlayableMedia.from(stream: stream, playlist: playlist) else { return }
         if ExternalPlayback.open(media) { return }
         #if os(macOS)
@@ -347,6 +362,17 @@ enum SearchResult: Identifiable, Hashable {
         }
     }
 
+    /// The catalog row's own id, which carries the owning playlist's UUID as a
+    /// prefix. `id` above namespaces by kind so a movie and a channel can't
+    /// collide in the list; this one is what `owner(ofContentID:)` reads.
+    var contentID: String {
+        switch self {
+        case let .movie(movie): movie.id
+        case let .series(series): series.id
+        case let .liveStream(stream): stream.id
+        }
+    }
+
     static func == (lhs: SearchResult, rhs: SearchResult) -> Bool {
         lhs.id == rhs.id
     }
@@ -360,6 +386,8 @@ enum SearchResult: Identifiable, Hashable {
 
 struct SearchResultRow: View {
     let result: SearchResult
+    /// Which playlist this row came from, or `nil` to leave the badge off.
+    var playlistName: String?
 
     var body: some View {
         HStack(spacing: 12) {
@@ -399,12 +427,24 @@ struct SearchResultRow: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                HStack(spacing: 4) {
-                    Image(systemName: categoryIcon)
-                    Text(LocalizedStringKey(categoryName))
+                HStack(spacing: 8) {
+                    HStack(spacing: 4) {
+                        Image(systemName: categoryIcon)
+                        Text(LocalizedStringKey(categoryName))
+                    }
+                    .foregroundStyle(.blue)
+                    // Only present while searching across playlists, where the
+                    // category alone doesn't say which provider a row is from.
+                    if let playlistName {
+                        HStack(spacing: 4) {
+                            Image(systemName: "rectangle.stack")
+                            Text(playlistName)
+                        }
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    }
                 }
                 .font(.caption2)
-                .foregroundStyle(.blue)
             }
 
             Spacer()

--- a/LumeTests/QuickSwitchResolverTests.swift
+++ b/LumeTests/QuickSwitchResolverTests.swift
@@ -4,7 +4,9 @@
 //
 //  Covers the shared quick-switch seam every switch surface reads its "which
 //  row is current" answer from: the stored-selection fallbacks of
-//  `[Playlist].active(for:)`, row ordering, and the `isCurrent` tag.
+//  `[Playlist].active(for:)`, row ordering, and the `isCurrent` tag. Also
+//  `owner(ofContentID:)`, which answers the other question — not which
+//  playlist is current, but which one a given row came from.
 //
 
 import Foundation
@@ -34,6 +36,33 @@ struct QuickSwitchResolverTests {
         }
         try context.save()
         return profiles
+    }
+
+    // MARK: - owner(ofContentID:)
+
+    @Test func `content resolves to the playlist whose prefix it carries`() throws {
+        let container = try makeProfileTestContainer()
+        let playlists = try makePlaylists(["First", "Second"], in: container.mainContext)
+        let id = "\(playlists[1].id.uuidString)-live-4021"
+
+        #expect(playlists.owner(ofContentID: id)?.id == playlists[1].id)
+    }
+
+    @Test func `content from a playlist that is gone owns nothing`() throws {
+        let container = try makeProfileTestContainer()
+        let playlists = try makePlaylists(["First", "Second"], in: container.mainContext)
+
+        #expect(playlists.owner(ofContentID: "\(UUID().uuidString)-live-4021") == nil)
+    }
+
+    @Test func `the owner is independent of which playlist is active`() throws {
+        let container = try makeProfileTestContainer()
+        let playlists = try makePlaylists(["First", "Second"], in: container.mainContext)
+        let id = "\(playlists[1].id.uuidString)-movie-77"
+
+        // The active playlist is First; the row is still Second's to play.
+        #expect(playlists.active(for: playlists[0].id.uuidString)?.id == playlists[0].id)
+        #expect(playlists.owner(ofContentID: id)?.id == playlists[1].id)
     }
 
     // MARK: - active(for:)


### PR DESCRIPTION
**Search across playlists works — acting on the results doesn't.**

`restrictToPlaylist` is dropped correctly when the setting is on, so the fetch really does return rows from every synced playlist. But `SearchView.playChannel` then built the media from `activePlaylist`:

```swift
guard let playlist = activePlaylist,
      let media = PlayableMedia.from(stream: stream, playlist: playlist) else { return }
```

A live URL is composed from its playlist's server, username, password and portal (`XtreamClient.buildLiveStreamURL`), so a channel found in playlist B was requested from playlist A. That doesn't reliably fail: stream ids are per-provider integers, so when A happens to hold the same id you get **a different channel playing, with no error**. Stalker results hit the wrong portal the same way. Only m3u channels carrying a `directURL` survived, which is why it reads as flaky rather than broken.

Movies and series were already fine — `MovieDetailView.moviePlaylist` resolves the owner from the playlist UUID prefixed onto every catalog id. Live TV in search was the one place still reaching for the active playlist.

**The fix** gives that idiom a name: `[Playlist].owner(ofContentID:)`, next to `active(for:)`, so "which playlist is current" and "which playlist is this row from" stop being answered by the same call. Search's live path uses it, falling back to the active playlist for an id no playlist claims.

**Also:** result rows now show their playlist's name while searching across playlists. Dedupe is on the playlist-prefixed id, so a title synced from two providers was two identical rows with nothing to tell them apart.

**Tests:** three cases on `owner(ofContentID:)` — prefix match, an id whose playlist is gone, and ownership staying put when a different playlist is active.

**Not addressed here** (happy to follow up): the 50-per-type result cap is shared across playlists and sorted by name, and a non-active Stalker playlist's VOD is unreachable since its catalog is never synced locally and `portalSearch` only queries the active playlist.
