### PR TITLE
fix(search): give each playlist a share of the result budget

### DIFF
--- a/Lume/Views/SearchFetching.swift
+++ b/Lume/Views/SearchFetching.swift
@@ -25,58 +25,117 @@ nonisolated struct SearchHits {
 /// takes a single `Sendable` value.
 nonisolated struct SearchRequest {
     let query: String
-    let playlistID: String
-    let restrictToPlaylist: Bool
+    /// The playlists to search, by `id.uuidString`. One id scopes the results
+    /// to that playlist; several give each its own share of the budget; empty
+    /// searches the store unscoped (there is no playlist yet).
+    let playlistIDs: [String]
     let wantMovies: Bool
     let wantSeries: Bool
     let wantLive: Bool
     let excludedCategoryIDs: Set<String>
+    /// Max rows per content type, across every playlist searched.
     let limit: Int
+
+    /// The fetches one type is split into. Searching several playlists runs one
+    /// per playlist so a single catalog can't spend the whole budget — plus one
+    /// for rows no category claims, which a per-playlist fetch matches on
+    /// category prefix would otherwise drop (m3u sources don't always supply a
+    /// category).
+    var scopes: [SearchScope] {
+        guard playlistIDs.count > 1 else {
+            return [SearchScope(
+                query: query,
+                playlistID: playlistIDs.first ?? "",
+                restrictToPlaylist: !playlistIDs.isEmpty,
+                excluded: excludedCategoryIDs
+            )]
+        }
+        var scopes = playlistIDs.map {
+            SearchScope(query: query, playlistID: $0, restrictToPlaylist: true, excluded: excludedCategoryIDs)
+        }
+        scopes.append(SearchScope(
+            query: query, playlistID: "", restrictToPlaylist: false,
+            excluded: excludedCategoryIDs, uncategorisedOnly: true
+        ))
+        return scopes
+    }
 }
 
 /// Runs the bounded `localizedStandardContains` fetches on a background
 /// `ModelContext` and returns only identifiers — never managed objects, which
 /// can't cross actor boundaries.
 nonisolated enum SearchFetcher {
+    /// A matched row and the name it sorts under, kept together so the merge
+    /// can re-sort what it picked without going back to the store.
+    private struct Row {
+        let id: PersistentIdentifier
+        let name: String
+    }
+
     static func fetch(container: ModelContainer, request: SearchRequest) -> SearchHits {
-        let scope = SearchScope(
-            query: request.query,
-            playlistID: request.playlistID,
-            restrictToPlaylist: request.restrictToPlaylist,
-            excluded: request.excludedCategoryIDs
-        )
-        let limit = request.limit
         let context = ModelContext(container)
+        let scopes = request.scopes
+        let limit = request.limit
         var hits = SearchHits()
 
         if request.wantMovies {
-            var descriptor = FetchDescriptor<Movie>(
-                predicate: searchMoviePredicate(scope: scope),
-                sortBy: [SortDescriptor(\.name)]
-            )
-            descriptor.fetchLimit = limit
-            hits.movies = ((try? context.fetch(descriptor)) ?? []).map(\.persistentModelID)
+            hits.movies = merge(scopes.map {
+                rows(in: context, predicate: searchMoviePredicate(scope: $0), name: \Movie.name, limit: limit)
+            }, limit: limit)
         }
 
         if request.wantSeries {
-            var descriptor = FetchDescriptor<Series>(
-                predicate: searchSeriesPredicate(scope: scope),
-                sortBy: [SortDescriptor(\.name)]
-            )
-            descriptor.fetchLimit = limit
-            hits.series = ((try? context.fetch(descriptor)) ?? []).map(\.persistentModelID)
+            hits.series = merge(scopes.map {
+                rows(in: context, predicate: searchSeriesPredicate(scope: $0), name: \Series.name, limit: limit)
+            }, limit: limit)
         }
 
         if request.wantLive {
-            var descriptor = FetchDescriptor<LiveStream>(
-                predicate: searchLiveStreamPredicate(scope: scope),
-                sortBy: [SortDescriptor(\.name)]
-            )
-            descriptor.fetchLimit = limit
-            hits.streams = ((try? context.fetch(descriptor)) ?? []).map(\.persistentModelID)
+            hits.streams = merge(scopes.map {
+                rows(in: context, predicate: searchLiveStreamPredicate(scope: $0), name: \LiveStream.name, limit: limit)
+            }, limit: limit)
         }
 
         return hits
+    }
+
+    private static func rows<Model: PersistentModel>(
+        in context: ModelContext,
+        predicate: Predicate<Model>,
+        name: KeyPath<Model, String>,
+        limit: Int
+    ) -> [Row] {
+        var descriptor = FetchDescriptor<Model>(predicate: predicate, sortBy: [SortDescriptor(name)])
+        descriptor.fetchLimit = limit
+        return ((try? context.fetch(descriptor)) ?? []).map {
+            Row(id: $0.persistentModelID, name: $0[keyPath: name])
+        }
+    }
+
+    /// Spends the budget by taking one row from each list in turn, then puts
+    /// what survived back in name order. The rotation is what keeps a playlist
+    /// whose titles sort early from crowding the others out — and a playlist
+    /// with only a couple of matches hands its unused share straight back. A
+    /// single list is already ordered and bounded, so it passes through.
+    private static func merge(_ lists: [[Row]], limit: Int) -> [PersistentIdentifier] {
+        guard lists.count > 1 else { return (lists.first ?? []).map(\.id) }
+        var picked: [Row] = []
+        var seen = Set<PersistentIdentifier>()
+        var index = 0
+        while picked.count < limit {
+            var advanced = false
+            for list in lists where index < list.count {
+                advanced = true
+                guard seen.insert(list[index].id).inserted else { continue }
+                picked.append(list[index])
+                if picked.count == limit { break }
+            }
+            guard advanced, picked.count < limit else { break }
+            index += 1
+        }
+        return picked
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+            .map(\.id)
     }
 }
 
@@ -89,6 +148,10 @@ nonisolated struct SearchScope {
     let playlistID: String
     let restrictToPlaylist: Bool
     let excluded: Set<String>
+    /// Matches only rows with no category at all. The other half of a
+    /// per-playlist split: playlist scoping keys off the playlist UUID prefixed
+    /// onto every category id, which uncategorised rows have nowhere to carry.
+    var uncategorisedOnly = false
 
     /// The excluded ids as optionals, so a predicate can test the optional
     /// `categoryId` against them directly. Neither `?? ""` (a ternary) nor a
@@ -104,11 +167,13 @@ nonisolated struct SearchScope {
 nonisolated func searchMoviePredicate(scope: SearchScope) -> Predicate<Movie> {
     let (query, playlistID) = (scope.query, scope.playlistID)
     let restrictToPlaylist = scope.restrictToPlaylist
+    let uncategorisedOnly = scope.uncategorisedOnly
     let excluded = scope.excludedOptional
     let filtersCategories = !excluded.isEmpty
     return #Predicate { movie in
         movie.name.localizedStandardContains(query)
             && (!restrictToPlaylist || (movie.categoryId?.localizedStandardContains(playlistID) ?? false))
+            && (!uncategorisedOnly || movie.categoryId == nil)
             && (!filtersCategories || movie.categoryId == nil || !excluded.contains(movie.categoryId))
     }
 }
@@ -116,11 +181,13 @@ nonisolated func searchMoviePredicate(scope: SearchScope) -> Predicate<Movie> {
 nonisolated func searchSeriesPredicate(scope: SearchScope) -> Predicate<Series> {
     let (query, playlistID) = (scope.query, scope.playlistID)
     let restrictToPlaylist = scope.restrictToPlaylist
+    let uncategorisedOnly = scope.uncategorisedOnly
     let excluded = scope.excludedOptional
     let filtersCategories = !excluded.isEmpty
     return #Predicate { series in
         series.name.localizedStandardContains(query)
             && (!restrictToPlaylist || (series.categoryId?.localizedStandardContains(playlistID) ?? false))
+            && (!uncategorisedOnly || series.categoryId == nil)
             && (!filtersCategories || series.categoryId == nil || !excluded.contains(series.categoryId))
     }
 }
@@ -130,12 +197,14 @@ nonisolated func searchSeriesPredicate(scope: SearchScope) -> Predicate<Series> 
 nonisolated func searchLiveStreamPredicate(scope: SearchScope) -> Predicate<LiveStream> {
     let (query, playlistID) = (scope.query, scope.playlistID)
     let restrictToPlaylist = scope.restrictToPlaylist
+    let uncategorisedOnly = scope.uncategorisedOnly
     let excluded = scope.excludedOptional
     let filtersCategories = !excluded.isEmpty
     return #Predicate { stream in
         stream.name.localizedStandardContains(query)
             && stream.isHidden == false
             && (!restrictToPlaylist || (stream.categoryId?.localizedStandardContains(playlistID) ?? false))
+            && (!uncategorisedOnly || stream.categoryId == nil)
             && (!filtersCategories || stream.categoryId == nil || !excluded.contains(stream.categoryId))
     }
 }

--- a/Lume/Views/SearchView.swift
+++ b/Lume/Views/SearchView.swift
@@ -220,7 +220,10 @@ struct SearchView: View {
     private func localSearch(
         query: String, playlist: Playlist?, wantMovies: Bool, wantSeries: Bool, wantLive: Bool
     ) async -> SearchHits {
-        // Scope to the active playlist unless cross-playlist search is on. Every
+        // Scope to the active playlist unless cross-playlist search is on, in
+        // which case every playlist is named and each gets its own share of the
+        // budget — one alphabetically-early catalog would otherwise fill all
+        // `resultLimit` rows and the others would look unsearched. Every
         // category id is prefixed with its playlist's UUID (see Category.id),
         // which appears nowhere else, so matching it within categoryId limits
         // results to that playlist. Hidden/restricted categories are excluded in
@@ -228,8 +231,7 @@ struct SearchView: View {
         // the viewer will never see.
         let request = SearchRequest(
             query: query,
-            playlistID: playlist?.id.uuidString ?? "",
-            restrictToPlaylist: !searchAllPlaylists && playlist != nil,
+            playlistIDs: searchAllPlaylists ? playlists.map(\.id.uuidString) : [playlist?.id.uuidString].compactMap { $0 },
             wantMovies: wantMovies,
             wantSeries: wantSeries,
             wantLive: wantLive,

--- a/LumeTests/Services/SearchPredicateTests.swift
+++ b/LumeTests/Services/SearchPredicateTests.swift
@@ -3,7 +3,8 @@
 //  LumeTests
 //
 //  Search excludes hidden/restricted categories inside the fetch, so the
-//  per-type result limit isn't spent on rows the viewer will never see. The
+//  per-type result limit isn't spent on rows the viewer will never see, and
+//  splits that limit between playlists when searching across them. The
 //  predicates must run against an on-disk SQLite store: in-memory stores
 //  evaluate predicates without SQL generation, so a form CoreData can't render
 //  passes there and traps on device (see `TmdbIdPredicateTests`).
@@ -129,5 +130,99 @@ struct SearchPredicateTests {
             )))
         )
         #expect(fetched.map(\.id) == ["m1"])
+    }
+
+    // MARK: - Cross-playlist budget
+
+    /// Two playlists, one of which alone can fill the whole budget with titles
+    /// that sort first. The other must still be represented — a single catalog
+    /// crowding the rest out is indistinguishable, on screen, from the setting
+    /// not working at all.
+    private func insertTwoCatalogs(_ context: ModelContext, limit: Int) throws -> (String, String) {
+        let big = UUID().uuidString
+        let small = UUID().uuidString
+        for index in 0 ..< (limit + 10) {
+            let movie = Movie(id: "\(big)-movie-\(index)", streamId: index, name: "Aaa Matrix \(index)")
+            movie.categoryId = "\(big)-vod-1"
+            context.insert(movie)
+        }
+        for index in 0 ..< 2 {
+            let movie = Movie(id: "\(small)-movie-\(index)", streamId: index, name: "Zzz Matrix \(index)")
+            movie.categoryId = "\(small)-vod-1"
+            context.insert(movie)
+        }
+        try context.save()
+        return (big, small)
+    }
+
+    private func names(_ ids: [PersistentIdentifier], in context: ModelContext) -> [String] {
+        ids.compactMap { (context.model(for: $0) as? Movie)?.name }
+    }
+
+    @Test func `each playlist gets a share of the result budget`() throws {
+        let container = try makeSQLiteContainer()
+        let context = container.mainContext
+        let limit = 20
+        let (big, small) = try insertTwoCatalogs(context, limit: limit)
+
+        let hits = SearchFetcher.fetch(container: container, request: SearchRequest(
+            query: "matrix", playlistIDs: [big, small],
+            wantMovies: true, wantSeries: false, wantLive: false,
+            excludedCategoryIDs: [], limit: limit
+        ))
+
+        #expect(hits.movies.count == limit)
+        let matched = names(hits.movies, in: context)
+        #expect(matched.contains { $0.hasPrefix("Zzz") })
+        #expect(matched.filter { $0.hasPrefix("Aaa") }.count == limit - 2)
+    }
+
+    @Test func `results stay in name order after the split`() throws {
+        let container = try makeSQLiteContainer()
+        let context = container.mainContext
+        let limit = 20
+        let (big, small) = try insertTwoCatalogs(context, limit: limit)
+
+        let hits = SearchFetcher.fetch(container: container, request: SearchRequest(
+            query: "matrix", playlistIDs: [big, small],
+            wantMovies: true, wantSeries: false, wantLive: false,
+            excludedCategoryIDs: [], limit: limit
+        ))
+
+        let matched = names(hits.movies, in: context)
+        #expect(matched == matched.sorted { $0.localizedStandardCompare($1) == .orderedAscending })
+    }
+
+    @Test func `a split search still finds uncategorised titles`() throws {
+        let container = try makeSQLiteContainer()
+        let context = container.mainContext
+        let (big, small) = try insertTwoCatalogs(context, limit: 5)
+        // m3u sources don't always supply a category, and a per-playlist fetch
+        // keys off the playlist UUID prefixed onto the category id.
+        context.insert(Movie(id: "orphan", streamId: 999, name: "Bbb Matrix"))
+        try context.save()
+
+        let hits = SearchFetcher.fetch(container: container, request: SearchRequest(
+            query: "matrix", playlistIDs: [big, small],
+            wantMovies: true, wantSeries: false, wantLive: false,
+            excludedCategoryIDs: [], limit: 20
+        ))
+
+        #expect(names(hits.movies, in: context).contains("Bbb Matrix"))
+    }
+
+    @Test func `a single playlist search is unchanged`() throws {
+        let container = try makeSQLiteContainer()
+        let context = container.mainContext
+        let (big, _) = try insertTwoCatalogs(context, limit: 5)
+
+        let hits = SearchFetcher.fetch(container: container, request: SearchRequest(
+            query: "matrix", playlistIDs: [big],
+            wantMovies: true, wantSeries: false, wantLive: false,
+            excludedCategoryIDs: [], limit: 20
+        ))
+
+        #expect(hits.movies.count == 15)
+        #expect(names(hits.movies, in: context).allSatisfy { $0.hasPrefix("Aaa") })
     }
 }


### PR DESCRIPTION
Follow-up to #193, independent of it.

With "Search All Playlists" on, the local pass ran a single fetch over the whole store: `fetchLimit = 50` per content type, `sortBy: name`. The cap is shared, so one catalog whose titles sort early can fill it on its own — and every other playlist comes back empty. On screen that's indistinguishable from the setting not working, which is how this got noticed.

It only bites on broad queries, but that's exactly when someone is browsing rather than looking for a title they can already name.

**The fix:** when several playlists are in scope, run one bounded fetch per playlist instead of one over everything, then spend the budget by rotating between the results. A playlist with two matches still places both; a playlist with hundreds hands its unused share back to the others. What survives the rotation is re-sorted by name, so the list reads exactly as it did before — the rotation decides *which* rows make the cut, not what order they're shown in.

A single-playlist search takes the old path untouched.

**One wrinkle worth calling out:** playlist scoping keys off the playlist UUID prefixed onto every category id, and m3u sources don't always supply a category. Those rows have no prefix to match, so splitting the fetch per playlist would have silently dropped them — they were only ever visible because the cross-playlist fetch was unscoped. They now get a pass of their own, and there's a test pinning it.

**Tests:** four new cases — a small catalog surviving beside one that could fill the budget, name order holding after the split, uncategorised titles still landing, and a single-playlist search returning what it always did.
