### PR TITLE
fix(search): search every Stalker portal, not just the active one

### DIFF
--- a/Lume/Views/SearchFetching.swift
+++ b/Lume/Views/SearchFetching.swift
@@ -139,3 +139,29 @@ nonisolated func searchLiveStreamPredicate(scope: SearchScope) -> Predicate<Live
             && (!filtersCategories || stream.categoryId == nil || !excluded.contains(stream.categoryId))
     }
 }
+
+// MARK: - Interleaving
+
+/// Spends `limit` by taking one element from each list in turn, preserving each
+/// list's own order and dropping repeats. Used for hits from several Stalker
+/// portals: each returns its own relevance ranking, and concatenating them
+/// would bury a second portal's best match under everything the first had to
+/// say. Lists shorter than the rest simply drop out of the rotation.
+nonisolated func interleaved<Element: Hashable>(_ lists: [[Element]], limit: Int) -> [Element] {
+    guard lists.count > 1 else { return Array((lists.first ?? []).prefix(limit)) }
+    var merged: [Element] = []
+    var seen = Set<Element>()
+    var index = 0
+    while merged.count < limit {
+        var advanced = false
+        for list in lists where index < list.count {
+            advanced = true
+            guard seen.insert(list[index]).inserted else { continue }
+            merged.append(list[index])
+            if merged.count == limit { break }
+        }
+        guard advanced, merged.count < limit else { break }
+        index += 1
+    }
+    return merged
+}

--- a/Lume/Views/SearchView.swift
+++ b/Lume/Views/SearchView.swift
@@ -184,12 +184,13 @@ struct SearchView: View {
         let wantLive = filter == .all || filter == .liveTV
 
         // A Stalker portal's movies/series aren't synced locally, so they can
-        // only be found through the portal's own search API. Live TV (which
+        // only be found through the portal's own search API — asked of every
+        // Stalker playlist in scope, not just the active one. Live TV (which
         // *is* synced) and every other source type use the local predicate
         // search. Cross-playlist search still runs the local pass too, so other
         // playlists' synced content is included.
         let usePortalForVODSeries = playlist?.sourceType == .stalker && !searchAllPlaylists
-        let portal = await portalSearch(query: query, playlist: playlist, wantMovies: wantMovies, wantSeries: wantSeries)
+        let portal = await portalSearch(query: query, wantMovies: wantMovies, wantSeries: wantSeries)
         guard !Task.isCancelled else { return }
 
         let localHits = await localSearch(
@@ -203,17 +204,43 @@ struct SearchView: View {
         results = assembleResults(portal: portal, localHits: localHits)
     }
 
-    /// Portal search hits (element ids) for a Stalker active playlist; empty
-    /// otherwise.
+    /// Portal search hits (element ids) from every Stalker playlist in scope.
+    /// A Stalker catalog's movies and series are never synced into the store,
+    /// so the portal's own search API is the only way to reach them — which
+    /// left a non-active Stalker playlist invisible to search whatever
+    /// "Search All Playlists" was set to, since the local pass has nothing of
+    /// its VOD to find.
     private func portalSearch(
-        query: String, playlist: Playlist?, wantMovies: Bool, wantSeries: Bool
+        query: String, wantMovies: Bool, wantSeries: Bool
     ) async -> (movies: [String], series: [String]) {
-        guard let playlist, playlist.sourceType == .stalker, wantMovies || wantSeries else { return ([], []) }
+        let targets = portalPlaylists
+        guard !targets.isEmpty, wantMovies || wantSeries else { return ([], []) }
         let manager = ContentSyncManager(modelContainer: modelContext.container)
-        return await manager.searchStalker(
-            query: query, playlist: playlist,
-            includeMovies: wantMovies, includeSeries: wantSeries, limit: resultLimit
-        )
+        var movies: [[String]] = []
+        var series: [[String]] = []
+        // One portal at a time: these are separate providers, each with its own
+        // connection allowance, and a Stalker middleware is quick to refuse a
+        // second session. The debounce means only a settled query gets here,
+        // and cancellation stops the walk before the next portal is asked.
+        for playlist in targets {
+            guard !Task.isCancelled else { break }
+            let hits = await manager.searchStalker(
+                query: query, playlist: playlist,
+                includeMovies: wantMovies, includeSeries: wantSeries, limit: resultLimit
+            )
+            movies.append(hits.movies)
+            series.append(hits.series)
+        }
+        // Each portal ranks its own hits, so rotate rather than concatenate.
+        return (interleaved(movies, limit: resultLimit), interleaved(series, limit: resultLimit))
+    }
+
+    /// The Stalker playlists this search asks directly: all of them while
+    /// searching across playlists, otherwise the active one if it happens to
+    /// be a portal.
+    private var portalPlaylists: [Playlist] {
+        let candidates = searchAllPlaylists ? playlists : [activePlaylist].compactMap { $0 }
+        return candidates.filter { $0.sourceType == .stalker }
     }
 
     /// Bounded local predicate search, run off the main thread.

--- a/LumeTests/Services/SearchInterleaveTests.swift
+++ b/LumeTests/Services/SearchInterleaveTests.swift
@@ -1,0 +1,41 @@
+//
+//  SearchInterleaveTests.swift
+//  LumeTests
+//
+//  Covers `interleaved(_:limit:)`, the rotation search spends its budget with
+//  when hits arrive from several Stalker portals — each ranks its own results,
+//  so concatenating would bury the second portal's best match.
+//
+
+import Foundation
+@testable import Lume
+import Testing
+
+struct SearchInterleaveTests {
+    @Test func `one list passes through, bounded by the limit`() {
+        #expect(interleaved([["a", "b", "c"]], limit: 2) == ["a", "b"])
+    }
+
+    @Test func `no lists yield nothing`() {
+        #expect(interleaved([[String]](), limit: 5).isEmpty)
+    }
+
+    @Test func `lists alternate so every portal places its best hit`() {
+        let merged = interleaved([["a1", "a2", "a3"], ["b1", "b2", "b3"]], limit: 4)
+        #expect(merged == ["a1", "b1", "a2", "b2"])
+    }
+
+    @Test func `a short list hands its remaining share back`() {
+        let merged = interleaved([["a1", "a2", "a3", "a4"], ["b1"]], limit: 4)
+        #expect(merged == ["a1", "b1", "a2", "a3"])
+    }
+
+    @Test func `an element two portals both return is listed once`() {
+        let merged = interleaved([["shared", "a2"], ["shared", "b2"]], limit: 4)
+        #expect(merged == ["shared", "a2", "b2"])
+    }
+
+    @Test func `the walk ends when every list is spent`() {
+        #expect(interleaved([["a1"], ["b1"]], limit: 50) == ["a1", "b1"])
+    }
+}


### PR DESCRIPTION
Follow-up to #193, independent of it and of #194.

Stalker VOD and series are never synced into the local catalog — `searchStalker` calls the portal's own search API and upserts the hits, which is the only way those titles are reachable. But `portalSearch` only ever asked the **active** playlist:

```swift
guard let playlist, playlist.sourceType == .stalker, wantMovies || wantSeries else { return ([], []) }
```

So a second Stalker playlist's movies and series were invisible to search no matter what "Search All Playlists" was set to. Turning the setting on didn't help — the local pass widens to every playlist, but there's nothing of that portal's VOD in the store for it to find, and nothing else was asking. Its live TV showed up (that *is* synced), which makes the gap look arbitrary from the outside.

`searchStalker` already takes any playlist. It was only the caller that was narrow.

**The fix:** ask every Stalker playlist in scope — all of them when searching across playlists, the active one otherwise.

**Serial, deliberately.** These are separate providers, each with its own connection allowance, and Stalker middleware is quick to refuse a second session. The walk goes one portal at a time and drops out as soon as the query is cancelled, which the 300 ms debounce already makes cheap. Most setups have one Stalker playlist, where nothing changes at all.

**Hits are rotated, not concatenated.** Each portal ranks its own results, so appending them would put the second portal's best match below fifty rows of the first's. `interleaved(_:limit:)` takes one from each in turn and drops repeats.

**Tests:** six cases on the rotation — alternation, a short list handing its share back, dedupe across portals, the limit, and the empty and single-list paths.

*(#194 spends the local fetch budget with the same rotation shape, on typed rows rather than ids. If both land, they're worth collapsing into one helper — kept separate here so neither PR depends on the other.)*
