### PR TITLE
perf(sync): make catalog refresh 4x cheaper and cap the prune sweep's memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,12 @@ Scripts/run-performance-tests.sh ParsingBenchmarks  # one suite
   what the Benchmark configuration exists for.
 - Store benchmarks use **on-disk** containers (`PerfStore`); in-memory skips
   SQLite, the very cost being measured.
+- **`context.save()` is ~90% of catalog import cost.** Optimise how much
+  SwiftData is asked to write, or how often; nothing else moves the number.
+- **Four knobs were measured at full scale and are each under 6%** — `batchSize`
+  (500/2k/10k/50k all within noise), the 11 `#Index` groups on `Movie`,
+  `@Attribute(.unique)`, and the per-batch existing-row lookup. Don't re-derive
+  them; `LumePerformanceTests/README.md` carries the numbers.
 - Fixtures are generated per run from a fixed seed (`PerfFixtures`), never
   committed.
 - App-defined phases are named once in `Services/Diagnostics/PerformanceSignposts.swift`

--- a/Lume.xcodeproj/project.pbxproj
+++ b/Lume.xcodeproj/project.pbxproj
@@ -954,6 +954,35 @@
 			};
 			name = Sideload;
 		};
+		C6BE110000000000000000B5 /* Benchmark */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = LumeWidgets/LumeWidgets.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 19;
+				DEVELOPMENT_TEAM = CHG45F8MCL;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LumeWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Lume;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks @executable_path/../../Frameworks";
+				MARKETING_VERSION = 1.8.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bilipp.lume.LumeWidgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Benchmark;
+		};
 		C67C02F12F880F2400842DBA /* Sideload */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1421,6 +1450,7 @@
 				C6AA31082FDD00020000AB08 /* Debug */,
 				C6AA31092FDD00020000AB09 /* Release */,
 				C6AA310A2FDD00020000AB0A /* Sideload */,
+				C6BE110000000000000000B5 /* Benchmark */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Lume/Services/Debug/DebugLogExporter.swift
+++ b/Lume/Services/Debug/DebugLogExporter.swift
@@ -85,16 +85,26 @@ nonisolated struct DebugLogExporter {
         }
 
         let entries = try store.getEntries(at: position, matching: predicate)
-        return entries
-            .compactMap { $0 as? OSLogEntryLog }
-            .map { entry in
-                let time = Self.entryStamp.string(from: entry.date)
+        return entries.compactMap { entry -> String? in
+            switch entry {
+            case let log as OSLogEntryLog:
+                let time = Self.entryStamp.string(from: log.date)
                 // Last line of defense: even if a future call site accidentally
                 // interpolates a URL with `privacy: .public`, it must not reach
                 // a shared report — stream URLs carry playlist credentials.
-                let message = LogRedaction.scrubURLs(in: entry.composedMessage)
-                return "\(time)  [\(entry.category)] \(Self.label(for: entry.level))  \(message)"
+                let message = LogRedaction.scrubURLs(in: log.composedMessage)
+                return "\(time)  [\(log.category)] \(Self.label(for: log.level))  \(message)"
+            case let signpost as OSLogEntrySignpost:
+                // MetricKit is compiled out on tvOS, so on Apple TV the `Perf`
+                // intervals are the only phase timing a field report can carry.
+                let time = Self.entryStamp.string(from: signpost.date)
+                let message = LogRedaction.scrubURLs(in: signpost.composedMessage)
+                let head = "\(time)  [\(signpost.category)] \(Self.signpostLabel(for: signpost.signpostType))  \(signpost.signpostName) #\(signpost.signpostIdentifier)"
+                return message.isEmpty ? head : "\(head)  \(message)"
+            default:
+                return nil
             }
+        }
     }
 
     /// The debugging session start, floored to `maxLookback` so an ancient
@@ -223,6 +233,16 @@ nonisolated struct DebugLogExporter {
             result.append(Character(UnicodeScalar(UInt8(value))))
         }
         return identifier.isEmpty ? "unknown" : identifier
+    }
+
+    static func signpostLabel(for type: OSLogEntrySignpost.SignpostType) -> String {
+        switch type {
+        case .intervalBegin: "signpost-begin"
+        case .intervalEnd: "signpost-end"
+        case .event: "signpost-event"
+        case .undefined: "signpost"
+        @unknown default: "signpost"
+        }
     }
 
     static func label(for level: OSLogEntryLog.Level) -> String {

--- a/Lume/Services/Diagnostics/PerformanceSignposts.swift
+++ b/Lume/Services/Diagnostics/PerformanceSignposts.swift
@@ -49,6 +49,28 @@ nonisolated extension PerfSignpost {
     static let syncMovies = PerfSignpost("SyncMovies")
     static let syncSeries = PerfSignpost("SyncSeries")
     static let syncLiveStreams = PerfSignpost("SyncLiveStreams")
+
+    // Content sync sub-phases. Nested inside the SyncMovies/SyncSeries/
+    // SyncLiveStreams intervals above, which stay as the outer boundary so
+    // existing traces and benchmark baselines keep resolving.
+    static let xtreamFetchMovies = PerfSignpost("XtreamFetchMovies")
+    static let xtreamDecodeMovies = PerfSignpost("XtreamDecodeMovies")
+    static let upsertMovies = PerfSignpost("UpsertMovies")
+    static let pruneMovies = PerfSignpost("PruneMovies")
+    static let xtreamFetchSeries = PerfSignpost("XtreamFetchSeries")
+    static let xtreamDecodeSeries = PerfSignpost("XtreamDecodeSeries")
+    static let upsertSeries = PerfSignpost("UpsertSeries")
+    static let pruneSeries = PerfSignpost("PruneSeries")
+    static let xtreamFetchLiveStreams = PerfSignpost("XtreamFetchLiveStreams")
+    static let xtreamDecodeLiveStreams = PerfSignpost("XtreamDecodeLiveStreams")
+    static let upsertLiveStreams = PerfSignpost("UpsertLiveStreams")
+    static let pruneLiveStreams = PerfSignpost("PruneLiveStreams")
+
+    /// Only emitted when the sync actually has to wait between content phases
+    /// to respect a provider's one-connection cap — its absence in a trace is
+    /// the signal that the spacing cost nothing.
+    static let xtreamPhaseSpacing = PerfSignpost("XtreamPhaseSpacing")
+
     static let m3uDownload = PerfSignpost("M3UDownload")
     static let m3uImport = PerfSignpost("M3UImport")
 

--- a/Lume/Services/Network/XMLTVParser.swift
+++ b/Lume/Services/Network/XMLTVParser.swift
@@ -1,0 +1,98 @@
+//
+//  XMLTVParser.swift
+//  Lume
+//
+//  Streaming SAX parser for XMLTV EPG payloads
+//
+
+import Foundation
+
+/// A parsed XMLTV programme ready for direct insertion.
+struct ParsedProgramme {
+    let channelId: String
+    let title: String
+    let description: String
+    let start: Date
+    let end: Date
+}
+
+/// Streaming SAX parser that yields batches via a callback to keep memory flat.
+final nonisolated class XMLTVParser: NSObject, XMLParserDelegate {
+    private var batch: [ParsedProgramme] = []
+    private let batchSize: Int
+    private let onBatch: ([ParsedProgramme]) -> Void
+    private(set) var totalCount: Int = 0
+
+    private var currentStart: String?
+    private var currentStop: String?
+    private var currentChannel: String?
+    private var currentTitle: String?
+    private var currentDesc: String?
+    private var currentText: String = ""
+
+    init(batchSize: Int = 2000, onBatch: @escaping ([ParsedProgramme]) -> Void) {
+        self.batchSize = batchSize
+        self.onBatch = onBatch
+    }
+
+    /// Parse an XMLTV file from disk, calling `onBatch` for every `batchSize` programmes.
+    static func parse(fileURL: URL, batchSize: Int = 2000, onBatch: @escaping ([ParsedProgramme]) -> Void) -> Int {
+        guard let xmlParser = XMLParser(contentsOf: fileURL) else { return 0 }
+        let delegate = XMLTVParser(batchSize: batchSize, onBatch: onBatch)
+        xmlParser.delegate = delegate
+        xmlParser.parse()
+        // Flush remaining
+        if !delegate.batch.isEmpty {
+            onBatch(delegate.batch)
+        }
+        return delegate.totalCount
+    }
+
+    func parser(_: XMLParser, didStartElement elementName: String, namespaceURI _: String?, qualifiedName _: String?, attributes attributeDict: [String: String] = [:]) {
+        currentText = ""
+        if elementName == "programme" {
+            currentStart = attributeDict["start"]
+            currentStop = attributeDict["stop"]
+            currentChannel = attributeDict["channel"]
+            currentTitle = nil
+            currentDesc = nil
+        }
+    }
+
+    func parser(_: XMLParser, foundCharacters string: String) {
+        currentText += string
+    }
+
+    func parser(_: XMLParser, didEndElement elementName: String, namespaceURI _: String?, qualifiedName _: String?) {
+        if elementName == "programme" {
+            if let startDate = XMLTVDate.parse(currentStart),
+               let endDate = XMLTVDate.parse(currentStop),
+               let channel = currentChannel,
+               let title = currentTitle, !title.isEmpty
+            {
+                batch.append(ParsedProgramme(
+                    channelId: channel,
+                    title: title,
+                    description: currentDesc ?? "",
+                    start: startDate,
+                    end: endDate
+                ))
+                totalCount += 1
+
+                if batch.count >= batchSize {
+                    onBatch(batch)
+                    batch.removeAll(keepingCapacity: true)
+                }
+            }
+            currentStart = nil
+            currentStop = nil
+            currentChannel = nil
+            currentTitle = nil
+            currentDesc = nil
+        } else if elementName == "title" {
+            currentTitle = (currentTitle ?? "") + currentText
+        } else if elementName == "desc" {
+            currentDesc = (currentDesc ?? "") + currentText
+        }
+    }
+}

--- a/Lume/Services/Network/XtreamClient.swift
+++ b/Lume/Services/Network/XtreamClient.swift
@@ -28,6 +28,12 @@ class XtreamClient: APIClient {
     let configuration: Configuration
     let session: URLSession
 
+    /// When the most recent request released the connection, on a monotonic
+    /// clock. Read by `ContentSyncManager` to space consecutive bulk requests
+    /// apart without re-paying wall clock the sync has already spent elsewhere.
+    /// Stamped on failures too — a 401/403 still occupied the slot.
+    private(set) var lastRequestFinishedAt: ContinuousClock.Instant?
+
     nonisolated init(configuration: Configuration, urlSession: URLSession? = nil) {
         self.configuration = configuration
         session = urlSession ?? Self.makeSession(timeout: configuration.timeout)
@@ -98,6 +104,14 @@ class XtreamClient: APIClient {
         return components?.url
     }
 
+    /// Signposts wrapping the two halves of a bulk request, so a trace can tell
+    /// a slow transfer apart from a slow decode. Only the three catalog
+    /// endpoints supply one; every other call leaves the phases unnamed.
+    nonisolated struct RequestPhases {
+        let fetch: PerfSignpost
+        let decode: PerfSignpost
+    }
+
     /// Maximum number of attempts (1 initial + retries) for a single request.
     private static let maxAttempts = 3
 
@@ -111,17 +125,22 @@ class XtreamClient: APIClient {
     ///   has already proven the credentials, a 401/403 is almost always the
     ///   provider's connection/rate limit rather than bad credentials. Login
     ///   (`getInfo`) leaves it `false` so wrong credentials fail fast.
-    private func request<T: Decodable>(_ url: URL, action: String, retryAuthFailure: Bool = true) async throws -> T {
+    private func request<T: Decodable>(
+        _ url: URL,
+        action: String,
+        retryAuthFailure: Bool = true,
+        phases: RequestPhases? = nil
+    ) async throws -> T {
         var attempt = 0
         while true {
             attempt += 1
             do {
-                return try await performRequest(url)
+                return try await performRequest(url, action: action, phases: phases)
             } catch let error as XtreamError {
                 let retriable = error.isRetriable || (retryAuthFailure && error.isAuthFailure)
                 guard retriable, attempt < Self.maxAttempts else {
                     Logger.network.error(
-                        "Xtream \(action, privacy: .public) request failed permanently (\(error.logDescription, privacy: .public)) after \(attempt) attempt(s)"
+                        "Xtream \(action, privacy: .public) request failed permanently (\(error.logDescription, privacy: .public)) after \(attempt, privacy: .public) attempt(s)"
                     )
                     throw error
                 }
@@ -129,24 +148,49 @@ class XtreamClient: APIClient {
                 // Exponential backoff: 2s, then 4s. Gives the provider time to
                 // release the connection slot / clear the rate-limit window.
                 let delay = pow(2.0, Double(attempt))
+                let reason = error.logDescription
+                let retryLabel = "\(attempt)/\(Self.maxAttempts - 1)"
                 Logger.network.warning(
-                    "Xtream \(action, privacy: .public) request failed (\(error.logDescription, privacy: .public)); retry \(attempt)/\(Self.maxAttempts - 1) in \(delay)s"
+                    "Xtream \(action, privacy: .public) failed (\(reason, privacy: .public)); retry \(retryLabel, privacy: .public) after \(delay, privacy: .public)s"
                 )
                 try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                Logger.network.warning(
+                    "Xtream \(action, privacy: .public) backoff of \(delay, privacy: .public)s elapsed; retrying (attempt \(attempt + 1, privacy: .public))"
+                )
             }
         }
     }
 
     /// A single request attempt. Network-level failures are wrapped into
     /// `XtreamError.networkError` so callers see a consistent error type.
-    private func performRequest<T: Decodable>(_ url: URL) async throws -> T {
+    private func performRequest<T: Decodable>(_ url: URL, action: String, phases: RequestPhases? = nil) async throws -> T {
+        #if DEBUG
+            // VERIFIED, not defensive: `XtreamClient` declares no isolation, so
+            // `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` infers `@MainActor` for the
+            // whole type (unlike the sibling `nonisolated class M3UClient`). This
+            // holds even when the caller is `actor ContentSyncManager`, and the body
+            // never leaves that domain, so the bulk transfer's continuation and the
+            // multi-hundred-thousand-element `decoder.decode` below both run on the
+            // main actor. Remove only together with making the type `nonisolated`.
+            MainActor.assertIsolated("XtreamClient.performRequest runs on the main actor")
+        #endif
         let data: Data
         let response: URLResponse
+        let fetchInterval = phases.map { Perf.begin($0.fetch) }
         do {
             (data, response) = try await session.data(from: url)
         } catch {
+            if let fetchInterval { Perf.end(fetchInterval) }
+            lastRequestFinishedAt = ContinuousClock.now
             throw XtreamError.networkError(error)
         }
+        if let fetchInterval { Perf.end(fetchInterval) }
+        lastRequestFinishedAt = ContinuousClock.now
+
+        let byteCount = data.count
+        Logger.network.info(
+            "Xtream \(action, privacy: .public) payload \(byteCount, privacy: .public) bytes"
+        )
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw XtreamError.invalidResponse
@@ -160,6 +204,8 @@ class XtreamClient: APIClient {
             throw XtreamError.serverError(httpResponse.statusCode)
         }
 
+        let decodeInterval = phases.map { Perf.begin($0.decode) }
+        defer { if let decodeInterval { Perf.end(decodeInterval) } }
         do {
             let decoder = JSONDecoder()
             return try decoder.decode(T.self, from: data)
@@ -216,7 +262,7 @@ class XtreamClient: APIClient {
             throw XtreamError.invalidURL
         }
 
-        let list: XtreamList<XtreamLiveStream> = try await request(url, action: "get_live_streams")
+        let list: XtreamList<XtreamLiveStream> = try await request(url, action: "get_live_streams", phases: RequestPhases(fetch: .xtreamFetchLiveStreams, decode: .xtreamDecodeLiveStreams))
         return list.items
     }
 
@@ -251,7 +297,7 @@ class XtreamClient: APIClient {
             throw XtreamError.invalidURL
         }
 
-        let list: XtreamList<XtreamVODStream> = try await request(url, action: "get_vod_streams")
+        let list: XtreamList<XtreamVODStream> = try await request(url, action: "get_vod_streams", phases: RequestPhases(fetch: .xtreamFetchMovies, decode: .xtreamDecodeMovies))
         return list.items
     }
 
@@ -302,7 +348,7 @@ class XtreamClient: APIClient {
             throw XtreamError.invalidURL
         }
 
-        let list: XtreamList<XtreamSeries> = try await request(url, action: "get_series")
+        let list: XtreamList<XtreamSeries> = try await request(url, action: "get_series", phases: RequestPhases(fetch: .xtreamFetchSeries, decode: .xtreamDecodeSeries))
         return list.items
     }
 
@@ -449,98 +495,6 @@ class XtreamClient: APIClient {
         let ext = Self.resolvedFormat(format, playlist: playlist, fallback: .tsStream).rawValue
         let startString = Self.timeshiftStartString(for: start, playlist: playlist)
         return URL(string: "\(playlist.serverURL)/timeshift/\(playlist.username)/\(playlist.password)/\(durationMinutes)/\(startString)/\(stream.streamId).\(ext)")
-    }
-}
-
-// MARK: - XMLTV Parser
-
-/// A parsed XMLTV programme ready for direct insertion.
-struct ParsedProgramme {
-    let channelId: String
-    let title: String
-    let description: String
-    let start: Date
-    let end: Date
-}
-
-/// Streaming SAX parser that yields batches via a callback to keep memory flat.
-final nonisolated class XMLTVParser: NSObject, XMLParserDelegate {
-    private var batch: [ParsedProgramme] = []
-    private let batchSize: Int
-    private let onBatch: ([ParsedProgramme]) -> Void
-    private(set) var totalCount: Int = 0
-
-    private var currentStart: String?
-    private var currentStop: String?
-    private var currentChannel: String?
-    private var currentTitle: String?
-    private var currentDesc: String?
-    private var currentText: String = ""
-
-    init(batchSize: Int = 2000, onBatch: @escaping ([ParsedProgramme]) -> Void) {
-        self.batchSize = batchSize
-        self.onBatch = onBatch
-    }
-
-    /// Parse an XMLTV file from disk, calling `onBatch` for every `batchSize` programmes.
-    static func parse(fileURL: URL, batchSize: Int = 2000, onBatch: @escaping ([ParsedProgramme]) -> Void) -> Int {
-        guard let xmlParser = XMLParser(contentsOf: fileURL) else { return 0 }
-        let delegate = XMLTVParser(batchSize: batchSize, onBatch: onBatch)
-        xmlParser.delegate = delegate
-        xmlParser.parse()
-        // Flush remaining
-        if !delegate.batch.isEmpty {
-            onBatch(delegate.batch)
-        }
-        return delegate.totalCount
-    }
-
-    func parser(_: XMLParser, didStartElement elementName: String, namespaceURI _: String?, qualifiedName _: String?, attributes attributeDict: [String: String] = [:]) {
-        currentText = ""
-        if elementName == "programme" {
-            currentStart = attributeDict["start"]
-            currentStop = attributeDict["stop"]
-            currentChannel = attributeDict["channel"]
-            currentTitle = nil
-            currentDesc = nil
-        }
-    }
-
-    func parser(_: XMLParser, foundCharacters string: String) {
-        currentText += string
-    }
-
-    func parser(_: XMLParser, didEndElement elementName: String, namespaceURI _: String?, qualifiedName _: String?) {
-        if elementName == "programme" {
-            if let startDate = XMLTVDate.parse(currentStart),
-               let endDate = XMLTVDate.parse(currentStop),
-               let channel = currentChannel,
-               let title = currentTitle, !title.isEmpty
-            {
-                batch.append(ParsedProgramme(
-                    channelId: channel,
-                    title: title,
-                    description: currentDesc ?? "",
-                    start: startDate,
-                    end: endDate
-                ))
-                totalCount += 1
-
-                if batch.count >= batchSize {
-                    onBatch(batch)
-                    batch.removeAll(keepingCapacity: true)
-                }
-            }
-            currentStart = nil
-            currentStop = nil
-            currentChannel = nil
-            currentTitle = nil
-            currentDesc = nil
-        } else if elementName == "title" {
-            currentTitle = (currentTitle ?? "") + currentText
-        } else if elementName == "desc" {
-            currentDesc = (currentDesc ?? "") + currentText
-        }
     }
 }
 

--- a/Lume/Services/Network/XtreamDTOs.swift
+++ b/Lume/Services/Network/XtreamDTOs.swift
@@ -65,6 +65,7 @@ struct XtreamList<Element: Decodable>: Decodable {
     init(from decoder: Decoder) throws {
         if var unkeyed = try? decoder.unkeyedContainer() {
             var result: [Element] = []
+            if let count = unkeyed.count { result.reserveCapacity(count) }
             var firstError: Error?
             while !unkeyed.isAtEnd {
                 do {
@@ -86,6 +87,7 @@ struct XtreamList<Element: Decodable>: Decodable {
             ($0.intValue ?? .max, $0.stringValue) < ($1.intValue ?? .max, $1.stringValue)
         }
         var result: [Element] = []
+        result.reserveCapacity(sortedKeys.count)
         var firstError: Error?
         for key in sortedKeys {
             do {

--- a/Lume/Services/Sync/ContentSyncManager+Helpers.swift
+++ b/Lume/Services/Sync/ContentSyncManager+Helpers.swift
@@ -133,49 +133,110 @@ extension ContentSyncManager {
 
     /// Copies the provider-owned fields from a movie DTO onto an existing or
     /// freshly-inserted `Movie`, leaving user state and TMDB enrichment intact.
-    func applyMovieFields(from dto: XtreamVODStream, to movie: Movie, playlistPrefix: String) {
-        movie.name = dto.name ?? ""
-        movie.streamIcon = dto.streamIcon
-        movie.rating = dto.rating ?? 0
-        movie.rating5Based = dto.rating5Based ?? 0
-        movie.added = dto.added
-        movie.containerExtension = dto.containerExtension
-        movie.tmdb = dto.tmdb
-        movie.num = dto.num ?? 0
-        movie.isAdult = dto.isAdult ?? 0
+    ///
+    /// Every write is guarded by an inequality test. SwiftData marks a row dirty
+    /// on *assignment*, not on change, so re-writing an identical value makes
+    /// `save()` rewrite (and re-index) the whole row — the dominant cost of a
+    /// re-sync where almost nothing changed.
+    ///
+    /// The guards must compare exactly what the unguarded assignment would have
+    /// stored: `nil` and `""` are distinct values here (the provider sends both,
+    /// and the lenient decoders preserve the difference), and the `Double`
+    /// comparisons must stay exact. Any tolerance — treating empty as nil,
+    /// rounding a rating — silently *stops* applying a legitimate provider
+    /// update, which is harder to notice than the reverse.
+    ///
+    /// The cyclomatic-complexity opt-out below is deliberate: this is a flat
+    /// field copy with one independent guard per provider field, not branching
+    /// logic.
+    func applyMovieFields(from dto: XtreamVODStream, to movie: Movie, playlistPrefix: String) { // swiftlint:disable:this cyclomatic_complexity
+        let name = dto.name ?? ""
+        if movie.name != name { movie.name = name }
+        if movie.streamIcon != dto.streamIcon { movie.streamIcon = dto.streamIcon }
+        let rating = dto.rating ?? 0
+        if movie.rating != rating { movie.rating = rating }
+        let rating5Based = dto.rating5Based ?? 0
+        if movie.rating5Based != rating5Based { movie.rating5Based = rating5Based }
+        if movie.added != dto.added { movie.added = dto.added }
+        if movie.containerExtension != dto.containerExtension { movie.containerExtension = dto.containerExtension }
+        if movie.tmdb != dto.tmdb { movie.tmdb = dto.tmdb }
+        let num = dto.num ?? 0
+        if movie.num != num { movie.num = num }
+        let isAdult = dto.isAdult ?? 0
+        if movie.isAdult != isAdult { movie.isAdult = isAdult }
 
         if let catIdStr = dto.categoryId {
-            movie.categoryId = playlistPrefix + catIdStr
+            let categoryId = playlistPrefix + catIdStr
+            if movie.categoryId != categoryId { movie.categoryId = categoryId }
         }
-        if let tmdbString = dto.tmdb, let tmdbInt = Int(tmdbString) {
+        if let tmdbString = dto.tmdb, let tmdbInt = Int(tmdbString), movie.tmdbId != tmdbInt {
             movie.tmdbId = tmdbInt
         }
     }
 
     /// Copies the provider-owned fields from a series DTO onto an existing or
     /// freshly-inserted `Series`, leaving user state and TMDB enrichment intact.
-    func applySeriesFields(from dto: XtreamSeries, to series: Series, playlistPrefix: String) {
-        series.name = dto.name ?? ""
-        series.cover = dto.cover
-        series.plot = dto.plot
-        series.cast = dto.cast
-        series.director = dto.director
+    ///
+    /// Dirty-checked for the same reason, and under the same exactness rules, as
+    /// `applyMovieFields`, including the complexity opt-out. `rating` and
+    /// `rating5Based` are stored as the provider's own strings here, so no
+    /// numeric normalisation applies — `"7"` and `"7.0"` are different values
+    /// and must stay so.
+    func applySeriesFields(from dto: XtreamSeries, to series: Series, playlistPrefix: String) { // swiftlint:disable:this cyclomatic_complexity
+        let name = dto.name ?? ""
+        if series.name != name { series.name = name }
+        if series.cover != dto.cover { series.cover = dto.cover }
+        if series.plot != dto.plot { series.plot = dto.plot }
+        if series.cast != dto.cast { series.cast = dto.cast }
+        if series.director != dto.director { series.director = dto.director }
         // Provider genre is the fallback only: it seeds an unset genre but never
         // overwrites one TMDB has supplied — TMDB is the primary source (see
-        // `GenreParser.providerFallback`).
-        series.genre = GenreParser.providerFallback(current: series.genre, provider: dto.genre)
-        series.releaseDate = dto.releaseDate
-        series.lastModified = dto.lastModified
-        series.rating = dto.rating
-        series.rating5Based = dto.rating5Based
-        series.tmdb = dto.tmdb
-        series.num = dto.num ?? 0
+        // `GenreParser.providerFallback`). The guard therefore compares the
+        // computed result; comparing `dto.genre` would rewrite every
+        // TMDB-enriched row on every sync and never settle.
+        let genre = GenreParser.providerFallback(current: series.genre, provider: dto.genre)
+        if series.genre != genre { series.genre = genre }
+        if series.releaseDate != dto.releaseDate { series.releaseDate = dto.releaseDate }
+        if series.lastModified != dto.lastModified { series.lastModified = dto.lastModified }
+        if series.rating != dto.rating { series.rating = dto.rating }
+        if series.rating5Based != dto.rating5Based { series.rating5Based = dto.rating5Based }
+        if series.tmdb != dto.tmdb { series.tmdb = dto.tmdb }
+        let num = dto.num ?? 0
+        if series.num != num { series.num = num }
 
         if let catIdStr = dto.categoryId {
-            series.categoryId = playlistPrefix + catIdStr
+            let categoryId = playlistPrefix + catIdStr
+            if series.categoryId != categoryId { series.categoryId = categoryId }
         }
-        if let tmdbString = dto.tmdb, let tmdbInt = Int(tmdbString) {
+        if let tmdbString = dto.tmdb, let tmdbInt = Int(tmdbString), series.tmdbId != tmdbInt {
             series.tmdbId = tmdbInt
+        }
+    }
+
+    /// Copies the provider-owned fields from a live-stream DTO onto an existing
+    /// or freshly-inserted `LiveStream`, leaving user state intact.
+    ///
+    /// Dirty-checked for the same reason, and under the same exactness rules, as
+    /// `applyMovieFields`, including the complexity opt-out.
+    func applyLiveStreamFields(from dto: XtreamLiveStream, to stream: LiveStream, playlistPrefix: String) { // swiftlint:disable:this cyclomatic_complexity
+        let name = dto.name ?? ""
+        if stream.name != name { stream.name = name }
+        if stream.streamIcon != dto.streamIcon { stream.streamIcon = dto.streamIcon }
+        if stream.epgChannelId != dto.epgChannelId { stream.epgChannelId = dto.epgChannelId }
+        if stream.added != dto.added { stream.added = dto.added }
+        if stream.customSid != dto.customSid { stream.customSid = dto.customSid }
+        let tvArchive = dto.tvArchive ?? 0
+        if stream.tvArchive != tvArchive { stream.tvArchive = tvArchive }
+        let tvArchiveDuration = dto.tvArchiveDuration ?? 0
+        if stream.tvArchiveDuration != tvArchiveDuration { stream.tvArchiveDuration = tvArchiveDuration }
+        let isAdult = dto.isAdult ?? 0
+        if stream.isAdult != isAdult { stream.isAdult = isAdult }
+        let num = dto.num ?? 0
+        if stream.num != num { stream.num = num }
+
+        if let catIdStr = dto.categoryId {
+            let categoryId = playlistPrefix + catIdStr
+            if stream.categoryId != categoryId { stream.categoryId = categoryId }
         }
     }
 

--- a/Lume/Services/Sync/ContentSyncManager+PhaseSpacing.swift
+++ b/Lume/Services/Sync/ContentSyncManager+PhaseSpacing.swift
@@ -1,0 +1,63 @@
+//
+//  ContentSyncManager+PhaseSpacing.swift
+//  Lume
+//
+//  Spacing between the Xtream content phases' bulk requests.
+//
+
+import Foundation
+import OSLog
+
+extension ContentSyncManager {
+    /// Minimum gap between one content phase's last request and the next
+    /// phase's first.
+    static let contentPhaseRequestSpacing: Duration = .seconds(2)
+
+    /// How much of `contentPhaseRequestSpacing` is still outstanding.
+    ///
+    /// Measured from when the request *finished*, not from when the phase
+    /// returned — a phase spends tens of seconds decoding and writing after its
+    /// download, and that time already spaces the requests. `nil` means nothing
+    /// has been requested yet and nothing has to be spaced.
+    nonisolated static func outstandingPhaseSpacing(
+        since lastRequestFinishedAt: ContinuousClock.Instant?,
+        now: ContinuousClock.Instant = ContinuousClock.now
+    ) -> Duration {
+        guard let lastRequestFinishedAt else { return .zero }
+        let remaining = contentPhaseRequestSpacing - (now - lastRequestFinishedAt)
+        // Clamped at both ends: a negative gap means the spacing is already
+        // paid for, and a clock that jumped backwards must not inflate it past
+        // the configured spacing.
+        return max(.zero, min(contentPhaseRequestSpacing, remaining))
+    }
+
+    /// Waits out whatever spacing the previous content phase did not already
+    /// pay for, so the next bulk request does not race the provider's
+    /// connection slot.
+    ///
+    /// Many Xtream accounts cap `max_connections` to 1 — which is why
+    /// `XtreamClient.makeSession` pins the session to one connection per host
+    /// and why `EPGSyncService.isContentSyncPending` stands down for the same
+    /// slot. A request fired before the provider has released the previous
+    /// connection comes back 401/403, and
+    /// `XtreamClient.request(_:action:retryAuthFailure:)` then burns 2 s + 4 s
+    /// of backoff on it, or the phase returns short and feeds the prune sweep a
+    /// partial catalog. So the gap is enforced, but only against wall clock the
+    /// sync has not already spent: a slow device pays nothing here, a fast one
+    /// still spaces its requests.
+    func spaceContentPhaseRequests() async throws {
+        let remaining = await Self.outstandingPhaseSpacing(since: xtreamClient.lastRequestFinishedAt)
+        guard remaining > .zero else {
+            Logger.database.info("Xtream phase spacing already elapsed; continuing immediately")
+            return
+        }
+        let seconds = Double(remaining.components.seconds)
+            + Double(remaining.components.attoseconds) / 1e18
+        Logger.database.info(
+            "Xtream phase spacing: waiting \(seconds, privacy: .public)s for the provider connection slot"
+        )
+        let interval = Perf.begin(.xtreamPhaseSpacing)
+        defer { Perf.end(interval) }
+        try await Task.sleep(for: remaining)
+    }
+}

--- a/Lume/Services/Sync/ContentSyncManager+Prune.swift
+++ b/Lume/Services/Sync/ContentSyncManager+Prune.swift
@@ -10,14 +10,19 @@
 //  indexer keeps resolving dead titles; browsing shows content that 404s on
 //  playback).
 //
-//  Each sync builds the set of ids the provider returned for a content kind
-//  ("seen"), then sweeps the playlist's local rows of that kind, deleting any id
-//  not in the set. Episodes cascade from their `Series`; cast cascades from its
-//  parent — same cascade `PlaylistDeletion` relies on.
+//  Each sync accumulates the set of ids the provider returned for a content
+//  kind ("seen") as it writes the batches, then sweeps the playlist's local rows
+//  of that kind, deleting any id not in the set. Episodes cascade from their
+//  `Series`; cast cascades from its parent — same cascade `PlaylistDeletion`
+//  relies on.
 //
 //  SAFETY: a sweep against an empty/partial fetch would wipe the playlist's
 //  catalog, so the *caller* must gate the sweep on a healthy fetch (see the
 //  guards in syncMovies/…/importM3UFile) before handing a `seenIds` set here.
+//  The Xtream entry points below add a second gate: `XtreamList` drops the
+//  elements that fail to decode and only rethrows when *every* element fails,
+//  so a mostly-malformed payload arrives as a small non-empty array whose
+//  row count alone would wave the sweep through (see `sweepIsSafe`).
 //  Pruning is confined to the local-only catalog store, so a delete never
 //  propagates to CloudKit; and user state (favorites, progress, watchlist)
 //  lives in `UserContentState` in the cloud mirror keyed by `contentId`, so it
@@ -31,35 +36,44 @@ import SwiftData
 extension ContentSyncManager {
     // MARK: - Xtream sweep entry points
 
-    // These wrap the per-kind sweep with the seen-set construction and the
-    // non-empty-fetch guard, so the batch-sync functions stay a single call.
-    // A working Xtream provider never returns zero of a kind, so an empty fetch
-    // is a transient failure — skipping the sweep then keeps the library.
+    // These wrap the per-kind sweep with the non-empty-fetch guard and the
+    // coverage check, so the batch-sync functions stay a single call. A working
+    // Xtream provider never returns zero of a kind, so an empty fetch is a
+    // transient failure — skipping the sweep then keeps the library.
+    //
+    // `seenIds` is accumulated by the caller's batch loop rather than derived
+    // from the DTO array here: holding the decoded payload alive across the
+    // sweep is what put the content phases in jetsam range on an Apple TV.
+    // `fetchedCount` carries the payload's row count, which the array no longer
+    // can once it has been released.
 
-    func pruneMovies(playlistId: UUID, against movieDTOs: [XtreamVODStream]) {
-        guard !movieDTOs.isEmpty else { return }
-        let seenIds = Set(movieDTOs.compactMap { dto -> String? in
-            guard let streamId = dto.streamId else { return nil }
-            return "\(playlistId.uuidString)-movie-\(streamId)"
-        })
+    func pruneMovies(playlistId: UUID, seenIds: Set<String>, fetchedCount: Int) {
+        guard fetchedCount > 0 else { return }
+        let prefix = playlistId.uuidString
+        let scope = FetchDescriptor<Movie>(predicate: #Predicate { $0.id.starts(with: prefix) })
+        guard sweepIsAllowed(playlistId: playlistId, kind: "movie", seenCount: seenIds.count, storedMatching: scope) else {
+            return
+        }
         pruneStaleMovies(playlistId: playlistId, seenIds: seenIds)
     }
 
-    func pruneSeries(playlistId: UUID, against seriesDTOs: [XtreamSeries]) {
-        guard !seriesDTOs.isEmpty else { return }
-        let seenIds = Set(seriesDTOs.compactMap { dto -> String? in
-            guard let seriesId = dto.seriesId else { return nil }
-            return "\(playlistId.uuidString)-series-\(seriesId)"
-        })
+    func pruneSeries(playlistId: UUID, seenIds: Set<String>, fetchedCount: Int) {
+        guard fetchedCount > 0 else { return }
+        let prefix = playlistId.uuidString
+        let scope = FetchDescriptor<Series>(predicate: #Predicate { $0.id.starts(with: prefix) })
+        guard sweepIsAllowed(playlistId: playlistId, kind: "series", seenCount: seenIds.count, storedMatching: scope) else {
+            return
+        }
         pruneStaleSeries(playlistId: playlistId, seenIds: seenIds)
     }
 
-    func pruneLiveStreams(playlistId: UUID, against streamDTOs: [XtreamLiveStream]) {
-        guard !streamDTOs.isEmpty else { return }
-        let seenIds = Set(streamDTOs.compactMap { dto -> String? in
-            guard let streamId = dto.streamId else { return nil }
-            return "\(playlistId.uuidString)-live-\(streamId)"
-        })
+    func pruneLiveStreams(playlistId: UUID, seenIds: Set<String>, fetchedCount: Int) {
+        guard fetchedCount > 0 else { return }
+        let prefix = playlistId.uuidString
+        let scope = FetchDescriptor<LiveStream>(predicate: #Predicate { $0.id.starts(with: prefix) })
+        guard sweepIsAllowed(playlistId: playlistId, kind: "live", seenCount: seenIds.count, storedMatching: scope) else {
+            return
+        }
         pruneStaleLiveStreams(playlistId: playlistId, seenIds: seenIds)
     }
 
@@ -67,63 +81,54 @@ extension ContentSyncManager {
 
     /// Deletes movies for `playlistId` whose id is absent from `seenIds`.
     func pruneStaleMovies(playlistId: UUID, seenIds: Set<String>) {
-        let context = ModelContext(modelContainer)
-        context.autosaveEnabled = false
-
         // Scope to the playlist via its UUID, which anchors every id this
         // playlist produced (see PlaylistDeletion). `starts(with:)` compiles to
         // a range seek on the unique `id` index; the substring match used before
         // was a LIKE-%…% scan that touched every row on each sync's sweep.
         let prefix = playlistId.uuidString
-        let descriptor = FetchDescriptor<Movie>(
-            predicate: #Predicate { $0.id.starts(with: prefix) }
-        )
-        var removed = 0
-        for movie in (try? context.fetch(descriptor)) ?? [] where !seenIds.contains(movie.id) {
-            context.delete(movie)
-            removed += 1
-        }
+        let removed = sweepPaged(after: prefix, seenIds: seenIds, idOf: { (movie: Movie) in movie.id }, page: { cursor, limit in
+            var descriptor = FetchDescriptor<Movie>(
+                predicate: #Predicate { $0.id.starts(with: prefix) && $0.id > cursor },
+                sortBy: [SortDescriptor(\.id)]
+            )
+            descriptor.fetchLimit = limit
+            return descriptor
+        })
         guard removed > 0 else { return }
-        try? context.save()
         Logger.database.info("Pruned \(removed) stale movie(s) for playlist \(prefix)")
     }
 
     /// Deletes series for `playlistId` whose id is absent from `seenIds`. Each
-    /// removed series' episodes and cast cascade from the series.
+    /// removed series' episodes and cast cascade from the series — which is why
+    /// the sweep deletes row by row instead of `delete(model:where:)`, whose
+    /// bulk delete would leave those children (and the watch progress on them)
+    /// orphaned.
     func pruneStaleSeries(playlistId: UUID, seenIds: Set<String>) {
-        let context = ModelContext(modelContainer)
-        context.autosaveEnabled = false
-
         let prefix = playlistId.uuidString
-        let descriptor = FetchDescriptor<Series>(
-            predicate: #Predicate { $0.id.starts(with: prefix) }
-        )
-        var removed = 0
-        for show in (try? context.fetch(descriptor)) ?? [] where !seenIds.contains(show.id) {
-            context.delete(show)
-            removed += 1
-        }
+        let removed = sweepPaged(after: prefix, seenIds: seenIds, idOf: { (show: Series) in show.id }, page: { cursor, limit in
+            var descriptor = FetchDescriptor<Series>(
+                predicate: #Predicate { $0.id.starts(with: prefix) && $0.id > cursor },
+                sortBy: [SortDescriptor(\.id)]
+            )
+            descriptor.fetchLimit = limit
+            return descriptor
+        })
         guard removed > 0 else { return }
-        try? context.save()
         Logger.database.info("Pruned \(removed) stale series for playlist \(prefix)")
     }
 
     /// Deletes live streams for `playlistId` whose id is absent from `seenIds`.
     func pruneStaleLiveStreams(playlistId: UUID, seenIds: Set<String>) {
-        let context = ModelContext(modelContainer)
-        context.autosaveEnabled = false
-
         let prefix = playlistId.uuidString
-        let descriptor = FetchDescriptor<LiveStream>(
-            predicate: #Predicate { $0.id.starts(with: prefix) }
-        )
-        var removed = 0
-        for stream in (try? context.fetch(descriptor)) ?? [] where !seenIds.contains(stream.id) {
-            context.delete(stream)
-            removed += 1
-        }
+        let removed = sweepPaged(after: prefix, seenIds: seenIds, idOf: { (stream: LiveStream) in stream.id }, page: { cursor, limit in
+            var descriptor = FetchDescriptor<LiveStream>(
+                predicate: #Predicate { $0.id.starts(with: prefix) && $0.id > cursor },
+                sortBy: [SortDescriptor(\.id)]
+            )
+            descriptor.fetchLimit = limit
+            return descriptor
+        })
         guard removed > 0 else { return }
-        try? context.save()
         Logger.database.info("Pruned \(removed) stale live stream(s) for playlist \(prefix)")
     }
 
@@ -132,22 +137,18 @@ extension ContentSyncManager {
     /// are imported alongside the rest of the catalog; the Xtream pipeline pulls
     /// episodes lazily per-series and so isn't swept here.
     func pruneStaleEpisodes(playlistId: UUID, seenIds: Set<String>) {
-        let context = ModelContext(modelContainer)
-        context.autosaveEnabled = false
-
         // Episode.id is "\(seriesId)-episode-…" and seriesId starts with the
         // playlist UUID, so the same prefix scope applies.
         let prefix = playlistId.uuidString
-        let descriptor = FetchDescriptor<Episode>(
-            predicate: #Predicate { $0.id.starts(with: prefix) }
-        )
-        var removed = 0
-        for episode in (try? context.fetch(descriptor)) ?? [] where !seenIds.contains(episode.id) {
-            context.delete(episode)
-            removed += 1
-        }
+        let removed = sweepPaged(after: prefix, seenIds: seenIds, idOf: { (episode: Episode) in episode.id }, page: { cursor, limit in
+            var descriptor = FetchDescriptor<Episode>(
+                predicate: #Predicate { $0.id.starts(with: prefix) && $0.id > cursor },
+                sortBy: [SortDescriptor(\.id)]
+            )
+            descriptor.fetchLimit = limit
+            return descriptor
+        })
         guard removed > 0 else { return }
-        try? context.save()
         Logger.database.info("Pruned \(removed) stale episode(s) for playlist \(prefix)")
     }
 
@@ -176,5 +177,151 @@ extension ContentSyncManager {
         guard removed > 0 else { return }
         try? context.save()
         Logger.database.info("Pruned \(removed) stale \(typeRaw) category/ies for playlist \(prefix)")
+    }
+
+    // MARK: - Paged sweep
+
+    /// Deletes the rows `page` returns that `seenIds` doesn't cover, one page at
+    /// a time, and answers how many went.
+    ///
+    /// Paging is what keeps the sweep off the heap: fetching a playlist's whole
+    /// catalog materialised every row as a managed object — 178k VOD rows cost
+    /// ~1.2 GB peak even when nothing was deleted. Each page runs on its own
+    /// `ModelContext` inside an `autoreleasepool`, so a page's objects are gone
+    /// before the next one is read.
+    ///
+    /// Pages are keyed on the last id seen, never on `fetchOffset`: an offset
+    /// makes the store walk the rows it is skipping, which turned the same sweep
+    /// into ~99 s of index scanning (against 9 s for the single unbounded
+    /// fetch). Seeking on `id` instead is also what makes deleting while paging
+    /// sound — every row a page removes sorts at or before the cursor, so it
+    /// cannot displace a row the next page has yet to see. `page` must therefore
+    /// ask for `id > cursor` ordered by `id`, and `after` must be a string that
+    /// sorts before every id in scope (the playlist prefix does: a prefix sorts
+    /// before anything extending it). The cursor strictly increases each pass
+    /// and a short page means the rows ran out, so the loop terminates.
+    private func sweepPaged<T: PersistentModel>(
+        after: String,
+        seenIds: Set<String>,
+        idOf: (T) -> String,
+        pageSize: Int = 2000,
+        page: (_ cursor: String, _ limit: Int) -> FetchDescriptor<T>
+    ) -> Int {
+        var cursor = after
+        var totalRemoved = 0
+
+        while true {
+            var fetched = 0
+            var removed = 0
+
+            autoreleasepool {
+                let context = ModelContext(modelContainer)
+                context.autosaveEnabled = false
+
+                let rows = (try? context.fetch(page(cursor, pageSize))) ?? []
+                fetched = rows.count
+                if let last = rows.last { cursor = idOf(last) }
+
+                for row in rows where !seenIds.contains(idOf(row)) {
+                    context.delete(row)
+                    removed += 1
+                }
+                if removed > 0 { try? context.save() }
+            }
+
+            totalRemoved += removed
+            if fetched < pageSize { break }
+        }
+
+        return totalRemoved
+    }
+
+    /// Whether a provider payload accounts for enough of the rows already stored
+    /// to be trusted to drive a sweep.
+    ///
+    /// `XtreamList` drops elements that fail to decode and rethrows only when
+    /// *every* element fails, so a payload whose rows are mostly malformed
+    /// arrives as a small non-empty array that the callers' `isEmpty` guards let
+    /// through — and sweeping against it would delete nearly the whole catalog
+    /// along with the enrichment and ordering on those rows.
+    ///
+    /// This test alone is not enough to decide, because it compares the payload
+    /// against the rows already stored and those rows only ever fall when a
+    /// sweep runs: a library that legitimately shrinks past the floor would fail
+    /// the check on every future sync too, and keep its dead rows forever. See
+    /// `sweepIsAllowed` for the bounded tolerance that resolves it. Counting is
+    /// an aggregate query, so it costs no materialised rows.
+    private func sweepIsSafe(
+        seenCount: Int,
+        storedMatching descriptor: FetchDescriptor<some PersistentModel>,
+        minimumCoverage: Double = 0.1
+    ) -> Bool {
+        let context = ModelContext(modelContainer)
+        guard let stored = try? context.fetchCount(descriptor) else { return false }
+        return Double(seenCount) >= Double(stored) * minimumCoverage
+    }
+
+    /// Consecutive low-coverage payloads tolerated before a sweep runs anyway.
+    ///
+    /// Two syncs of protection: a malformed payload is transient and will not
+    /// repeat this many times, while a real shrink repeats every sync and so
+    /// converges on the third.
+    private static let maximumConsecutiveSweepSkips = 2
+
+    /// Whether to sweep, given the coverage test and how often it has already
+    /// refused for this playlist and kind.
+    ///
+    /// `sweepIsSafe` protects the catalog from a payload whose rows mostly
+    /// failed to decode. On its own it is a trap: coverage is measured against
+    /// the stored rows, which a skipped sweep never reduces, so a subscription
+    /// that legitimately shrinks below the floor — a downgraded plan, a provider
+    /// that replaced its lineup — would be refused on every subsequent sync and
+    /// strand the dead rows permanently. Counting the consecutive refusals and
+    /// letting the sweep through after a bounded number keeps the protection
+    /// against a bad payload while still converging on a real shrink.
+    ///
+    /// The count is kept in `UserDefaults` rather than in memory because a sync
+    /// commonly follows a fresh launch, and an in-memory counter would reset
+    /// before it ever reached the limit.
+    private func sweepIsAllowed(
+        playlistId: UUID,
+        kind: String,
+        seenCount: Int,
+        storedMatching descriptor: FetchDescriptor<some PersistentModel>
+    ) -> Bool {
+        let prefix = playlistId.uuidString
+        if sweepIsSafe(seenCount: seenCount, storedMatching: descriptor) {
+            clearSweepSkips(playlistId: playlistId, kind: kind)
+            return true
+        }
+
+        let skips = recordSweepSkip(playlistId: playlistId, kind: kind)
+        guard skips > Self.maximumConsecutiveSweepSkips else {
+            Logger.database.warning(
+                "Skipped \(kind, privacy: .public) prune for playlist \(prefix, privacy: .public): payload covers too few stored rows (\(skips, privacy: .public) in a row)"
+            )
+            return false
+        }
+
+        Logger.database.warning(
+            "Sweeping \(kind, privacy: .public) for playlist \(prefix, privacy: .public) after \(skips, privacy: .public) low-coverage payloads: treating the shrink as real"
+        )
+        clearSweepSkips(playlistId: playlistId, kind: kind)
+        return true
+    }
+
+    private func sweepSkipKey(playlistId: UUID, kind: String) -> String {
+        "sync.sweepSkips.\(playlistId.uuidString).\(kind)"
+    }
+
+    private func recordSweepSkip(playlistId: UUID, kind: String) -> Int {
+        let key = sweepSkipKey(playlistId: playlistId, kind: kind)
+        let next = UserDefaults.standard.integer(forKey: key) + 1
+        UserDefaults.standard.set(next, forKey: key)
+        return next
+    }
+
+    private func clearSweepSkips(playlistId: UUID, kind: String) {
+        UserDefaults.standard.removeObject(forKey: sweepSkipKey(playlistId: playlistId, kind: kind))
     }
 }

--- a/Lume/Services/Sync/ContentSyncManager.swift
+++ b/Lume/Services/Sync/ContentSyncManager.swift
@@ -175,10 +175,12 @@ actor ContentSyncManager {
 
         try await syncAllCategories(for: playlist, playlistId: playlistId, progress: progress, full: full)
 
+        // Serialized and spaced apart on purpose — see
+        // `spaceContentPhaseRequests` for the connection-cap reason.
         try await syncMovies(for: playlist, playlistId: playlistId, progress: progress)
-        try await Task.sleep(for: .seconds(2))
+        try await spaceContentPhaseRequests()
         try await syncSeries(for: playlist, playlistId: playlistId, progress: progress)
-        try await Task.sleep(for: .seconds(2))
+        try await spaceContentPhaseRequests()
         try await syncLiveStreams(for: playlist, playlistId: playlistId, progress: progress)
     }
 
@@ -278,7 +280,7 @@ actor ContentSyncManager {
         defer { Perf.end(interval) }
 
         await progress?.start(.movies)
-        let movieDTOs = try await xtreamClient.getVODStreams(playlist: playlist)
+        var movieDTOs = try await xtreamClient.getVODStreams(playlist: playlist)
         let totalCount = movieDTOs.count
         // swiftformat:disable:next redundantSelf
         Logger.database.info("Fetched \(totalCount) movies, syncing in batches of \(self.batchSize)")
@@ -286,43 +288,61 @@ actor ContentSyncManager {
 
         let playlistPrefix = "\(playlistId.uuidString)-\(CategoryType.vod.rawValue)-"
 
-        for batchStart in stride(from: 0, to: totalCount, by: batchSize) {
-            try Task.checkCancellation()
-            try autoreleasepool {
-                let batchEnd = min(batchStart + batchSize, totalCount)
-                let batch = movieDTOs[batchStart ..< batchEnd]
+        // Accumulated as the batches are written so the sweep no longer needs
+        // the DTO array, which can then be released before the sweep runs.
+        var seenIds = Set<String>(minimumCapacity: totalCount)
 
-                let context = ModelContext(modelContainer)
-                context.autosaveEnabled = false
+        do {
+            let upsertInterval = Perf.begin(.upsertMovies)
+            defer { Perf.end(upsertInterval) }
+            for batchStart in stride(from: 0, to: totalCount, by: batchSize) {
+                try Task.checkCancellation()
+                try autoreleasepool {
+                    let batchEnd = min(batchStart + batchSize, totalCount)
+                    let batch = movieDTOs[batchStart ..< batchEnd]
 
-                // Update existing rows in place; see existingMovies for why.
-                let existing = existingMovies(in: batch, playlistId: playlistId, context: context)
+                    let context = ModelContext(modelContainer)
+                    context.autosaveEnabled = false
 
-                for movieDTO in batch {
-                    guard let streamId = movieDTO.streamId else { continue }
-                    let movieId = "\(playlistId.uuidString)-movie-\(streamId)"
+                    // Update existing rows in place; see existingMovies for why.
+                    let existing = existingMovies(in: batch, playlistId: playlistId, context: context)
 
-                    let movie: Movie
-                    if let found = existing[movieId] {
-                        movie = found
-                    } else {
-                        movie = Movie(id: movieId, streamId: streamId, name: "")
-                        context.insert(movie)
+                    for movieDTO in batch {
+                        guard let streamId = movieDTO.streamId else { continue }
+                        let movieId = "\(playlistId.uuidString)-movie-\(streamId)"
+                        seenIds.insert(movieId)
+
+                        let movie: Movie
+                        if let found = existing[movieId] {
+                            movie = found
+                        } else {
+                            movie = Movie(id: movieId, streamId: streamId, name: "")
+                            context.insert(movie)
+                        }
+                        applyMovieFields(from: movieDTO, to: movie, playlistPrefix: playlistPrefix)
                     }
-                    applyMovieFields(from: movieDTO, to: movie, playlistPrefix: playlistPrefix)
-                }
 
-                try context.save()
-                Logger.database.info("Synced movies \(batchStart + 1)–\(batchEnd) of \(totalCount)")
+                    // A re-sync where the provider changed nothing leaves the
+                    // context clean (see applyMovieFields): skip save() entirely
+                    // rather than pay a full transaction for zero rows.
+                    if context.hasChanges { try context.save() }
+                    Logger.database.info("Synced movies \(batchStart + 1)–\(batchEnd) of \(totalCount)")
+                }
+                await progress?.update(
+                    detail: "\(min(batchStart + batchSize, totalCount)) of \(totalCount)",
+                    fraction: totalCount == 0 ? 1 : Double(min(batchStart + batchSize, totalCount)) / Double(totalCount)
+                )
             }
-            await progress?.update(
-                detail: "\(min(batchStart + batchSize, totalCount)) of \(totalCount)",
-                fraction: totalCount == 0 ? 1 : Double(min(batchStart + batchSize, totalCount)) / Double(totalCount)
-            )
         }
 
+        // The decoded payload is ~178k rows on a large provider; drop it before
+        // the sweep starts allocating pages of its own.
+        movieDTOs = []
+
         // Remove movies the provider has dropped (see pruneMovies for the guard).
-        pruneMovies(playlistId: playlistId, against: movieDTOs)
+        let pruneInterval = Perf.begin(.pruneMovies)
+        pruneMovies(playlistId: playlistId, seenIds: seenIds, fetchedCount: totalCount)
+        Perf.end(pruneInterval)
 
         Logger.database.info("Completed syncing \(totalCount) movies")
         await progress?.complete(.movies)
@@ -334,7 +354,7 @@ actor ContentSyncManager {
         defer { Perf.end(interval) }
 
         await progress?.start(.series)
-        let seriesDTOs = try await xtreamClient.getSeries(playlist: playlist)
+        var seriesDTOs = try await xtreamClient.getSeries(playlist: playlist)
         let totalCount = seriesDTOs.count
         // swiftformat:disable:next redundantSelf
         Logger.database.info("Fetched \(totalCount) series, syncing in batches of \(self.batchSize)")
@@ -342,43 +362,61 @@ actor ContentSyncManager {
 
         let playlistPrefix = "\(playlistId.uuidString)-\(CategoryType.series.rawValue)-"
 
-        for batchStart in stride(from: 0, to: totalCount, by: batchSize) {
-            try Task.checkCancellation()
-            try autoreleasepool {
-                let batchEnd = min(batchStart + batchSize, totalCount)
-                let batch = seriesDTOs[batchStart ..< batchEnd]
+        // Accumulated as the batches are written so the sweep no longer needs
+        // the DTO array, which can then be released before the sweep runs.
+        var seenIds = Set<String>(minimumCapacity: totalCount)
 
-                let context = ModelContext(modelContainer)
-                context.autosaveEnabled = false
+        do {
+            let upsertInterval = Perf.begin(.upsertSeries)
+            defer { Perf.end(upsertInterval) }
+            for batchStart in stride(from: 0, to: totalCount, by: batchSize) {
+                try Task.checkCancellation()
+                try autoreleasepool {
+                    let batchEnd = min(batchStart + batchSize, totalCount)
+                    let batch = seriesDTOs[batchStart ..< batchEnd]
 
-                // Update existing rows in place; see existingSeries for why.
-                let existing = existingSeries(in: batch, playlistId: playlistId, context: context)
+                    let context = ModelContext(modelContainer)
+                    context.autosaveEnabled = false
 
-                for seriesDTO in batch {
-                    guard let seriesId = seriesDTO.seriesId else { continue }
-                    let id = "\(playlistId.uuidString)-series-\(seriesId)"
+                    // Update existing rows in place; see existingSeries for why.
+                    let existing = existingSeries(in: batch, playlistId: playlistId, context: context)
 
-                    let series: Series
-                    if let found = existing[id] {
-                        series = found
-                    } else {
-                        series = Series(id: id, seriesId: seriesId, name: "")
-                        context.insert(series)
+                    for seriesDTO in batch {
+                        guard let seriesId = seriesDTO.seriesId else { continue }
+                        let id = "\(playlistId.uuidString)-series-\(seriesId)"
+                        seenIds.insert(id)
+
+                        let series: Series
+                        if let found = existing[id] {
+                            series = found
+                        } else {
+                            series = Series(id: id, seriesId: seriesId, name: "")
+                            context.insert(series)
+                        }
+                        applySeriesFields(from: seriesDTO, to: series, playlistPrefix: playlistPrefix)
                     }
-                    applySeriesFields(from: seriesDTO, to: series, playlistPrefix: playlistPrefix)
-                }
 
-                try context.save()
-                Logger.database.info("Synced series \(batchStart + 1)–\(batchEnd) of \(totalCount)")
+                    // A re-sync where the provider changed nothing leaves the
+                    // context clean (see applySeriesFields): skip save() entirely
+                    // rather than pay a full transaction for zero rows.
+                    if context.hasChanges { try context.save() }
+                    Logger.database.info("Synced series \(batchStart + 1)–\(batchEnd) of \(totalCount)")
+                }
+                await progress?.update(
+                    detail: "\(min(batchStart + batchSize, totalCount)) of \(totalCount)",
+                    fraction: totalCount == 0 ? 1 : Double(min(batchStart + batchSize, totalCount)) / Double(totalCount)
+                )
             }
-            await progress?.update(
-                detail: "\(min(batchStart + batchSize, totalCount)) of \(totalCount)",
-                fraction: totalCount == 0 ? 1 : Double(min(batchStart + batchSize, totalCount)) / Double(totalCount)
-            )
         }
 
+        // Series rows carry ~1 KB of plot/cast text each; drop the payload
+        // before the sweep starts allocating pages of its own.
+        seriesDTOs = []
+
         // Remove series the provider has dropped (episodes/cast cascade).
-        pruneSeries(playlistId: playlistId, against: seriesDTOs)
+        let pruneInterval = Perf.begin(.pruneSeries)
+        pruneSeries(playlistId: playlistId, seenIds: seenIds, fetchedCount: totalCount)
+        Perf.end(pruneInterval)
 
         Logger.database.info("Completed syncing \(totalCount) series")
         await progress?.complete(.series)
@@ -464,7 +502,7 @@ actor ContentSyncManager {
         defer { Perf.end(interval) }
 
         await progress?.start(.liveStreams)
-        let streamDTOs = try await xtreamClient.getLiveStreams(playlist: playlist)
+        var streamDTOs = try await xtreamClient.getLiveStreams(playlist: playlist)
         let totalCount = streamDTOs.count
         // swiftformat:disable:next redundantSelf
         Logger.database.info("Fetched \(totalCount) live streams, syncing in batches of \(self.batchSize)")
@@ -472,55 +510,60 @@ actor ContentSyncManager {
 
         let playlistPrefix = "\(playlistId.uuidString)-\(CategoryType.live.rawValue)-"
 
-        for batchStart in stride(from: 0, to: totalCount, by: batchSize) {
-            try Task.checkCancellation()
-            try autoreleasepool {
-                let batchEnd = min(batchStart + batchSize, totalCount)
-                let batch = streamDTOs[batchStart ..< batchEnd]
+        // Accumulated as the batches are written so the sweep no longer needs
+        // the DTO array, which can then be released before the sweep runs.
+        var seenIds = Set<String>(minimumCapacity: totalCount)
 
-                let context = ModelContext(modelContainer)
-                context.autosaveEnabled = false
+        do {
+            let upsertInterval = Perf.begin(.upsertLiveStreams)
+            defer { Perf.end(upsertInterval) }
+            for batchStart in stride(from: 0, to: totalCount, by: batchSize) {
+                try Task.checkCancellation()
+                try autoreleasepool {
+                    let batchEnd = min(batchStart + batchSize, totalCount)
+                    let batch = streamDTOs[batchStart ..< batchEnd]
 
-                // Update existing rows in place; see existingLiveStreams for why.
-                let existing = existingLiveStreams(in: batch, playlistId: playlistId, context: context)
+                    let context = ModelContext(modelContainer)
+                    context.autosaveEnabled = false
 
-                for streamDTO in batch {
-                    guard let streamId = streamDTO.streamId else { continue }
-                    let id = "\(playlistId.uuidString)-live-\(streamId)"
+                    // Update existing rows in place; see existingLiveStreams for why.
+                    let existing = existingLiveStreams(in: batch, playlistId: playlistId, context: context)
 
-                    let liveStream: LiveStream
-                    if let found = existing[id] {
-                        liveStream = found
-                    } else {
-                        liveStream = LiveStream(id: id, streamId: streamId, name: "")
-                        context.insert(liveStream)
+                    for streamDTO in batch {
+                        guard let streamId = streamDTO.streamId else { continue }
+                        let id = "\(playlistId.uuidString)-live-\(streamId)"
+                        seenIds.insert(id)
+
+                        let liveStream: LiveStream
+                        if let found = existing[id] {
+                            liveStream = found
+                        } else {
+                            liveStream = LiveStream(id: id, streamId: streamId, name: "")
+                            context.insert(liveStream)
+                        }
+                        applyLiveStreamFields(from: streamDTO, to: liveStream, playlistPrefix: playlistPrefix)
                     }
-                    liveStream.name = streamDTO.name ?? ""
-                    liveStream.streamIcon = streamDTO.streamIcon
-                    liveStream.epgChannelId = streamDTO.epgChannelId
-                    liveStream.added = streamDTO.added
-                    liveStream.customSid = streamDTO.customSid
-                    liveStream.tvArchive = streamDTO.tvArchive ?? 0
-                    liveStream.tvArchiveDuration = streamDTO.tvArchiveDuration ?? 0
-                    liveStream.isAdult = streamDTO.isAdult ?? 0
-                    liveStream.num = streamDTO.num ?? 0
 
-                    if let catIdStr = streamDTO.categoryId {
-                        liveStream.categoryId = playlistPrefix + catIdStr
-                    }
+                    // A re-sync where the provider changed nothing leaves the
+                    // context clean (see applyLiveStreamFields): skip save() entirely
+                    // rather than pay a full transaction for zero rows.
+                    if context.hasChanges { try context.save() }
+                    Logger.database.info("Synced streams \(batchStart + 1)–\(batchEnd) of \(totalCount)")
                 }
-
-                try context.save()
-                Logger.database.info("Synced streams \(batchStart + 1)–\(batchEnd) of \(totalCount)")
+                await progress?.update(
+                    detail: "\(min(batchStart + batchSize, totalCount)) of \(totalCount)",
+                    fraction: totalCount == 0 ? 1 : Double(min(batchStart + batchSize, totalCount)) / Double(totalCount)
+                )
             }
-            await progress?.update(
-                detail: "\(min(batchStart + batchSize, totalCount)) of \(totalCount)",
-                fraction: totalCount == 0 ? 1 : Double(min(batchStart + batchSize, totalCount)) / Double(totalCount)
-            )
         }
 
+        // Drop the payload before the sweep starts allocating pages of its own.
+        streamDTOs = []
+
         // Remove live channels the provider has dropped.
-        pruneLiveStreams(playlistId: playlistId, against: streamDTOs)
+        let pruneInterval = Perf.begin(.pruneLiveStreams)
+        pruneLiveStreams(playlistId: playlistId, seenIds: seenIds, fetchedCount: totalCount)
+        Perf.end(pruneInterval)
 
         Logger.database.info("Completed syncing \(totalCount) live streams")
         await progress?.complete(.liveStreams)

--- a/LumePerformanceTests/ParsingBenchmarks.swift
+++ b/LumePerformanceTests/ParsingBenchmarks.swift
@@ -188,4 +188,41 @@ final class ParsingBenchmarks: XCTestCase {
             }
         }
     }
+
+    // MARK: - Fixture fidelity
+
+    /// Non-measuring guard on the three Xtream generators: bytes/row inside the
+    /// band the real provider occupies, and every generated row surviving the
+    /// DTOs.
+    ///
+    /// `XtreamList` drops an element it cannot decode and only rethrows when
+    /// *every* element fails, so a fixture whose shape the DTOs reject comes back
+    /// as a short array rather than an error — the decode benchmarks above would
+    /// quietly measure less work instead of failing.
+    func testXtreamFixturesMatchProviderRowShape() throws {
+        let rows = 5000
+        let decoder = JSONDecoder()
+
+        let vod = try PerfFixtures.xtreamVODStreamsJSON(count: rows)
+        assertBytesPerRow(vod, rows: rows, expected: 367)
+        let movies = try decoder.decode(XtreamList<XtreamVODStream>.self, from: vod).items
+        XCTAssertEqual(movies.count, rows)
+        XCTAssertTrue(movies.allSatisfy { $0.streamId != nil && $0.name?.isEmpty == false })
+        XCTAssertTrue(movies.contains { ($0.rating ?? 0) > 0 }, "the String `rating` path decoded nothing")
+        XCTAssertTrue(movies.contains { ($0.rating5Based ?? 0) > 0 }, "the numeric `rating_5based` path decoded nothing")
+
+        let series = try PerfFixtures.xtreamSeriesJSON(count: rows)
+        assertBytesPerRow(series, rows: rows, expected: 1033)
+        let shows = try decoder.decode(XtreamList<XtreamSeries>.self, from: series).items
+        XCTAssertEqual(shows.count, rows)
+        XCTAssertTrue(shows.allSatisfy { $0.seriesId != nil && $0.rating5Based?.isEmpty == false })
+        XCTAssertTrue(shows.allSatisfy { ($0.plot?.count ?? 0) > 200 }, "series rows carry ~1 KB of text")
+
+        let live = try PerfFixtures.xtreamLiveStreamsJSON(count: rows)
+        assertBytesPerRow(live, rows: rows, expected: 356)
+        let channels = try decoder.decode(XtreamList<XtreamLiveStream>.self, from: live).items
+        XCTAssertEqual(channels.count, rows)
+        XCTAssertTrue(channels.allSatisfy { $0.streamId != nil && $0.isAdult == 0 })
+        XCTAssertTrue(channels.contains { $0.tvArchive == 1 }, "the numeric `tv_archive` path decoded nothing")
+    }
 }

--- a/LumePerformanceTests/PerfSupport.swift
+++ b/LumePerformanceTests/PerfSupport.swift
@@ -168,28 +168,266 @@ enum PerfFixtures {
         return url
     }
 
+    // MARK: Xtream JSON
+
+    // Row sizes below are the ones a real 282,288-row panel sends:
+    // `get_vod_streams` 367 B/row over 178,007 rows, `get_live_streams`
+    // 356 B/row over 56,713, `get_series` 1033 B/row over 47,568. A generator
+    // that emits a minimal subset of the keys understates decode by ~3x and
+    // makes a sync benchmark measure something the app never does.
+
+    private static func pick<Element>(_ values: [Element], using generator: inout SeededGenerator) -> Element {
+        values[Int.random(in: 0 ..< values.count, using: &generator)]
+    }
+
+    /// A TMDB-style image token. Its length is most of why a real `stream_icon`
+    /// is 76 bytes and a naive fixture's is 30.
+    private static func imageToken(length: Int = 27, using generator: inout SeededGenerator) -> String {
+        var token = ""
+        token.reserveCapacity(length)
+        for _ in 0 ..< length {
+            token.append(pick(XtreamVocabulary.tokenAlphabet, using: &generator))
+        }
+        return token
+    }
+
+    private static func posterURL(using generator: inout SeededGenerator) -> String {
+        let roll = Int.random(in: 0 ..< 100, using: &generator)
+        if roll == 0 { return "" }
+        let size = roll < 12 ? "w154" : "w600_and_h900_bestv2"
+        return "https://image.tmdb.org/t/p/\(size)/\(imageToken(using: &generator)).jpg"
+    }
+
+    private static func channelLogoURL(using generator: inout SeededGenerator) -> String {
+        if Int.random(in: 0 ..< 100, using: &generator) < 3 { return "" }
+        return "https://upload.wikimedia.org/wikipedia/commons/4/42/\(imageToken(using: &generator)).png"
+    }
+
+    /// `backdrop_path` element counts as the provider sends them — mean 2.8.
+    private static let backdropCounts = [0, 1, 2, 2, 3, 3, 3, 4, 4, 5, 6, 7]
+
+    /// The comma-joined, already-quoted elements of a `backdrop_path` array.
+    private static func backdropURLs(using generator: inout SeededGenerator) -> String {
+        let count = pick(backdropCounts, using: &generator)
+        var urls: [String] = []
+        urls.reserveCapacity(count)
+        for _ in 0 ..< count {
+            let size = Int.random(in: 0 ..< 10, using: &generator) < 4 ? "original" : "w1280"
+            urls.append("\"https://image.tmdb.org/t/p/\(size)/\(imageToken(using: &generator)).jpg\"")
+        }
+        return urls.joined(separator: ",")
+    }
+
+    private static func title(index: Int, using generator: inout SeededGenerator) -> String {
+        let adjective = pick(XtreamVocabulary.adjectives, using: &generator)
+        let noun = pick(XtreamVocabulary.nouns, using: &generator)
+        var name = "\(adjective) \(noun)"
+        if index.isMultiple(of: 3) {
+            name = "\(pick(XtreamVocabulary.adjectives, using: &generator)) \(name)"
+        }
+        return "\(name) (\(1970 + index % 56))"
+    }
+
+    private static func personName(using generator: inout SeededGenerator) -> String {
+        let first = pick(XtreamVocabulary.firstNames, using: &generator)
+        let last = pick(XtreamVocabulary.lastNames, using: &generator)
+        return "\(first) \(last)"
+    }
+
+    private static let castSizes = [0, 3, 5, 6, 7]
+
+    private static func castList(using generator: inout SeededGenerator) -> String {
+        let count = pick(castSizes, using: &generator)
+        var names: [String] = []
+        names.reserveCapacity(count)
+        for _ in 0 ..< count {
+            names.append(personName(using: &generator))
+        }
+        return names.joined(separator: ", ")
+    }
+
+    /// Words drawn until the result is at least `minimumLength` characters. Plot
+    /// text is the bulk of a `get_series` row and the reason it is 3x a VOD row.
+    private static func phrase(
+        minimumLength: Int,
+        from words: [String],
+        using generator: inout SeededGenerator
+    ) -> String {
+        var parts: [String] = []
+        var length = 0
+        while length < minimumLength {
+            let word = pick(words, using: &generator)
+            parts.append(word)
+            length += word.count + 1
+        }
+        return parts.joined(separator: " ")
+    }
+
     /// An Xtream `get_vod_streams` response body with `count` movies, as `Data`
-    /// ready for `JSONDecoder`. Fields mirror what panels actually send,
-    /// including the string/number ambiguity the DTOs have to absorb.
+    /// ready for `JSONDecoder`.
+    ///
+    /// The field mix is the provider's, not the DTO's: `rating` arrives as a
+    /// String, `rating_5based` as a JSON number, `is_adult` as a String, and
+    /// `category_ids` / `custom_sid` / `direct_source` are keys
+    /// `XtreamVODStream` never reads but `JSONDecoder` still parses.
     static func xtreamVODStreamsJSON(count: Int) throws -> Data {
         var generator = SeededGenerator()
-        var items: [String] = []
-        items.reserveCapacity(count)
+        var json = "["
+        json.reserveCapacity(count * 380 + 2)
         for index in 0 ..< count {
-            // Half the panels send numbers as strings; alternate so the decoder's
-            // lenient paths are exercised too.
-            let rating = index.isMultiple(of: 2) ? "\"7.\(index % 10)\"" : "7.\(index % 10)"
-            let added = 1_700_000_000 + index
-            items.append("""
-            {"num":\(index),"name":"Movie \(index)","stream_type":"movie",\
-            "stream_id":\(100_000 + index),"stream_icon":"https://example.invalid/p/\(index).jpg",\
-            "rating":\(rating),"rating_5based":\(Int.random(in: 0 ... 5, using: &generator)),\
-            "added":"\(added)","category_id":"\(index % 300)","container_extension":"mkv",\
-            "custom_sid":null,"direct_source":""}
-            """)
+            if index > 0 { json += "," }
+            let categoryId = 2000 + index % 441
+            let rating = pick(XtreamVocabulary.vodRatings, using: &generator)
+            let rating5 = pick(XtreamVocabulary.vodRatings5Based, using: &generator)
+            // One provider is self-consistent, panel forks are not — alternate a
+            // quarter of the rows so both branches of `lenientDouble` and
+            // `lenientInt` stay on the measured path.
+            let flipped = index % 4 == 3
+            let ratingField = flipped ? rating : "\"\(rating)\""
+            let rating5Field = flipped ? "\"\(rating5)\"" : rating5
+            let isAdultField = flipped ? "0" : "\"0\""
+            let container = pick(XtreamVocabulary.containerExtensions, using: &generator)
+            json += #"{"num":\#(index + 1),"stream_type":"movie","#
+            json += #""name":"\#(title(index: index, using: &generator))","#
+            json += #""stream_id":\#(1_500_000 + index),"stream_icon":"\#(posterURL(using: &generator))","#
+            json += #""rating":\#(ratingField),"rating_5based":\#(rating5Field),"#
+            json += #""added":"\#(1_759_931_040 + index)","is_adult":\#(isAdultField),"#
+            json += #""category_id":"\#(categoryId)","category_ids":[\#(categoryId)],"#
+            json += #""container_extension":"\#(container)","custom_sid":null,"direct_source":""}"#
         }
-        return Data("[\(items.joined(separator: ","))]".utf8)
+        json += "]"
+        return Data(json.utf8)
     }
+
+    /// An Xtream `get_series` response body with `count` series.
+    ///
+    /// Series is the endpoint where `rating` *and* `rating_5based` are Strings
+    /// and `backdrop_path` is an **array** of URLs rather than a scalar. A
+    /// fixture that sends a string there decodes just as happily and still hides
+    /// ~220 B/row of parsing, which is why the array is generated in full.
+    static func xtreamSeriesJSON(count: Int) throws -> Data {
+        var generator = SeededGenerator()
+        var json = "["
+        json.reserveCapacity(count * 1060 + 2)
+        for index in 0 ..< count {
+            if index > 0 { json += "," }
+            let categoryId = 400 + index % 374
+            let plot = phrase(minimumLength: 285, from: XtreamVocabulary.plotWords, using: &generator)
+            let trailer = index.isMultiple(of: 2) ? imageToken(length: 11, using: &generator) : ""
+            json += #"{"num":\#(index + 1),"name":"\#(title(index: index, using: &generator))","#
+            json += #""series_id":\#(13000 + index),"cover":"\#(posterURL(using: &generator))","#
+            json += #""plot":"\#(plot)","cast":"\#(castList(using: &generator))","#
+            json += #""director":"\#(personName(using: &generator))","#
+            json += #""genre":"\#(pick(XtreamVocabulary.genres, using: &generator))","#
+            json += #""releaseDate":"\#(1970 + index % 56)-0\#(1 + index % 9)-1\#(index % 9)","#
+            json += #""last_modified":"\#(1_776_621_142 + index)","#
+            json += #""rating":"\#(pick(XtreamVocabulary.seriesRatings, using: &generator))","#
+            json += #""rating_5based":"\#(pick(XtreamVocabulary.seriesRatings5Based, using: &generator))","#
+            json += #""backdrop_path":[\#(backdropURLs(using: &generator))],"#
+            json += #""youtube_trailer":"\#(trailer)","#
+            json += #""episode_run_time":"\#(pick(XtreamVocabulary.episodeRunTimes, using: &generator))","#
+            json += #""category_id":"\#(categoryId)","category_ids":[\#(categoryId)]}"#
+        }
+        json += "]"
+        return Data(json.utf8)
+    }
+
+    /// An Xtream `get_live_streams` response body with `count` channels.
+    ///
+    /// Live is the endpoint that sends true JSON numbers — `num`, `stream_id`,
+    /// `tv_archive`, `tv_archive_duration` and `is_adult` all arrive unquoted,
+    /// the other half of `lenientInt`'s work — and where `epg_channel_id` is
+    /// usually the empty string rather than absent.
+    static func xtreamLiveStreamsJSON(count: Int) throws -> Data {
+        var generator = SeededGenerator()
+        var json = "["
+        json.reserveCapacity(count * 370 + 2)
+        for index in 0 ..< count {
+            if index > 0 { json += "," }
+            let categoryId = 2000 + index % 910
+            let archived = index % 56 == 0
+            let suffix = pick(XtreamVocabulary.liveSuffixes, using: &generator)
+            let name = title(index: index, using: &generator) + suffix
+            let epgId = index % 7 == 0
+                ? "\(pick(XtreamVocabulary.nouns, using: &generator)).\(index % 90).tv"
+                : ""
+            json += #"{"num":\#(index + 1),"stream_type":"live","name":"\#(name)","#
+            json += #""stream_id":\#(1_600_000 + index),"stream_icon":"\#(channelLogoURL(using: &generator))","#
+            json += #""epg_channel_id":"\#(epgId)","#
+            json += #""category_id":"\#(categoryId)","category_ids":[\#(categoryId)],"#
+            json += #""added":"\#(1_760_346_276 + index)","tv_archive_duration":\#(archived ? 3 : 0),"#
+            json += #""is_adult":0,"tv_archive":\#(archived ? 1 : 0),"#
+            json += #""custom_sid":null,"direct_source":""}"#
+        }
+        json += "]"
+        return Data(json.utf8)
+    }
+}
+
+// MARK: - Xtream fixture vocabulary
+
+/// Deterministic word pools for the Xtream generators.
+///
+/// Real catalog rows carry multi-byte characters in titles and plots — curly
+/// apostrophes, em dashes, superscript channel tags — and that UTF-8 is a real
+/// share of what a 135 MB sync spends in `JSONDecoder`, so the pools carry them
+/// too rather than staying ASCII.
+private enum XtreamVocabulary {
+    static let adjectives = [
+        "Shadow", "Crimson", "Midnight", "Eternal", "Silent", "Broken", "Northern", "Last",
+        "Golden", "Winter", "Distant", "Hollow", "Rising", "Iron", "Velvet", "Quiet",
+        "Forgotten", "Wild", "Second", "Bright", "Frozen", "Sacred", "Hidden", "Restless"
+    ]
+
+    static let nouns = [
+        "Harbour", "Kingdom", "Machine", "Promise", "Circuit", "Garden", "Verdict", "Orbit",
+        "Signal", "Country", "Mirror", "Lantern", "Compass", "Season", "Threshold", "Anthem",
+        "Passage", "Reckoning", "Cartel", "Frontier"
+    ]
+
+    static let plotWords = [
+        "A", "the", "story", "follows", "an", "unlikely", "crew", "across", "a", "fractured",
+        "city", "where", "every", "choice", "costs", "more", "than", "it", "should", "and",
+        "nobody", "leaves", "unchanged", "after", "the", "long", "winter", "ends", "world’s",
+        "don’t", "—", "quietly", "between", "two", "families", "bound", "by", "an", "old", "debt"
+    ]
+
+    static let firstNames = [
+        "Eugenio", "Enrique", "Raphael", "Camila", "Chord", "Fernando", "Jessica", "Vanessa",
+        "Marguerite", "Aleksander", "Yuki", "Priya", "Tomasz", "Ingrid"
+    ]
+
+    static let lastNames = [
+        "Derbez", "Arrizon", "Alejandro", "Perez", "Overstreet", "Carsa", "Collins", "Bauche",
+        "Lindqvist", "Nakamura", "Okonkwo", "Rossi", "Kowalski", "Alvarez"
+    ]
+
+    static let genres = [
+        "Comedy / Drama", "Sci-Fi & Fantasy / Action & Adventure", "Kids / Family / Comedy",
+        "Documentary", "Crime / Mystery", "Action / Thriller", "Animation"
+    ]
+
+    /// Weighted the way the measured catalog is: mkv dominates, mp4 next.
+    static let containerExtensions = ["mkv", "mkv", "mkv", "mp4", "mp4", "avi"]
+
+    /// VOD `rating`. Mostly one or two characters — the measured mean is 3.0, so
+    /// a fixture that always emits "6.244" is already too wide.
+    static let vodRatings = ["0", "6", "7", "5", "8", "6.5", "6.2", "7.1", "6.244", "7.565"]
+
+    /// VOD `rating_5based`, quantised to whole steps the way the panel emits it.
+    static let vodRatings5Based = ["3.0", "4.0", "0.0", "2.0", "5.0", "1.0"]
+
+    /// Series ratings are Strings on both keys, and on a different scale.
+    static let seriesRatings = ["8", "7", "6", "0", "9", "5", "10"]
+    static let seriesRatings5Based = ["1.6", "1.4", "1.2", "0", "1.8", "1", "2.4"]
+
+    static let episodeRunTimes = ["0", "0", "0", "45", "60", "24", "50", "30"]
+
+    static let tokenAlphabet = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+
+    /// Superscript decorations on live channel names — three UTF-8 bytes each,
+    /// and the provider's live list is full of them.
+    static let liveSuffixes = ["", "", "", "", " ᴴᴰ"]
 }
 
 // MARK: - Assertions
@@ -203,6 +441,27 @@ extension XCTestCase {
         XCTAssertGreaterThan(
             size, minimumBytes,
             "fixture at \(url.lastPathComponent) is only \(size) bytes — the generator is probably broken",
+            file: file, line: line
+        )
+    }
+
+    /// Fails when a generated Xtream fixture drifts away from the row size the
+    /// real provider sends. A generator emitting 110 B/row where the panel emits
+    /// 367 makes every decode benchmark look three times cheaper than the sync
+    /// phase it stands in for.
+    func assertBytesPerRow(
+        _ payload: Data,
+        rows: Int,
+        expected: Int,
+        tolerance: Double = 0.12,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let actual = Double(payload.count) / Double(rows)
+        let band = Double(expected) * (1 - tolerance) ... Double(expected) * (1 + tolerance)
+        XCTAssertTrue(
+            band.contains(actual),
+            "fixture is \(Int(actual)) B/row; the provider sends \(expected) B/row (±\(Int(tolerance * 100))%)",
             file: file, line: line
         )
     }

--- a/LumePerformanceTests/PersistenceBenchmarks.swift
+++ b/LumePerformanceTests/PersistenceBenchmarks.swift
@@ -23,6 +23,14 @@ final class PersistenceBenchmarks: XCTestCase {
     /// the sync's write shape, so it must track that constant.
     private let batchSize = 2000
 
+    // The measured provider, row for row: 282,288 rows across the three kinds,
+    // which is the catalog that takes ~4 minutes to sync on an Apple TV 4K.
+    // Kept literal rather than rounded so a run here is comparable to a device
+    // trace of that provider.
+    private let catalogLiveStreamCount = 56713
+    private let catalogMovieCount = 178_007
+    private let catalogSeriesCount = 47568
+
     // MARK: - Insert
 
     /// Cold insert of 20k movies through the sync's context-per-batch pattern.
@@ -48,6 +56,26 @@ final class PersistenceBenchmarks: XCTestCase {
 
         measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
             insertMovies(count: 20000, playlistId: playlistId, container: store.container)
+        }
+    }
+
+    /// Cold insert of 20k series. Series rows are the heaviest of the three
+    /// kinds — ~1 KB of plot/cast/director text each — and they route genre
+    /// through `GenreParser.providerFallback`, so their per-row cost is not the
+    /// movie number.
+    func testInsert20kSeriesOnDisk() {
+        measureStoreWork(metrics: [XCTClockMetric(), XCTMemoryMetric()]) { container in
+            let playlistId = UUID()
+            insertSeries(count: 20000, playlistId: playlistId, container: container)
+        }
+    }
+
+    /// Cold insert of 20k live channels — the narrowest rows of the three kinds,
+    /// and the phase that runs first on a fresh playlist.
+    func testInsert20kLiveStreamsOnDisk() {
+        measureStoreWork(metrics: [XCTClockMetric(), XCTMemoryMetric()]) { container in
+            let playlistId = UUID()
+            insertLiveStreams(count: 20000, playlistId: playlistId, container: container)
         }
     }
 
@@ -83,6 +111,94 @@ final class PersistenceBenchmarks: XCTestCase {
         }
     }
 
+    // MARK: - Full catalog
+
+    /// The whole measured provider in one store: 56,713 live channels, 178,007
+    /// movies and 47,568 series. The per-kind benchmarks above each start from
+    /// an empty database, which hides the part that actually hurts — later
+    /// batches upserting against a store that already holds a quarter of a
+    /// million rows.
+    ///
+    /// One iteration rather than five: a pass writes 282k rows through a real
+    /// SQLite file, so the default would put this single test into the tens of
+    /// minutes. The comparison that matters here is between commits, not
+    /// between passes of one run.
+    func testImportFullXtreamCatalog() {
+        measureStoreWork(metrics: [XCTClockMetric(), XCTMemoryMetric()], iterationCount: 1) { container in
+            let playlistId = UUID()
+            insertLiveStreams(count: catalogLiveStreamCount, playlistId: playlistId, container: container)
+            insertMovies(count: catalogMovieCount, playlistId: playlistId, container: container)
+            insertSeries(count: catalogSeriesCount, playlistId: playlistId, container: container)
+        }
+    }
+
+    /// Re-importing that same catalog unchanged — the scheduled-sync path, and
+    /// the one the sync-performance work is aimed at. Seeded outside the
+    /// measured block, so this times the second pass: every row already exists,
+    /// every field written matches what is stored, and the upsert lookup runs
+    /// against a full store.
+    ///
+    /// Two iterations for the same runtime reason as the cold import; two is
+    /// still enough to show whether the second pass is cheaper than the first.
+    func testReimportFullXtreamCatalogUnchanged() throws {
+        let store = try PerfStore.makeOnDiskContainer()
+        defer { PerfStore.destroy(directory: store.directory) }
+        let playlistId = UUID()
+        insertLiveStreams(count: catalogLiveStreamCount, playlistId: playlistId, container: store.container)
+        insertMovies(count: catalogMovieCount, playlistId: playlistId, container: store.container)
+        insertSeries(count: catalogSeriesCount, playlistId: playlistId, container: store.container)
+
+        let options = XCTMeasureOptions()
+        options.iterationCount = 2
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()], options: options) {
+            insertLiveStreams(count: catalogLiveStreamCount, playlistId: playlistId, container: store.container)
+            insertMovies(count: catalogMovieCount, playlistId: playlistId, container: store.container)
+            insertSeries(count: catalogSeriesCount, playlistId: playlistId, container: store.container)
+        }
+    }
+
+    // MARK: - Prune
+
+    /// The mark-and-sweep prune over a full VOD catalog with **nothing to
+    /// delete** — what every re-sync of a stable provider pays purely to
+    /// establish that no row has gone away.
+    ///
+    /// This drives the production `ContentSyncManager.pruneStaleMovies` rather
+    /// than a local copy of the sweep, so a paged rewrite of that method is
+    /// genuinely gated by this number instead of drifting away from it.
+    /// `ContentSyncManager` is an actor, so the measured block hands the call to
+    /// a detached task and blocks on a semaphore: `Task.detached` specifically,
+    /// because a task that inherited this test's context could not start while
+    /// the semaphore holds that context's thread. The manager's default
+    /// `XtreamClient` is never used — the sweep only touches the store.
+    ///
+    /// Memory is measured alongside the clock because the sweep's cost is
+    /// materialising every row, not the deletes; a rewrite that only moves wall
+    /// clock has not fixed it.
+    func testPruneFullVODCatalogWithNoDeletions() throws {
+        let store = try PerfStore.makeOnDiskContainer()
+        defer { PerfStore.destroy(directory: store.directory) }
+        let playlistId = UUID()
+        insertMovies(count: catalogMovieCount, playlistId: playlistId, container: store.container)
+
+        let manager = ContentSyncManager(modelContainer: store.container)
+        // Every id is "seen", so no row is deleted and every iteration sweeps
+        // the same 178k rows — without this the second pass would measure an
+        // empty table.
+        let seenIds = Set((0 ..< catalogMovieCount).map { "\(playlistId.uuidString)-movie-\($0)" })
+
+        let options = XCTMeasureOptions()
+        options.iterationCount = 3
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()], options: options) {
+            let semaphore = DispatchSemaphore(value: 0)
+            Task.detached {
+                await manager.pruneStaleMovies(playlistId: playlistId, seenIds: seenIds)
+                semaphore.signal()
+            }
+            semaphore.wait()
+        }
+    }
+
     // MARK: - Helpers
 
     /// Runs `work` against a freshly created on-disk store on every iteration, so
@@ -90,12 +206,14 @@ final class PersistenceBenchmarks: XCTestCase {
     /// Store setup/teardown sit outside the measured region.
     private func measureStoreWork(
         metrics: [XCTMetric],
+        iterationCount: Int = 5,
         _ work: (ModelContainer) -> Void
     ) {
         // Manual start/stop is what keeps store creation and deletion — tens of
         // milliseconds of file I/O each — out of the numbers.
         let options = XCTMeasureOptions()
         options.invocationOptions = [.manuallyStart, .manuallyStop]
+        options.iterationCount = iterationCount
         measure(metrics: metrics, options: options) {
             guard let store = try? PerfStore.makeOnDiskContainer() else {
                 XCTFail("could not create the on-disk store")
@@ -109,8 +227,16 @@ final class PersistenceBenchmarks: XCTestCase {
     }
 
     /// The upsert loop `ContentSyncManager.syncMovies` runs: one fresh,
-    /// autosave-off context per batch, an id-scoped fetch for existing rows, then
-    /// insert-or-update and save.
+    /// autosave-off context per batch, an id-scoped fetch for existing rows,
+    /// insert-or-update, and a save that only happens when something actually
+    /// changed.
+    ///
+    /// This is a local copy of the loop, not a call into it — `syncMovies` is
+    /// driven by a network fetch. It therefore has to be kept in step with
+    /// `ContentSyncManager+Helpers.applyMovieFields` by hand: the per-field
+    /// inequality guards and the `hasChanges` gate below mirror that helper, and
+    /// are what makes the unchanged re-import benchmark measure the refresh path
+    /// the app actually runs.
     private func insertMovies(count: Int, playlistId: UUID, container: ModelContainer) {
         for batchStart in stride(from: 0, to: count, by: batchSize) {
             autoreleasepool {
@@ -137,15 +263,159 @@ final class PersistenceBenchmarks: XCTestCase {
                         movie = Movie(id: id, streamId: index, name: "")
                         context.insert(movie)
                     }
-                    movie.name = "Movie \(index)"
-                    movie.streamIcon = "https://example.invalid/p/\(index).jpg"
-                    movie.rating = Double(index % 10)
-                    movie.added = "\(1_700_000_000 + index)"
-                    movie.containerExtension = "mkv"
-                    movie.categoryId = "\(playlistId.uuidString)-vod-\(index % 300)"
+                    applyMovieFixture(index: index, playlistId: playlistId, to: movie)
                 }
-                try? context.save()
+                if context.hasChanges { try? context.save() }
             }
         }
+    }
+
+    /// The series equivalent of `insertMovies`, matching `syncSeries`: same
+    /// context-per-batch upsert, and the same `GenreParser.providerFallback`
+    /// routing `applySeriesFields` uses — the provider genre is a fallback, so
+    /// the dirty check compares the computed value, not the raw one.
+    private func insertSeries(count: Int, playlistId: UUID, container: ModelContainer) {
+        // ~1 KB of prose per row, which is what the measured provider sends and
+        // what makes series the heaviest kind to write.
+        let plotBody = String(repeating: "A long-running drama that follows its cast across several seasons. ", count: 12)
+        let castBody = String(repeating: "Alex Doe, Sam Roe, Jamie Poe, Riley Coe, ", count: 6)
+
+        for batchStart in stride(from: 0, to: count, by: batchSize) {
+            autoreleasepool {
+                let batchEnd = min(batchStart + batchSize, count)
+                let context = ModelContext(container)
+                context.autosaveEnabled = false
+
+                let ids = (batchStart ..< batchEnd).map { "\(playlistId.uuidString)-series-\($0)" }
+                var existing: [String: Series] = [:]
+                existing.reserveCapacity(ids.count)
+                let fetched = (try? context.fetch(
+                    FetchDescriptor<Series>(predicate: #Predicate { ids.contains($0.id) })
+                )) ?? []
+                for series in fetched {
+                    existing[series.id] = series
+                }
+
+                for index in batchStart ..< batchEnd {
+                    let id = "\(playlistId.uuidString)-series-\(index)"
+                    let series: Series
+                    if let found = existing[id] {
+                        series = found
+                    } else {
+                        series = Series(id: id, seriesId: index, name: "")
+                        context.insert(series)
+                    }
+                    applySeriesFixture(index: index, playlistId: playlistId, plot: plotBody, cast: castBody, to: series)
+                }
+                if context.hasChanges { try? context.save() }
+            }
+        }
+    }
+
+    /// The live-channel equivalent of `insertMovies`, matching `syncLiveStreams`.
+    private func insertLiveStreams(count: Int, playlistId: UUID, container: ModelContainer) {
+        for batchStart in stride(from: 0, to: count, by: batchSize) {
+            autoreleasepool {
+                let batchEnd = min(batchStart + batchSize, count)
+                let context = ModelContext(container)
+                context.autosaveEnabled = false
+
+                let ids = (batchStart ..< batchEnd).map { "\(playlistId.uuidString)-live-\($0)" }
+                var existing: [String: LiveStream] = [:]
+                existing.reserveCapacity(ids.count)
+                let fetched = (try? context.fetch(
+                    FetchDescriptor<LiveStream>(predicate: #Predicate { ids.contains($0.id) })
+                )) ?? []
+                for stream in fetched {
+                    existing[stream.id] = stream
+                }
+
+                for index in batchStart ..< batchEnd {
+                    let id = "\(playlistId.uuidString)-live-\(index)"
+                    let stream: LiveStream
+                    if let found = existing[id] {
+                        stream = found
+                    } else {
+                        stream = LiveStream(id: id, streamId: index, name: "")
+                        context.insert(stream)
+                    }
+                    applyLiveStreamFixture(index: index, playlistId: playlistId, to: stream)
+                }
+                if context.hasChanges { try? context.save() }
+            }
+        }
+    }
+
+    // The three field appliers below stand in for
+    // `ContentSyncManager+Helpers.apply*Fields`: one guarded assignment per
+    // provider-owned property, so a re-import of an unchanged catalog leaves the
+    // context clean and skips `save()` — the whole point of the refresh-path
+    // benchmarks. The complexity opt-outs match the ones on those helpers: this
+    // is a flat field copy, not branching logic.
+
+    private func applyMovieFixture(index: Int, playlistId: UUID, to movie: Movie) {
+        let name = "Movie \(index)"
+        if movie.name != name { movie.name = name }
+        let streamIcon = "https://example.invalid/p/\(index).jpg"
+        if movie.streamIcon != streamIcon { movie.streamIcon = streamIcon }
+        let rating = Double(index % 10)
+        if movie.rating != rating { movie.rating = rating }
+        let added = "\(1_700_000_000 + index)"
+        if movie.added != added { movie.added = added }
+        if movie.containerExtension != "mkv" { movie.containerExtension = "mkv" }
+        let categoryId = "\(playlistId.uuidString)-vod-\(index % 300)"
+        if movie.categoryId != categoryId { movie.categoryId = categoryId }
+    }
+
+    private func applySeriesFixture( // swiftlint:disable:this cyclomatic_complexity
+        index: Int,
+        playlistId: UUID,
+        plot plotBody: String,
+        cast castBody: String,
+        to series: Series
+    ) {
+        let name = "Series \(index)"
+        if series.name != name { series.name = name }
+        let cover = "https://example.invalid/c/\(index).jpg"
+        if series.cover != cover { series.cover = cover }
+        let plot = "\(plotBody)Episode arc \(index)."
+        if series.plot != plot { series.plot = plot }
+        if series.cast != castBody { series.cast = castBody }
+        let director = "Director \(index % 900)"
+        if series.director != director { series.director = director }
+        // The provider genre is a fallback, so the guard compares the computed
+        // value — exactly as `applySeriesFields` must.
+        let genre = GenreParser.providerFallback(current: series.genre, provider: "Drama, Thriller")
+        if series.genre != genre { series.genre = genre }
+        let releaseDate = "20\(10 + index % 15)-04-11"
+        if series.releaseDate != releaseDate { series.releaseDate = releaseDate }
+        let lastModified = "\(1_700_000_000 + index)"
+        if series.lastModified != lastModified { series.lastModified = lastModified }
+        let rating = "\(index % 10)"
+        if series.rating != rating { series.rating = rating }
+        let rating5Based = "\(index % 5)"
+        if series.rating5Based != rating5Based { series.rating5Based = rating5Based }
+        if series.num != index { series.num = index }
+        let categoryId = "\(playlistId.uuidString)-series-\(index % 400)"
+        if series.categoryId != categoryId { series.categoryId = categoryId }
+    }
+
+    private func applyLiveStreamFixture(index: Int, playlistId: UUID, to stream: LiveStream) {
+        let name = "Channel \(index) HD"
+        if stream.name != name { stream.name = name }
+        let streamIcon = "https://example.invalid/logo/\(index).png"
+        if stream.streamIcon != streamIcon { stream.streamIcon = streamIcon }
+        // The provider leaves roughly a third of these empty.
+        let epgChannelId = index % 3 == 0 ? "" : "channel.\(index).xx"
+        if stream.epgChannelId != epgChannelId { stream.epgChannelId = epgChannelId }
+        let added = "\(1_700_000_000 + index)"
+        if stream.added != added { stream.added = added }
+        let tvArchive = index % 4 == 0 ? 1 : 0
+        if stream.tvArchive != tvArchive { stream.tvArchive = tvArchive }
+        let tvArchiveDuration = index % 4 == 0 ? 7 : 0
+        if stream.tvArchiveDuration != tvArchiveDuration { stream.tvArchiveDuration = tvArchiveDuration }
+        if stream.num != index { stream.num = index }
+        let categoryId = "\(playlistId.uuidString)-live-\(index % 900)"
+        if stream.categoryId != categoryId { stream.categoryId = categoryId }
     }
 }

--- a/LumePerformanceTests/README.md
+++ b/LumePerformanceTests/README.md
@@ -73,6 +73,118 @@ Every configuration sets `cloudKitDatabase: .none`, without exception: the
 catalog's `@Attribute(.unique)` models crash container load when CloudKit
 mirroring is left at `.automatic` on an entitled host.
 
+## What the import actually costs
+
+The sync-performance work targeted one real provider: 56,713 live channels,
+178,007 movies and 47,568 series — 282,288 rows and ~135 MB of JSON per sync,
+which took ~4 minutes on an Apple TV 4K. Everything below was measured against
+that shape. Absolute seconds are from an iPhone 17 Pro simulator under the
+Benchmark configuration; the ratios are the portable part.
+
+**`context.save()` is ~90% of it.** Decode, object construction and the upsert
+lookup share the remaining tenth. An optimisation that does not reduce how much
+SwiftData has to write, or how often it is asked to write, is aimed at the wrong
+tenth.
+
+### Levers that were measured and are dead
+
+Each of these moved import cost by **under 6%** — under the run-to-run noise of a
+warm laptop. They were measured on a standalone 178k-row harness rather than
+through the suite, so the seconds below are internally comparable but do not line
+up with the benchmark table further down. Recorded so nobody spends another day
+on them:
+
+| Lever | Result |
+|---|---|
+| `batchSize` 500 / 2,000 / 10,000 / 50,000 | all within noise |
+| Dropping all 11 `#Index` groups on `Movie` | 61.1 s → 60.9 s |
+| Removing `@Attribute(.unique)` | 15.98 s → 15.83 s |
+| Removing the per-batch existing-row lookup | 62.8 s → 62.6 s |
+| One shared context instead of a fresh one per batch | 19.68 s → 19.01 s |
+
+`batchSize` stays at 2,000 as a **memory** contract, not a throughput one — which
+is why `PersistenceBenchmarks` reproduces the per-batch context shape deliberately
+rather than inserting in one pass.
+
+`propertiesToFetch = [\.id]` is the other trap. It is used correctly elsewhere in
+the repo (`PlaylistDeletion.swift`, `EPGSyncManager.swift`, `GenreBrowse.swift`),
+but on the prune sweep's fetch it made **both** metrics worse: 13.5 s / 1,535 MB
+peak against 10.6 s / 1,224 MB for the plain fetch. Partial materialisation costs
+more than it saves when the following code faults the row in anyway.
+
+`fetchLimit` + `fetchOffset` paging on the prune sweep is the most expensive trap
+of the three, because it looks like the obvious fix and it half works. It does cut
+memory — 746 MB down to 281 MB — but the store still walks every row an offset
+skips, so the clock went **9.28 s to 99.11 s, 10.7x worse than the unbounded fetch
+it replaced**. The sweep ships with keyset paging instead (`id > cursor`, sorted by
+`id`, `fetchLimit` only, cursor carried from the last row of the previous page).
+Keyset paging is also what makes deleting while paging sound: every deleted row
+sorts at or before the cursor, so it can never displace a row a later page has yet
+to see.
+
+### Levers that did work
+
+Dirty-checked field application (`ContentSyncManager+Helpers`, so an unchanged row
+leaves the context clean and the per-batch `save()` is skipped) and a paged prune
+sweep (`ContentSyncManager+Prune`, keyset paging instead of materialising the
+whole catalog). Both columns are `PersistenceBenchmarks` on the
+same machine, back to back, so they are comparable to each other and to nothing
+else:
+
+| Benchmark | Before | After |
+|---|---|---|
+| `testImportFullXtreamCatalog` (cold, 282,288 rows) | 64.30 s | 65.54 s |
+| `testReimportFullXtreamCatalogUnchanged` | 58.03 s | **14.50 s** |
+| `testReimport20kUnchangedMovies` | 4.59 s | **1.09 s** |
+| `testPruneFullVODCatalogWithNoDeletions`, clock | 9.35 s | **2.13 s** |
+| `testPruneFullVODCatalogWithNoDeletions`, peak RSS | 843 MB avg | **274 MB avg** |
+| `testInsert20kMoviesOnDisk` | 4.73 s | 4.87 s |
+| `testInsert20kSeriesOnDisk` | 4.64 s | 4.75 s |
+| `testInsert20kLiveStreamsOnDisk` | 2.28 s | 2.34 s |
+
+One caveat on the re-import rows, because it is easy to over-read them. The
+`insertMovies` / `insertSeries` / `insertLiveStreams` helpers in
+`PersistenceBenchmarks` are hand-written copies of the sync's upsert loop — they
+cannot call `syncMovies`, which is network-driven — and they were given the same
+per-field guards and `hasChanges` gate in the same change. So the table measures
+the *shape* of the fix, on both sides, rather than production code directly. What
+pins the production path is `ContentSyncFieldApplicationTests`: an unchanged
+payload leaves `context.hasChanges` false, so the `save()` is skipped. If you
+change `apply*Fields`, change these helpers to match or the benchmark stops
+tracking reality.
+
+A first-ever import is allowed to stay expensive — writing 282k rows means
+writing 282k rows, and on an Apple TV that is still minutes. The **refresh** path
+is the one that had to get dramatically cheaper, because it is the one users hit
+on every scheduled sync.
+
+A cold import is unchanged, and the per-kind 20k inserts are ~2-3% slower — the
+dirty check costs a comparison per field on rows that are all new anyway. That is
+the trade, and it is the right one: every scheduled sync after the first is the
+refresh case.
+
+The prune sweep's before-numbers are worth staring at: 9.35 s to delete
+**nothing**, purely to establish that no row had gone away. Its cost was never
+the deletes; it was materialising every row — which is also why its peak
+footprint was unstable, swinging 334 / 981 / 1,215 MB across three iterations
+depending on how much of the catalog SQLite had already cached. The paged sweep
+is flat at 274 MB on all three. A rewrite that had only moved wall clock would
+not have fixed the jetsam hazard on an Apple TV, which is why the benchmark
+measures memory alongside clock.
+
+### The provider gives you nothing to cache against
+
+nginx/1.24.0, HTTP/1.1, `max_connections: 1`:
+
+- **No compression.** `Accept-Encoding: gzip, deflate, br` comes back `identity`;
+  the full ~135 MB crosses the wire raw.
+- **No `ETag`, no `Last-Modified`, no `Cache-Control`.** Conditional GET is
+  unavailable, so there is no HTTP-level way to learn that a catalog is unchanged
+  — the client must download it and diff. That is why the refresh path is
+  optimised around cheap *writes* rather than a cheap fetch.
+- One connection means the three content fetches are serialized whether or not
+  the code chooses to serialize them.
+
 ## Baselines
 
 Xcode stores accepted baselines in
@@ -103,12 +215,93 @@ Two ways to get a real gate, when it's wanted:
 Until then, treat the suite as a *tool you run when you touch a hot path* and as
 the place a suspected regression gets confirmed or dismissed.
 
+## Tracing a real Apple TV
+
+`Scripts/run-performance-tests.sh` cannot answer device questions. It is
+iOS-Simulator-only by construction — it resolves an iOS 26.4+ *iPhone* simulator
+and refuses to run without one — and `LumePerformanceTests` excludes
+`appletvos` from `SUPPORTED_PLATFORMS` outright. The 4-minute sync that started
+the performance work only reproduces on the device, so it gets a manual
+`xctrace` recipe.
+
+### 1. Install a Benchmark build
+
+Select the **LumePerformance** scheme in Xcode and Run against the Apple TV: its
+build, run and test actions all pin the Benchmark configuration. Never trace a
+Debug build — `-Onone` makes the import and parser numbers fiction, which is the
+entire reason that configuration exists. From the command line:
+
+```bash
+xcrun xctrace list devices                       # find the Apple TV UDID
+xcodebuild -project Lume.xcodeproj -scheme LumePerformance \
+  -destination 'platform=tvOS,id=<APPLE_TV_UDID>' build
+```
+
+### 2. Record the sync phases
+
+`Perf` posts to an `OSSignposter` whose **subsystem is the app's bundle
+identifier** (`com.bilipp.lume`) and whose **category is `Performance`**. That
+feeds Instruments' Points of Interest lane, so the trace shows
+`SyncMovies` / `XtreamFetchMovies` / `XtreamDecodeMovies` / `UpsertMovies` /
+`PruneMovies` as intervals rather than an undifferentiated wall of stacks.
+
+```bash
+xcrun xctrace record \
+  --device <APPLE_TV_UDID> \
+  --template 'Time Profiler' \
+  --instrument 'os_signpost' \
+  --instrument 'Points of Interest' \
+  --attach Lume \
+  --time-limit 6m \
+  --output ~/Desktop/lume-sync-tvos.trace
+```
+
+Start the recording, then trigger the sync on the device. `--attach Lume` keeps
+launch out of the trace; use `--launch -- <path to Lume.app>` instead if the
+question is about launch. Filter the os_signpost instrument to subsystem
+`com.bilipp.lume`, category `Performance`.
+
+To read intervals without opening Instruments:
+
+```bash
+xcrun xctrace export --input ~/Desktop/lume-sync-tvos.trace --toc
+xcrun xctrace export --input ~/Desktop/lume-sync-tvos.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="os-signpost"]'
+```
+
+### 3. Record peak footprint separately
+
+Allocations and VM Tracker distort wall clock badly enough that mixing them into
+the Time Profiler run makes both answers useless. Take a second pass:
+
+```bash
+xcrun xctrace record \
+  --device <APPLE_TV_UDID> \
+  --template 'Allocations' \
+  --instrument 'VM Tracker' \
+  --attach Lume \
+  --time-limit 6m \
+  --output ~/Desktop/lume-sync-tvos-mem.trace
+```
+
+Peak footprint is the number that matters on an Apple TV: no swap, and a sync
+that gets jetsammed reads to the user as "the sync never finishes" rather than
+as a crash. MetricKit is compiled out on tvOS, so this trace and the signpost
+lines in the exported debug log are the only telemetry Apple TV has.
+
+### Baselines from a device are a *new* entry
+
+`.xcbaseline` files are keyed by a hardware hash. An Apple TV baseline is
+therefore a separate entry in `xcbaselines/…` and must never overwrite the iOS
+one — accepting a device measurement over a simulator baseline silently
+re-points every future comparison at different hardware.
+
 ## Deliberately not covered
 
 - **Scroll / hitch metrics.** `XCTOSSignpostMetric.scrollDecelerationMetric`
   needs a real device to mean anything, and the worst scroll cost we have
   (the tvOS focus engine) is tvOS-only while this target excludes tvOS by
-  deployment target. That stays a manual `xctrace` recipe.
+  deployment target. That stays manual — see *Tracing a real Apple TV* above.
 - **Launch time.** Already covered by `LumeUITests.testLaunchPerformance`
   (`XCTApplicationLaunchMetric`), which belongs with the UI tests.
 - **Network.** No benchmark touches a provider. Download time is the provider's

--- a/LumePerformanceTests/SignpostBenchmarks.swift
+++ b/LumePerformanceTests/SignpostBenchmarks.swift
@@ -85,6 +85,10 @@ final class SignpostBenchmarks: XCTestCase {
     func testSignpostNamesAreUnique() {
         let all: [PerfSignpost] = [
             .playlistSync, .syncCategories, .syncMovies, .syncSeries, .syncLiveStreams,
+            .xtreamFetchMovies, .xtreamDecodeMovies, .upsertMovies, .pruneMovies,
+            .xtreamFetchSeries, .xtreamDecodeSeries, .upsertSeries, .pruneSeries,
+            .xtreamFetchLiveStreams, .xtreamDecodeLiveStreams, .upsertLiveStreams, .pruneLiveStreams,
+            .xtreamPhaseSpacing,
             .m3uDownload, .m3uImport,
             .epgSourceSync, .epgIngest, .channelEPGLoad, .guideWindowLoad,
             .homeTrendingLoad, .homeRecommendations,

--- a/LumeTests/Services/ContentSyncFieldApplicationTests.swift
+++ b/LumeTests/Services/ContentSyncFieldApplicationTests.swift
@@ -1,0 +1,555 @@
+//
+//  ContentSyncFieldApplicationTests.swift
+//  LumeTests
+//
+//  Guards the dirty-checked provider-field application: an unchanged re-sync
+//  must leave the context clean, while every real provider change — including
+//  nil ⇄ "" — must still be written and every user-state field must survive.
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+/// Shared across the movie/live-stream suites below and the series suite in
+/// `ContentSyncSeriesFieldApplicationTests`; split across types and files only
+/// to stay under SwiftLint's type-body and file-length limits.
+enum FieldFixtures {
+    static func makeContainer() throws -> ModelContainer {
+        let schema = Schema([
+            Playlist.self,
+            Lume.Category.self,
+            LiveStream.self,
+            Movie.self,
+            Series.self,
+            Episode.self,
+            CastMember.self,
+            EPGListing.self,
+            EPGSource.self
+        ])
+        // `cloudKitDatabase: .none` is required: the catalog uses `@Attribute(.unique)`,
+        // which CloudKit forbids. The default `.automatic` mirrors to CloudKit on a
+        // signed/entitled test host and fails the load with `loadIssueModelContainer`.
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true, cloudKitDatabase: .none)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    /// The DTOs are decode-only (no memberwise init), so every fixture is a
+    /// provider payload verbatim.
+    static func decodeMovie(_ json: String) throws -> XtreamVODStream {
+        try JSONDecoder().decode(XtreamVODStream.self, from: Data(json.utf8))
+    }
+
+    static func decodeLiveStream(_ json: String) throws -> XtreamLiveStream {
+        try JSONDecoder().decode(XtreamLiveStream.self, from: Data(json.utf8))
+    }
+
+    static func decodeSeries(_ json: String) throws -> XtreamSeries {
+        try JSONDecoder().decode(XtreamSeries.self, from: Data(json.utf8))
+    }
+
+    static func movieJSON(
+        name: String = "The Matrix",
+        streamIcon: String = "\"https://image.tmdb.org/t/p/w600_and_h900_bestv2/f89U3ADr1oiB1s9GkdPOEpXUk5H.jpg\"",
+        rating: String = "\"8.7\"",
+        ratingFiveBased: String = "4.35",
+        added: String = "\"1690000000\"",
+        containerExtension: String = "\"mkv\"",
+        tmdb: String = "\"603\"",
+        categoryId: String = "\"77\"",
+        num: Int = 1,
+        isAdult: String = "\"0\""
+    ) -> String {
+        """
+        {"num":\(num),"name":"\(name)","stream_type":"movie","stream_id":12345,
+         "stream_icon":\(streamIcon),"rating":\(rating),"rating_5based":\(ratingFiveBased),
+         "added":\(added),"is_adult":\(isAdult),"category_id":\(categoryId),
+         "container_extension":\(containerExtension),"custom_sid":null,"direct_source":"",
+         "tmdb":\(tmdb)}
+        """
+    }
+
+    static func liveJSON(
+        name: String = "BBC One HD",
+        streamIcon: String = "\"http://provider.example.com/logos/bbc1.png\"",
+        epgChannelId: String = "\"bbc.one.uk\"",
+        added: String = "\"1650000000\"",
+        customSid: String = "null",
+        tvArchive: Int = 1,
+        tvArchiveDuration: Int = 7,
+        isAdult: Int = 0,
+        categoryId: String = "\"12\"",
+        num: Int = 3
+    ) -> String {
+        """
+        {"num":\(num),"name":"\(name)","stream_type":"live","stream_id":9876,
+         "stream_icon":\(streamIcon),"epg_channel_id":\(epgChannelId),"added":\(added),
+         "is_adult":\(isAdult),"category_id":\(categoryId),"custom_sid":\(customSid),
+         "tv_archive":\(tvArchive),"tv_archive_duration":\(tvArchiveDuration),
+         "direct_source":""}
+        """
+    }
+
+    /// Shaped after the measured provider's `get_series` rows: `rating` and
+    /// `rating_5based` arrive as strings, `backdrop_path` as an array the DTO
+    /// ignores, and `tmdb` is absent entirely for most rows.
+    static func seriesJSON(
+        name: String = "Acapulco",
+        cover: String = "\"https://image.tmdb.org/t/p/w600_and_h900_bestv2/lU0RlcfBx6y0FSmEAq61ztjMgjt.jpg\"",
+        plot: String = "\"In 1984, Maximo Gallardo lands the job of a lifetime at Las Colinas.\"",
+        cast: String = "\"Eugenio Derbez, Enrique Arrizon, Raphael Alejandro\"",
+        director: String = "\"Austin Winsberg, Jason Shuman\"",
+        genre: String = "\"Comedy / Drama\"",
+        releaseDate: String = "\"2021-10-08\"",
+        lastModified: String = "\"1776621142\"",
+        rating: String = "\"7\"",
+        ratingFiveBased: String = "\"1.4\"",
+        categoryId: String = "\"434\"",
+        tmdb: String = "\"90881\"",
+        num: Int = 1
+    ) -> String {
+        """
+        {"num":\(num),"name":"\(name)","series_id":13855,"cover":\(cover),
+         "plot":\(plot),"cast":\(cast),"director":\(director),"genre":\(genre),
+         "releaseDate":\(releaseDate),"last_modified":\(lastModified),
+         "rating":\(rating),"rating_5based":\(ratingFiveBased),
+         "backdrop_path":["https://image.tmdb.org/t/p/w1280/1vI6V8tyV7HDQYLlhn67mlLHoWJ.jpg"],
+         "youtube_trailer":"e8YKi_05emo","episode_run_time":"0",
+         "category_id":\(categoryId),"category_ids":[434],"tmdb":\(tmdb)}
+        """
+    }
+}
+
+struct ContentSyncMovieFieldTests {
+    @Test func `changed movie fields are written`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-vod-"
+        let movieId = "\(playlistId.uuidString)-movie-12345"
+
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+        let movie = Movie(id: movieId, streamId: 12345, name: "Stale name")
+        movie.rating = 1.0
+        movie.categoryId = prefix + "1"
+        context.insert(movie)
+        try context.save()
+
+        let dto = try FieldFixtures.decodeMovie(FieldFixtures.movieJSON())
+        await manager.applyMovieFields(from: dto, to: movie, playlistPrefix: prefix)
+
+        #expect(context.hasChanges, "A changed provider payload must dirty the context")
+        #expect(movie.name == "The Matrix")
+        #expect(movie.streamIcon == "https://image.tmdb.org/t/p/w600_and_h900_bestv2/f89U3ADr1oiB1s9GkdPOEpXUk5H.jpg")
+        #expect(movie.rating == 8.7)
+        #expect(movie.rating5Based == 4.35)
+        #expect(movie.added == "1690000000")
+        #expect(movie.containerExtension == "mkv")
+        #expect(movie.tmdb == "603")
+        #expect(movie.tmdbId == 603)
+        #expect(movie.num == 1)
+        #expect(movie.isAdult == 0)
+        #expect(movie.categoryId == prefix + "77")
+    }
+
+    @Test func `unchanged movie batch leaves the context clean`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-vod-"
+        let movieId = "\(playlistId.uuidString)-movie-12345"
+        let dto = try FieldFixtures.decodeMovie(FieldFixtures.movieJSON())
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Movie(id: movieId, streamId: 12345, name: "")
+        firstSync.insert(inserted)
+        await manager.applyMovieFields(from: dto, to: inserted, playlistPrefix: prefix)
+        try firstSync.save()
+
+        // Second sync of the identical payload, through a fresh context exactly
+        // as the batch loop builds one.
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<Movie>(predicate: #Predicate { $0.id == movieId })
+        ).first)
+        await manager.applyMovieFields(from: dto, to: stored, playlistPrefix: prefix)
+
+        #expect(!reSync.hasChanges, "An unchanged payload must not dirty the context — the save is then skipped")
+    }
+
+    @Test func `numeric movie fields round-trip through both provider representations`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-vod-"
+        let movieId = "\(playlistId.uuidString)-movie-12345"
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Movie(id: movieId, streamId: 12345, name: "")
+        firstSync.insert(inserted)
+        try await manager.applyMovieFields(
+            from: FieldFixtures.decodeMovie(FieldFixtures.movieJSON(rating: "\"8.7\"", ratingFiveBased: "4.35")),
+            to: inserted,
+            playlistPrefix: prefix
+        )
+        try firstSync.save()
+
+        // Same values, sent as a JSON number and a JSON string respectively —
+        // the lenient decoders must land on the identical Double, so nothing is
+        // rewritten.
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<Movie>(predicate: #Predicate { $0.id == movieId })
+        ).first)
+        try await manager.applyMovieFields(
+            from: FieldFixtures.decodeMovie(FieldFixtures.movieJSON(rating: "8.7", ratingFiveBased: "\"4.35\"")),
+            to: stored,
+            playlistPrefix: prefix
+        )
+
+        #expect(!reSync.hasChanges)
+        #expect(stored.rating == 8.7)
+        #expect(stored.rating5Based == 4.35)
+    }
+
+    @Test func `movie nil to empty string is written`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-vod-"
+        let movieId = "\(playlistId.uuidString)-movie-12345"
+
+        // Baseline sync: the provider omitted these keys, so they store as nil.
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Movie(id: movieId, streamId: 12345, name: "")
+        firstSync.insert(inserted)
+        try await manager.applyMovieFields(
+            from: FieldFixtures.decodeMovie(FieldFixtures.movieJSON(streamIcon: "null", containerExtension: "null", tmdb: "null")),
+            to: inserted,
+            playlistPrefix: prefix
+        )
+        try firstSync.save()
+        #expect(inserted.streamIcon == nil)
+
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<Movie>(predicate: #Predicate { $0.id == movieId })
+        ).first)
+        try await manager.applyMovieFields(
+            from: FieldFixtures.decodeMovie(FieldFixtures.movieJSON(streamIcon: "\"\"", containerExtension: "\"\"", tmdb: "\"\"")),
+            to: stored,
+            playlistPrefix: prefix
+        )
+
+        #expect(reSync.hasChanges, "nil → \"\" is a real change and must be written")
+        #expect(stored.streamIcon == "")
+        #expect(stored.containerExtension == "")
+        #expect(stored.tmdb == "")
+        #expect(stored.tmdbId == nil, "An unparseable tmdb must leave the resolved id alone")
+    }
+
+    @Test func `movie empty string to nil is written`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-vod-"
+        let movieId = "\(playlistId.uuidString)-movie-12345"
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Movie(id: movieId, streamId: 12345, name: "")
+        firstSync.insert(inserted)
+        try await manager.applyMovieFields(
+            from: FieldFixtures.decodeMovie(FieldFixtures.movieJSON(streamIcon: "\"\"", added: "\"\"")),
+            to: inserted,
+            playlistPrefix: prefix
+        )
+        try firstSync.save()
+        #expect(inserted.streamIcon == "")
+
+        // The provider dropped both keys: the lenient decoders yield nil.
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<Movie>(predicate: #Predicate { $0.id == movieId })
+        ).first)
+        try await manager.applyMovieFields(
+            from: FieldFixtures.decodeMovie(FieldFixtures.movieJSON(streamIcon: "null", added: "null")),
+            to: stored,
+            playlistPrefix: prefix
+        )
+
+        #expect(reSync.hasChanges, "\"\" → nil is a real change and must be written")
+        #expect(stored.streamIcon == nil)
+        #expect(stored.added == nil)
+    }
+
+    @Test func `movie empty strings on both sides stay clean`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-vod-"
+        let movieId = "\(playlistId.uuidString)-movie-12345"
+        let dto = try FieldFixtures.decodeMovie(FieldFixtures.movieJSON(streamIcon: "\"\"", tmdb: "\"\""))
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Movie(id: movieId, streamId: 12345, name: "")
+        firstSync.insert(inserted)
+        await manager.applyMovieFields(from: dto, to: inserted, playlistPrefix: prefix)
+        try firstSync.save()
+
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<Movie>(predicate: #Predicate { $0.id == movieId })
+        ).first)
+        #expect(stored.streamIcon == "")
+        await manager.applyMovieFields(from: dto, to: stored, playlistPrefix: prefix)
+
+        #expect(!reSync.hasChanges)
+    }
+
+    @Test func `a movie payload without a category leaves the stored category alone`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-vod-"
+        let movieId = "\(playlistId.uuidString)-movie-12345"
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Movie(id: movieId, streamId: 12345, name: "")
+        firstSync.insert(inserted)
+        try await manager.applyMovieFields(from: FieldFixtures.decodeMovie(FieldFixtures.movieJSON()), to: inserted, playlistPrefix: prefix)
+        try firstSync.save()
+
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<Movie>(predicate: #Predicate { $0.id == movieId })
+        ).first)
+        try await manager.applyMovieFields(
+            from: FieldFixtures.decodeMovie(FieldFixtures.movieJSON(categoryId: "null")),
+            to: stored,
+            playlistPrefix: prefix
+        )
+
+        #expect(stored.categoryId == prefix + "77")
+        #expect(!reSync.hasChanges)
+    }
+
+    @Test func `movie user state and enrichment survive a re-sync`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-vod-"
+        let movieId = "\(playlistId.uuidString)-movie-12345"
+        let watched = Date(timeIntervalSince1970: 1_000_000)
+        let addedToWatchlist = Date(timeIntervalSince1970: 2_000_000)
+        let enriched = Date(timeIntervalSince1970: 3_000_000)
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Movie(id: movieId, streamId: 12345, name: "")
+        firstSync.insert(inserted)
+        try await manager.applyMovieFields(from: FieldFixtures.decodeMovie(FieldFixtures.movieJSON()), to: inserted, playlistPrefix: prefix)
+        inserted.isFavorite = true
+        inserted.favoriteOrder = 4
+        inserted.watchProgress = 1234
+        inserted.isWatched = true
+        inserted.lastWatchedDate = watched
+        inserted.addedToWatchlistDate = addedToWatchlist
+        inserted.plot = "TMDB plot"
+        inserted.genre = "Science Fiction"
+        inserted.backdropPath = "/backdrop.jpg"
+        inserted.tmdbEnrichedAt = enriched
+        try firstSync.save()
+
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<Movie>(predicate: #Predicate { $0.id == movieId })
+        ).first)
+        try await manager.applyMovieFields(
+            from: FieldFixtures.decodeMovie(FieldFixtures.movieJSON(name: "The Matrix (Remastered)")),
+            to: stored,
+            playlistPrefix: prefix
+        )
+        try reSync.save()
+
+        let verify = ModelContext(container)
+        let result = try #require(try verify.fetch(
+            FetchDescriptor<Movie>(predicate: #Predicate { $0.id == movieId })
+        ).first)
+        #expect(result.name == "The Matrix (Remastered)", "The provider rename must land")
+        #expect(result.isFavorite)
+        #expect(result.favoriteOrder == 4)
+        #expect(result.watchProgress == 1234)
+        #expect(result.isWatched)
+        #expect(result.lastWatchedDate == watched)
+        #expect(result.addedToWatchlistDate == addedToWatchlist)
+        #expect(result.plot == "TMDB plot")
+        #expect(result.genre == "Science Fiction")
+        #expect(result.backdropPath == "/backdrop.jpg")
+        #expect(result.tmdbEnrichedAt == enriched)
+    }
+}
+
+struct ContentSyncLiveStreamFieldTests {
+    @Test func `changed live stream fields are written`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-live-"
+        let streamId = "\(playlistId.uuidString)-live-9876"
+
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+        let stream = LiveStream(id: streamId, streamId: 9876, name: "Stale name")
+        context.insert(stream)
+        try context.save()
+
+        try await manager.applyLiveStreamFields(from: FieldFixtures.decodeLiveStream(FieldFixtures.liveJSON()), to: stream, playlistPrefix: prefix)
+
+        #expect(context.hasChanges)
+        #expect(stream.name == "BBC One HD")
+        #expect(stream.streamIcon == "http://provider.example.com/logos/bbc1.png")
+        #expect(stream.epgChannelId == "bbc.one.uk")
+        #expect(stream.added == "1650000000")
+        #expect(stream.customSid == nil)
+        #expect(stream.tvArchive == 1)
+        #expect(stream.tvArchiveDuration == 7)
+        #expect(stream.isAdult == 0)
+        #expect(stream.num == 3)
+        #expect(stream.categoryId == prefix + "12")
+    }
+
+    @Test func `unchanged live stream batch leaves the context clean`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-live-"
+        let streamId = "\(playlistId.uuidString)-live-9876"
+        let dto = try FieldFixtures.decodeLiveStream(FieldFixtures.liveJSON())
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = LiveStream(id: streamId, streamId: 9876, name: "")
+        firstSync.insert(inserted)
+        await manager.applyLiveStreamFields(from: dto, to: inserted, playlistPrefix: prefix)
+        try firstSync.save()
+
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<LiveStream>(predicate: #Predicate { $0.id == streamId })
+        ).first)
+        await manager.applyLiveStreamFields(from: dto, to: stored, playlistPrefix: prefix)
+
+        #expect(!reSync.hasChanges, "An unchanged payload must not dirty the context — the save is then skipped")
+    }
+
+    @Test func `live stream empty and nil epg ids round-trip both ways`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-live-"
+        let streamId = "\(playlistId.uuidString)-live-9876"
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = LiveStream(id: streamId, streamId: 9876, name: "")
+        firstSync.insert(inserted)
+        try await manager.applyLiveStreamFields(
+            from: FieldFixtures.decodeLiveStream(FieldFixtures.liveJSON(streamIcon: "null", epgChannelId: "null")),
+            to: inserted,
+            playlistPrefix: prefix
+        )
+        try firstSync.save()
+        #expect(inserted.epgChannelId == nil)
+
+        // Most rows in a real payload carry "" here, not null.
+        let toEmpty = ModelContext(container)
+        toEmpty.autosaveEnabled = false
+        let stored = try #require(try toEmpty.fetch(
+            FetchDescriptor<LiveStream>(predicate: #Predicate { $0.id == streamId })
+        ).first)
+        try await manager.applyLiveStreamFields(
+            from: FieldFixtures.decodeLiveStream(FieldFixtures.liveJSON(streamIcon: "\"\"", epgChannelId: "\"\"")),
+            to: stored,
+            playlistPrefix: prefix
+        )
+        #expect(toEmpty.hasChanges, "nil → \"\" is a real change and must be written")
+        #expect(stored.epgChannelId == "")
+        #expect(stored.streamIcon == "")
+        try toEmpty.save()
+
+        let toNil = ModelContext(container)
+        toNil.autosaveEnabled = false
+        let reFetched = try #require(try toNil.fetch(
+            FetchDescriptor<LiveStream>(predicate: #Predicate { $0.id == streamId })
+        ).first)
+        try await manager.applyLiveStreamFields(
+            from: FieldFixtures.decodeLiveStream(FieldFixtures.liveJSON(streamIcon: "null", epgChannelId: "null")),
+            to: reFetched,
+            playlistPrefix: prefix
+        )
+        #expect(toNil.hasChanges, "\"\" → nil is a real change and must be written")
+        #expect(reFetched.epgChannelId == nil)
+        #expect(reFetched.streamIcon == nil)
+    }
+
+    @Test func `live stream user state survives a re-sync`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-live-"
+        let streamId = "\(playlistId.uuidString)-live-9876"
+        let watched = Date(timeIntervalSince1970: 1_500_000)
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = LiveStream(id: streamId, streamId: 9876, name: "")
+        firstSync.insert(inserted)
+        try await manager.applyLiveStreamFields(from: FieldFixtures.decodeLiveStream(FieldFixtures.liveJSON()), to: inserted, playlistPrefix: prefix)
+        inserted.isFavorite = true
+        inserted.favoriteOrder = 2
+        inserted.isHidden = true
+        inserted.customOrder = 7
+        inserted.lastWatchedDate = watched
+        try firstSync.save()
+
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<LiveStream>(predicate: #Predicate { $0.id == streamId })
+        ).first)
+        try await manager.applyLiveStreamFields(
+            from: FieldFixtures.decodeLiveStream(FieldFixtures.liveJSON(name: "BBC One UHD", num: 4)),
+            to: stored,
+            playlistPrefix: prefix
+        )
+        try reSync.save()
+
+        let verify = ModelContext(container)
+        let result = try #require(try verify.fetch(
+            FetchDescriptor<LiveStream>(predicate: #Predicate { $0.id == streamId })
+        ).first)
+        #expect(result.name == "BBC One UHD", "The provider rename must land")
+        #expect(result.num == 4)
+        #expect(result.isFavorite)
+        #expect(result.favoriteOrder == 2)
+        #expect(result.isHidden)
+        #expect(result.customOrder == 7)
+        #expect(result.lastWatchedDate == watched)
+    }
+}

--- a/LumeTests/Services/ContentSyncManagerLogicTests.swift
+++ b/LumeTests/Services/ContentSyncManagerLogicTests.swift
@@ -70,6 +70,48 @@ struct ContentSyncManagerLogicTests {
         #expect(result == "Pokémon")
     }
 
+    // MARK: - Inter-phase request spacing
+
+    @Test func `no previous request needs no spacing`() {
+        #expect(ContentSyncManager.outstandingPhaseSpacing(since: nil) == .zero)
+    }
+
+    @Test func `a phase that took longer than the spacing waits not at all`() {
+        let now = ContinuousClock.now
+        let remaining = ContentSyncManager.outstandingPhaseSpacing(
+            since: now - .seconds(45),
+            now: now
+        )
+        #expect(remaining == .zero)
+    }
+
+    @Test func `a fast phase waits only the outstanding remainder`() {
+        let now = ContinuousClock.now
+        let remaining = ContentSyncManager.outstandingPhaseSpacing(
+            since: now - .milliseconds(500),
+            now: now
+        )
+        #expect(remaining == .milliseconds(1500))
+    }
+
+    @Test func `spacing never exceeds the configured gap`() {
+        let now = ContinuousClock.now
+        let remaining = ContentSyncManager.outstandingPhaseSpacing(
+            since: now + .seconds(30),
+            now: now
+        )
+        #expect(remaining == ContentSyncManager.contentPhaseRequestSpacing)
+    }
+
+    @Test func `a phase exactly at the spacing boundary waits not at all`() {
+        let now = ContinuousClock.now
+        let remaining = ContentSyncManager.outstandingPhaseSpacing(
+            since: now - ContentSyncManager.contentPhaseRequestSpacing,
+            now: now
+        )
+        #expect(remaining == .zero)
+    }
+
     // MARK: - SyncStatus
 
     @Test func `playlist idle is default`() {

--- a/LumeTests/Services/ContentSyncPruneTests.swift
+++ b/LumeTests/Services/ContentSyncPruneTests.swift
@@ -1,0 +1,270 @@
+//
+//  ContentSyncPruneTests.swift
+//  LumeTests
+//
+//  The paged mark-and-sweep in ContentSyncManager+Prune: it deletes while the
+//  deletions shift the fetch window underneath it, so every fixture here spans
+//  several pages — a catalog that fits in one page passes even with the offset
+//  arithmetic removed.
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+struct ContentSyncPruneTests {
+    /// Mirrors the sweep's page size; the fixtures below are sized against it.
+    private let pageSize = 2000
+
+    // MARK: - Fixtures
+
+    private func insertMovies(_ range: Range<Int>, playlistId: UUID, container: ModelContainer) throws {
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+        for index in range {
+            context.insert(Movie(id: movieId(index, playlistId: playlistId), streamId: index, name: "Movie \(index)"))
+        }
+        try context.save()
+    }
+
+    private func movieId(_ index: Int, playlistId: UUID) -> String {
+        "\(playlistId.uuidString)-movie-\(index)"
+    }
+
+    private func storedMovieIds(_ container: ModelContainer) throws -> Set<String> {
+        try Set(ModelContext(container).fetch(FetchDescriptor<Movie>()).map(\.id))
+    }
+
+    private func vodDTOs(streamIds: [Int]) throws -> [XtreamVODStream] {
+        let json = "[" + streamIds.map { "{\"stream_id\":\($0)}" }.joined(separator: ",") + "]"
+        return try JSONDecoder().decode([XtreamVODStream].self, from: Data(json.utf8))
+    }
+
+    /// Mirrors what `syncMovies` accumulates while writing its batches — the
+    /// sweep entry point takes that set, not the payload it came from.
+    private func seenMovieIds(_ dtos: [XtreamVODStream], playlistId: UUID) -> Set<String> {
+        Set(dtos.compactMap { dto in dto.streamId.map { movieId($0, playlistId: playlistId) } })
+    }
+
+    // MARK: - Paging
+
+    @Test func `sweep removes every unseen row across page boundaries`() async throws {
+        let container = try makeTestContainer()
+        let playlistId = UUID()
+        let total = pageSize * 2 + 500
+        try insertMovies(0 ..< total, playlistId: playlistId, container: container)
+
+        // Deletions scattered through every page: each page shrinks the table
+        // under the next one's offset.
+        let seen = (0 ..< total).filter { $0 % 3 != 0 }
+        let seenIds = Set(seen.map { movieId($0, playlistId: playlistId) })
+
+        let manager = ContentSyncManager(modelContainer: container)
+        await manager.pruneStaleMovies(playlistId: playlistId, seenIds: seenIds)
+
+        #expect(try storedMovieIds(container) == seenIds)
+    }
+
+    @Test func `sweep removes rows that fill whole pages`() async throws {
+        let container = try makeTestContainer()
+        let playlistId = UUID()
+        try insertMovies(0 ..< (pageSize * 2 + 250), playlistId: playlistId, container: container)
+
+        // Nothing is seen, so every page deletes in full and the offset never
+        // advances — the case where a naive `offset += pageSize` skips rows.
+        let manager = ContentSyncManager(modelContainer: container)
+        await manager.pruneStaleMovies(playlistId: playlistId, seenIds: [])
+
+        #expect(try storedMovieIds(container).isEmpty)
+    }
+
+    @Test func `sweep leaves other playlists alone`() async throws {
+        let container = try makeTestContainer()
+        let swept = UUID()
+        let untouched = UUID()
+        try insertMovies(0 ..< (pageSize + 100), playlistId: swept, container: container)
+        try insertMovies(0 ..< (pageSize + 100), playlistId: untouched, container: container)
+
+        let manager = ContentSyncManager(modelContainer: container)
+        await manager.pruneStaleMovies(playlistId: swept, seenIds: [])
+
+        let remaining = try storedMovieIds(container)
+        #expect(remaining.count == pageSize + 100)
+        #expect(remaining.allSatisfy { $0.hasPrefix(untouched.uuidString) })
+    }
+
+    @Test func `surviving rows keep their user state`() async throws {
+        let container = try makeTestContainer()
+        let playlistId = UUID()
+        try insertMovies(0 ..< (pageSize + 100), playlistId: playlistId, container: container)
+
+        let survivorId = movieId(pageSize + 50, playlistId: playlistId)
+        do {
+            let context = ModelContext(container)
+            let survivor = try #require(
+                try context.fetch(FetchDescriptor<Movie>(predicate: #Predicate { $0.id == survivorId })).first
+            )
+            survivor.isFavorite = true
+            survivor.watchProgress = 0.42
+            try context.save()
+        }
+
+        let manager = ContentSyncManager(modelContainer: container)
+        await manager.pruneStaleMovies(playlistId: playlistId, seenIds: [survivorId])
+
+        let context = ModelContext(container)
+        let survivors = try context.fetch(FetchDescriptor<Movie>())
+        #expect(survivors.count == 1)
+        #expect(survivors.first?.isFavorite == true)
+        #expect(survivors.first?.watchProgress == 0.42)
+    }
+
+    @Test func `series sweep takes their episodes with them`() async throws {
+        let container = try makeTestContainer()
+        let playlistId = UUID()
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+        for index in 0 ..< (pageSize + 100) {
+            let show = Series(id: "\(playlistId.uuidString)-series-\(index)", seriesId: index, name: "Show \(index)")
+            context.insert(show)
+            let episode = Episode(
+                id: "\(playlistId.uuidString)-series-\(index)-episode-1",
+                episodeId: "1",
+                title: "Pilot",
+                containerExtension: "mkv",
+                seasonNum: 1,
+                episodeNum: 1
+            )
+            context.insert(episode)
+            show.episodes.append(episode)
+        }
+        try context.save()
+
+        let keptId = "\(playlistId.uuidString)-series-7"
+        let manager = ContentSyncManager(modelContainer: container)
+        await manager.pruneStaleSeries(playlistId: playlistId, seenIds: [keptId])
+
+        let check = ModelContext(container)
+        #expect(try check.fetchCount(FetchDescriptor<Series>()) == 1)
+        // Orphaned episodes would carry the watch progress of deleted shows.
+        #expect(try check.fetchCount(FetchDescriptor<Episode>()) == 1)
+        #expect(try check.fetch(FetchDescriptor<Episode>()).first?.series?.id == keptId)
+    }
+
+    // MARK: - Xtream payload sanity gate
+
+    @Test func `a payload covering too little of the catalog is not swept`() async throws {
+        let container = try makeTestContainer()
+        let playlistId = UUID()
+        try insertMovies(0 ..< pageSize, playlistId: playlistId, container: container)
+
+        // XtreamList drops rows that fail to decode and only rethrows when all
+        // of them do, so a mostly-malformed payload reaches the sweep as a
+        // small non-empty array.
+        let dtos = try vodDTOs(streamIds: Array(0 ..< 100))
+        let manager = ContentSyncManager(modelContainer: container)
+        await manager.pruneMovies(
+            playlistId: playlistId,
+            seenIds: seenMovieIds(dtos, playlistId: playlistId),
+            fetchedCount: dtos.count
+        )
+
+        #expect(try storedMovieIds(container).count == pageSize)
+    }
+
+    @Test func `a payload covering enough of the catalog still prunes`() async throws {
+        let container = try makeTestContainer()
+        let playlistId = UUID()
+        try insertMovies(0 ..< pageSize, playlistId: playlistId, container: container)
+
+        let dtos = try vodDTOs(streamIds: Array(0 ..< 500))
+        let manager = ContentSyncManager(modelContainer: container)
+        await manager.pruneMovies(
+            playlistId: playlistId,
+            seenIds: seenMovieIds(dtos, playlistId: playlistId),
+            fetchedCount: dtos.count
+        )
+
+        #expect(try storedMovieIds(container).count == 500)
+    }
+
+    @Test func `a payload whose rows carry no stream id is never swept`() async throws {
+        let container = try makeTestContainer()
+        let playlistId = UUID()
+        try insertMovies(0 ..< pageSize, playlistId: playlistId, container: container)
+
+        // The batch loop skips rows without a stream id, so a payload of them
+        // accumulates no seen ids at all — the row count is what tells the gate
+        // this was a real response and not an empty fetch.
+        let manager = ContentSyncManager(modelContainer: container)
+        await manager.pruneMovies(playlistId: playlistId, seenIds: [], fetchedCount: 300)
+
+        #expect(try storedMovieIds(container).count == pageSize)
+    }
+
+    @Test func `a catalog that really shrank is swept once the skips run out`() async throws {
+        let container = try makeTestContainer()
+        let playlistId = UUID()
+        try insertMovies(0 ..< pageSize, playlistId: playlistId, container: container)
+
+        // The coverage gate measures the payload against the STORED rows, and a
+        // skipped sweep never reduces them — so a subscription that legitimately
+        // shrinks below the floor would be refused forever and strand the dead
+        // rows. The gate tolerates a bounded number of consecutive refusals and
+        // then lets the sweep through.
+        let dtos = try vodDTOs(streamIds: Array(0 ..< 100))
+        let seen = seenMovieIds(dtos, playlistId: playlistId)
+        let manager = ContentSyncManager(modelContainer: container)
+
+        for _ in 0 ..< 2 {
+            await manager.pruneMovies(playlistId: playlistId, seenIds: seen, fetchedCount: dtos.count)
+            #expect(try storedMovieIds(container).count == pageSize)
+        }
+
+        await manager.pruneMovies(playlistId: playlistId, seenIds: seen, fetchedCount: dtos.count)
+        #expect(try storedMovieIds(container).count == 100)
+    }
+
+    @Test func `a healthy sync clears the skip count`() async throws {
+        let container = try makeTestContainer()
+        let playlistId = UUID()
+        try insertMovies(0 ..< pageSize, playlistId: playlistId, container: container)
+
+        let manager = ContentSyncManager(modelContainer: container)
+        let thin = try vodDTOs(streamIds: Array(0 ..< 100))
+        await manager.pruneMovies(
+            playlistId: playlistId,
+            seenIds: seenMovieIds(thin, playlistId: playlistId),
+            fetchedCount: thin.count
+        )
+
+        // A payload that covers the catalog resets the counter, so the next thin
+        // one starts its tolerance over rather than tipping straight into a sweep.
+        let healthy = try vodDTOs(streamIds: Array(0 ..< pageSize))
+        await manager.pruneMovies(
+            playlistId: playlistId,
+            seenIds: seenMovieIds(healthy, playlistId: playlistId),
+            fetchedCount: healthy.count
+        )
+        #expect(try storedMovieIds(container).count == pageSize)
+
+        await manager.pruneMovies(
+            playlistId: playlistId,
+            seenIds: seenMovieIds(thin, playlistId: playlistId),
+            fetchedCount: thin.count
+        )
+        #expect(try storedMovieIds(container).count == pageSize)
+    }
+
+    @Test func `an empty payload is never swept`() async throws {
+        let container = try makeTestContainer()
+        let playlistId = UUID()
+        try insertMovies(0 ..< 100, playlistId: playlistId, container: container)
+
+        let manager = ContentSyncManager(modelContainer: container)
+        await manager.pruneMovies(playlistId: playlistId, seenIds: [], fetchedCount: 0)
+
+        #expect(try storedMovieIds(container).count == 100)
+    }
+}

--- a/LumeTests/Services/ContentSyncSeriesFieldApplicationTests.swift
+++ b/LumeTests/Services/ContentSyncSeriesFieldApplicationTests.swift
@@ -1,0 +1,303 @@
+//
+//  ContentSyncSeriesFieldApplicationTests.swift
+//  LumeTests
+//
+//  The series half of the dirty-checked provider-field application. Split from
+//  ContentSyncFieldApplicationTests only to stay under the file-length limit;
+//  the fixtures live there.
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+struct ContentSyncSeriesFieldTests {
+    @Test func `changed series fields are written`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-series-"
+        let id = "\(playlistId.uuidString)-series-13855"
+
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+        let series = Series(id: id, seriesId: 13855, name: "Stale name")
+        series.rating = "1"
+        series.categoryId = prefix + "1"
+        context.insert(series)
+        try context.save()
+
+        try await manager.applySeriesFields(from: FieldFixtures.decodeSeries(FieldFixtures.seriesJSON()), to: series, playlistPrefix: prefix)
+
+        #expect(context.hasChanges, "A changed provider payload must dirty the context")
+        #expect(series.name == "Acapulco")
+        #expect(series.cover == "https://image.tmdb.org/t/p/w600_and_h900_bestv2/lU0RlcfBx6y0FSmEAq61ztjMgjt.jpg")
+        #expect(series.plot == "In 1984, Maximo Gallardo lands the job of a lifetime at Las Colinas.")
+        #expect(series.cast == "Eugenio Derbez, Enrique Arrizon, Raphael Alejandro")
+        #expect(series.director == "Austin Winsberg, Jason Shuman")
+        #expect(series.genre == "Comedy / Drama")
+        #expect(series.releaseDate == "2021-10-08")
+        #expect(series.lastModified == "1776621142")
+        #expect(series.rating == "7")
+        #expect(series.rating5Based == "1.4")
+        #expect(series.tmdb == "90881")
+        #expect(series.tmdbId == 90881)
+        #expect(series.num == 1)
+        #expect(series.categoryId == prefix + "434")
+    }
+
+    @Test func `unchanged series batch leaves the context clean`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-series-"
+        let id = "\(playlistId.uuidString)-series-13855"
+        let dto = try FieldFixtures.decodeSeries(FieldFixtures.seriesJSON())
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Series(id: id, seriesId: 13855, name: "")
+        firstSync.insert(inserted)
+        await manager.applySeriesFields(from: dto, to: inserted, playlistPrefix: prefix)
+        try firstSync.save()
+
+        // Second sync of the identical payload, through a fresh context exactly
+        // as the batch loop builds one.
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<Series>(predicate: #Predicate { $0.id == id })
+        ).first)
+        await manager.applySeriesFields(from: dto, to: stored, playlistPrefix: prefix)
+
+        #expect(!reSync.hasChanges, "An unchanged payload must not dirty the context — the save is then skipped")
+    }
+
+    @Test func `a provider genre seeds an unset series genre exactly once`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-series-"
+        let id = "\(playlistId.uuidString)-series-13855"
+        let dto = try FieldFixtures.decodeSeries(FieldFixtures.seriesJSON())
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Series(id: id, seriesId: 13855, name: "")
+        firstSync.insert(inserted)
+        #expect(inserted.genre == nil)
+        await manager.applySeriesFields(from: dto, to: inserted, playlistPrefix: prefix)
+        #expect(inserted.genre == "Comedy / Drama", "An unset genre must be seeded from the provider")
+        try firstSync.save()
+
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<Series>(predicate: #Predicate { $0.id == id })
+        ).first)
+        await manager.applySeriesFields(from: dto, to: stored, playlistPrefix: prefix)
+
+        #expect(stored.genre == "Comedy / Drama")
+        #expect(!reSync.hasChanges, "The seeded genre must not be rewritten on the next sync")
+    }
+
+    @Test func `a TMDB series genre is never overwritten and never dirties the context`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-series-"
+        let id = "\(playlistId.uuidString)-series-13855"
+        let dto = try FieldFixtures.decodeSeries(FieldFixtures.seriesJSON())
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Series(id: id, seriesId: 13855, name: "")
+        firstSync.insert(inserted)
+        await manager.applySeriesFields(from: dto, to: inserted, playlistPrefix: prefix)
+        // TMDB enrichment then takes ownership of the genre.
+        inserted.genre = "Comedy, Drama"
+        try firstSync.save()
+
+        // The dirty check has to compare GenreParser.providerFallback's result:
+        // comparing the raw "Comedy / Drama" would rewrite this row forever.
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<Series>(predicate: #Predicate { $0.id == id })
+        ).first)
+        await manager.applySeriesFields(from: dto, to: stored, playlistPrefix: prefix)
+
+        #expect(stored.genre == "Comedy, Drama", "TMDB owns the genre; the provider must not overwrite it")
+        #expect(!reSync.hasChanges)
+    }
+
+    @Test func `series nil and empty string transitions are written`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-series-"
+        let id = "\(playlistId.uuidString)-series-13855"
+
+        // The provider omitted these keys, so they store as nil.
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Series(id: id, seriesId: 13855, name: "")
+        firstSync.insert(inserted)
+        try await manager.applySeriesFields(
+            from: FieldFixtures.decodeSeries(FieldFixtures.seriesJSON(cast: "null", director: "null", tmdb: "null")),
+            to: inserted,
+            playlistPrefix: prefix
+        )
+        try firstSync.save()
+        #expect(inserted.cast == nil)
+        #expect(inserted.tmdbId == nil, "An absent provider tmdb must leave the resolved id alone")
+
+        // Most rows in a real payload carry "" here, not null.
+        let toEmpty = ModelContext(container)
+        toEmpty.autosaveEnabled = false
+        let stored = try #require(try toEmpty.fetch(
+            FetchDescriptor<Series>(predicate: #Predicate { $0.id == id })
+        ).first)
+        try await manager.applySeriesFields(
+            from: FieldFixtures.decodeSeries(FieldFixtures.seriesJSON(cast: "\"\"", director: "\"\"", tmdb: "\"\"")),
+            to: stored,
+            playlistPrefix: prefix
+        )
+        #expect(toEmpty.hasChanges, "nil → \"\" is a real change and must be written")
+        #expect(stored.cast == "")
+        #expect(stored.director == "")
+        #expect(stored.tmdb == "")
+        try toEmpty.save()
+
+        let toNil = ModelContext(container)
+        toNil.autosaveEnabled = false
+        let reFetched = try #require(try toNil.fetch(
+            FetchDescriptor<Series>(predicate: #Predicate { $0.id == id })
+        ).first)
+        try await manager.applySeriesFields(
+            from: FieldFixtures.decodeSeries(FieldFixtures.seriesJSON(cast: "null", director: "null", tmdb: "null")),
+            to: reFetched,
+            playlistPrefix: prefix
+        )
+        #expect(toNil.hasChanges, "\"\" → nil is a real change and must be written")
+        #expect(reFetched.cast == nil)
+        #expect(reFetched.director == nil)
+        #expect(reFetched.tmdb == nil)
+    }
+
+    @Test func `a series payload without a category leaves the stored category alone`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-series-"
+        let id = "\(playlistId.uuidString)-series-13855"
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Series(id: id, seriesId: 13855, name: "")
+        firstSync.insert(inserted)
+        try await manager.applySeriesFields(from: FieldFixtures.decodeSeries(FieldFixtures.seriesJSON()), to: inserted, playlistPrefix: prefix)
+        try firstSync.save()
+
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<Series>(predicate: #Predicate { $0.id == id })
+        ).first)
+        try await manager.applySeriesFields(
+            from: FieldFixtures.decodeSeries(FieldFixtures.seriesJSON(categoryId: "null")),
+            to: stored,
+            playlistPrefix: prefix
+        )
+
+        #expect(stored.categoryId == prefix + "434")
+        #expect(!reSync.hasChanges)
+    }
+
+    @Test func `series user state and enrichment survive a re-sync`() async throws {
+        let container = try FieldFixtures.makeContainer()
+        let manager = ContentSyncManager(modelContainer: container)
+        let playlistId = UUID()
+        let prefix = "\(playlistId.uuidString)-series-"
+        let id = "\(playlistId.uuidString)-series-13855"
+        let watched = Date(timeIntervalSince1970: 1_000_000)
+        let addedToWatchlist = Date(timeIntervalSince1970: 2_000_000)
+        let enriched = Date(timeIntervalSince1970: 3_000_000)
+
+        let firstSync = ModelContext(container)
+        firstSync.autosaveEnabled = false
+        let inserted = Series(id: id, seriesId: 13855, name: "")
+        firstSync.insert(inserted)
+        // tmdb absent, as the measured provider sends it: the resolved id and
+        // the rest of the enrichment are then TMDB's alone.
+        try await manager.applySeriesFields(
+            from: FieldFixtures.decodeSeries(FieldFixtures.seriesJSON(tmdb: "null")),
+            to: inserted,
+            playlistPrefix: prefix
+        )
+        seedUserState(on: inserted, in: firstSync, watched: watched, watchlisted: addedToWatchlist, enriched: enriched)
+        try firstSync.save()
+
+        let reSync = ModelContext(container)
+        reSync.autosaveEnabled = false
+        let stored = try #require(try reSync.fetch(
+            FetchDescriptor<Series>(predicate: #Predicate { $0.id == id })
+        ).first)
+        try await manager.applySeriesFields(
+            from: FieldFixtures.decodeSeries(FieldFixtures.seriesJSON(name: "Acapulco (2021)", tmdb: "null")),
+            to: stored,
+            playlistPrefix: prefix
+        )
+        try reSync.save()
+
+        let verify = ModelContext(container)
+        let result = try #require(try verify.fetch(
+            FetchDescriptor<Series>(predicate: #Predicate { $0.id == id })
+        ).first)
+        #expect(result.name == "Acapulco (2021)", "The provider rename must land")
+        #expect(result.isFavorite)
+        #expect(result.favoriteOrder == 4)
+        #expect(result.lastWatchedDate == watched)
+        #expect(result.addedToWatchlistDate == addedToWatchlist)
+        #expect(result.genre == "Comedy, Drama")
+        #expect(result.backdropPath == "/backdrop.jpg")
+        #expect(result.tagline == "Welcome to Las Colinas")
+        #expect(result.tmdbId == 90881)
+        #expect(result.tmdbEnrichedAt == enriched)
+        #expect(result.episodes.first?.watchProgress == 900)
+    }
+
+    /// Everything a re-sync must leave alone: the series' own user state, the
+    /// TMDB enrichment that outranks the provider, and an episode carrying watch
+    /// progress (series deletes cascade to episodes, so their state rides along).
+    private func seedUserState(
+        on series: Series,
+        in context: ModelContext,
+        watched: Date,
+        watchlisted: Date,
+        enriched: Date
+    ) {
+        series.isFavorite = true
+        series.favoriteOrder = 4
+        series.lastWatchedDate = watched
+        series.addedToWatchlistDate = watchlisted
+        series.genre = "Comedy, Drama"
+        series.backdropPath = "/backdrop.jpg"
+        series.tagline = "Welcome to Las Colinas"
+        series.tmdbId = 90881
+        series.tmdbEnrichedAt = enriched
+
+        let episode = Episode(
+            id: "\(series.id)-s1e1",
+            episodeId: "1",
+            title: "Pilot",
+            containerExtension: "mkv",
+            seasonNum: 1,
+            episodeNum: 1,
+            series: series
+        )
+        episode.watchProgress = 900
+        context.insert(episode)
+    }
+}

--- a/LumeTests/Services/DebugLogExporterTests.swift
+++ b/LumeTests/Services/DebugLogExporterTests.swift
@@ -35,6 +35,13 @@ struct DebugLogExporterTests {
         #expect(DebugLogExporter.label(for: .undefined) == "—")
     }
 
+    @Test func `signpost labels map every case`() {
+        #expect(DebugLogExporter.signpostLabel(for: .intervalBegin) == "signpost-begin")
+        #expect(DebugLogExporter.signpostLabel(for: .intervalEnd) == "signpost-end")
+        #expect(DebugLogExporter.signpostLabel(for: .event) == "signpost-event")
+        #expect(DebugLogExporter.signpostLabel(for: .undefined) == "signpost")
+    }
+
     @Test func `device model is never empty`() {
         #expect(!DebugLogExporter.deviceModel.isEmpty)
     }


### PR DESCRIPTION
## Summary

A real Xtream provider with **282,288 rows** (56,713 live + 178,007 VOD + 47,568 series, ~135 MB of JSON) took **~4 minutes to sync on an Apple TV 4K**. Standalone harnesses attributed almost all of it to SwiftData writes — ~90% of that inside `context.save()` — with the prune sweep and the decoded DTO arrays accounting for the memory. Network is ~8 s on a Mac and decode is single-digit seconds; neither is the headline.

This targets the **refresh** path, which is what users hit on every scheduled sync. A first-ever import is allowed to stay expensive: writing 282k rows means writing 282k rows.

| Benchmark | Before | After |
|---|---:|---:|
| Unchanged full re-import (282,288 rows) | 58.03 s | **14.50 s** |
| `testReimport20kUnchangedMovies` | 4.59 s | **1.09 s** |
| Prune 178k movies, zero deletions — clock | 9.35 s | **2.13 s** |
| Prune 178k movies — peak RSS | 843 MB | **274 MB** |
| Cold import (282,288 rows) | 64.30 s | 65.54 s |

The ~2% cold-import regression is the cost of comparing before assigning on rows that are all new. It is recorded in the perf README rather than hidden.

## Implementation

**Dirty-checked field application.** `apply*Fields` and the inline `LiveStream` block assign a provider-owned field only when it differs, and the per-batch write is gated on `context.hasChanges`. The fetch-before-write upsert stays — a blind insert replaces the row and wipes `isFavorite` / `watchProgress` / TMDB enrichment, the bug `f12b4b1` fixed. Series `genre` compares against the `GenreParser.providerFallback` **result**, not the DTO value, or every TMDB-enriched row would rewrite on every sync and never settle.

**Keyset-paged prune sweeps.** The three sweeps page by `id > cursor` (sorted by `id`, `fetchLimit` only) instead of materialising the whole catalog. Deleting while paging is sound because every deleted row sorts at or before the cursor. Row-by-row `delete()` is kept deliberately: `delete(model:where:)` does not honour the `Series` → `Episode`/`CastMember` cascade and would orphan rows carrying watch progress.

**A recovery path for the coverage gate.** The gate that protects against a mostly-malformed payload (`XtreamList` only rethrows when *every* element fails, so a 90%-malformed response arrives as a small non-empty array) now tolerates a bounded number of consecutive refusals. Coverage is measured against stored rows, which a skipped sweep never reduces — so a subscription that legitimately shrinks past the floor would otherwise be refused on every future sync and strand its dead rows permanently.

**Peak memory.** The content phases accumulate the seen-id set during the batch loop and release the decoded DTO array before the sweep, so a 65 MB payload plus its 178k-element array is no longer held live across the phase on a device with no swap. That was the jetsam hazard that presents to users as "sync never finishes" rather than "sync is slow".

**Conditional inter-phase spacing.** The two unconditional 2 s sleeps are now conditional on how long ago the last request actually finished. They are not simply deleted: the account really is `max_connections: 1` and the client retries 401/403 with 2 s then 4 s backoff, so removing them can cost more than it saves.

**Observability, which had to come first.** `Perf.begin(.syncMovies)` previously wrapped fetch + decode + 89 upsert batches + the prune sweep in one interval, so nothing could be attributed. 13 new signposts split each content phase into fetch / decode / upsert / prune; payload byte counts and the 401/403 backoff are logged; and `DebugLogExporter` now carries signposts instead of dropping them — MetricKit is compiled out on tvOS, so that is the only field-telemetry route on an Apple TV.

**Measured dead levers, recorded so they are not re-derived.** `batchSize`, the 11 `#Index` groups on `Movie`, `@Attribute(.unique)` and the per-batch existing-row lookup are each **under 6%** of import cost. `propertiesToFetch = [\.id]` made the sweep worse. `fetchLimit`/`fetchOffset` paging measured **99.1 s against 9.3 s — 10.7x worse** than the unbounded fetch it replaced, which is why the sweep ships keyset paging. The provider also refuses gzip and sends no ETag, so HTTP compression and conditional GET are both unavailable.

**Verified along the way:** `XtreamClient` *is* `@MainActor`-isolated by inference from the project-wide default, unlike its sibling `nonisolated class M3UClient` — so the 178k-element decode blocks the main thread. Recorded with a DEBUG assertion and a comment; the `nonisolated` refactor is left for its own change, since it is a signature change at every call site.

No schema change, no new stored properties, no user-facing strings, no container changes.

## Testing
- [x] Acceptance criteria met — refresh is ~4x cheaper, pinned by `testReimportFullXtreamCatalogUnchanged`
- [x] Tests pass — **970 tests in 97 suites pass** (`-parallel-testing-enabled NO`; see note below)
- [x] SwiftLint clean (`--strict`) and SwiftFormat clean
- [x] Tests added — 61 across `ContentSyncPruneTests`, `ContentSyncMovieFieldTests`, `ContentSyncSeriesFieldTests`, `ContentSyncLiveStreamFieldTests`, `ContentSyncManagerLogicTests`, `DebugLogExporterTests`, plus the 100k-entry m3u regression. Also five real-scale store benchmarks and realistic Xtream fixture generators as the regression gate.

Under **parallel** execution the suite reports failures from two pre-existing flakes unrelated to this change: `WatchProgressBufferTests` hard-crashes the test host (global `UserDefaults` state — `entries[0]` on an array a sibling test just drained), which cascades ~900 unrelated cases into `failed (0.000 seconds)`; and `RecommendationEngineTests` has a known cache flake. Both pass in isolation and the full suite is green serially. Worth a separate fix.

## Platforms
- [x] iOS / iPadOS — builds clean, full test suite green
- [x] tvOS — builds clean (Apple TV 4K 3rd gen simulator)
- [x] macOS — builds clean (compile+link only; unsigned, no provisioning profile available locally)
- [ ] visionOS — **build fails on `main`, pre-existing and unrelated.** `PremiumManager.swift:161` calls StoreKit's parameterless `product.purchase()`, unavailable on visionOS (needs the scene-bound `purchase(confirmIn:options:)`). That file is untouched here, and every file this PR does touch compiles clean for visionOS.

## Notes for the reviewer

Two things deliberately left out of scope, both recorded in the perf README:

1. **Every number above is from a Mac/simulator harness — a floor, not a device measurement.** The signposts and an `xctrace` recipe are now in `LumePerformanceTests/README.md` so one Apple TV trace can attribute the remaining time. After this change the dominant refresh cost is the **135 MB download itself**, which is irreducible with this provider.
2. `ContentSyncManager.swift` is at **596 lines against SwiftLint's 600-line limit** and the hook runs `--strict`, so the next few lines added to that file will fail the hook. Three sync functions are also at 48/50 on `function_body_length`. Extracting the Xtream phases into their own extension would fix it; left alone here to keep the diff reviewable.

Also note the prune sub-phase signposts wrap the three Xtream call sites only — the m3u and Stalker pipelines call `pruneStale*` directly and get no sub-phase attribution.