### PR TITLE
fix(live-tv): pin programme titles to the visible part of their block

### DIFF
--- a/Lume/Views/LiveTV/EPG/EPGComponents.swift
+++ b/Lume/Views/LiveTV/EPG/EPGComponents.swift
@@ -278,6 +278,21 @@ struct EPGProgramBlockView: View {
             .padding(.horizontal, metrics.blockInset)
             .padding(.vertical, metrics.blockInset * 0.55)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            // Keeps the text of a partially scrolled block readable instead of
+            // letting it ride off the leading edge with the block's own origin.
+            // Driven by `visualEffect` rather than the shared scroll offset: the
+            // closure re-runs on geometry change without invalidating the
+            // block's body, where observing the guide's per-frame offset would
+            // re-render every realized cell — the cost the grid is built around.
+            .visualEffect { [inset = metrics.blockInset] content, proxy in
+                content.offset(
+                    x: EPGStickyText.shift(
+                        blockMinX: proxy.frame(in: .scrollView).minX,
+                        blockWidth: proxy.size.width,
+                        inset: inset
+                    )
+                )
+            }
 
             if isLive {
                 liveProgressBar

--- a/Lume/Views/LiveTV/EPG/EPGComponents.swift
+++ b/Lume/Views/LiveTV/EPG/EPGComponents.swift
@@ -33,6 +33,12 @@ struct EPGMetrics {
     var headerHeight: CGFloat
     var blockCornerRadius: CGFloat
     var blockInset: CGFloat
+    /// How much of the programme already in progress stays visible when the
+    /// guide parks on "now": enough to show where the current show started —
+    /// and the tail of the one before it — rather than only what is still to
+    /// come. The 10-foot layout fits hours across the screen, so it needs a
+    /// wider lead-in than a phone to read as the same amount of context.
+    var nowLeadInMinutes: CGFloat
 
     static var current: EPGMetrics {
         #if os(tvOS)
@@ -43,7 +49,8 @@ struct EPGMetrics {
                 channelColumnWidth: 300,
                 headerHeight: 68,
                 blockCornerRadius: 16,
-                blockInset: 18
+                blockInset: 18,
+                nowLeadInMinutes: 30
             )
         #elseif os(macOS)
             EPGMetrics(
@@ -53,7 +60,8 @@ struct EPGMetrics {
                 channelColumnWidth: 210,
                 headerHeight: 36,
                 blockCornerRadius: 7,
-                blockInset: 10
+                blockInset: 10,
+                nowLeadInMinutes: 10
             )
         #else
             EPGMetrics(
@@ -63,7 +71,8 @@ struct EPGMetrics {
                 channelColumnWidth: 136,
                 headerHeight: 36,
                 blockCornerRadius: 9,
-                blockInset: 10
+                blockInset: 10,
+                nowLeadInMinutes: 10
             )
         #endif
     }

--- a/Lume/Views/LiveTV/EPG/EPGGridScroller.swift
+++ b/Lume/Views/LiveTV/EPG/EPGGridScroller.swift
@@ -190,12 +190,10 @@ struct EPGGridScroller: View {
         }
     }
 
-    /// Scroll offset that places `date` just inside the leading edge of the
-    /// grid. The lead-in only has to clear the marker's own cap; anything wider
-    /// puts the red line on top of the airing programme's title, which pins to
-    /// the leading edge one block inset in (`EPGStickyText`).
+    /// Scroll offset that parks `date` `metrics.nowLeadInMinutes` inside the
+    /// grid's leading edge.
     private func scrollTarget(forNow date: Date) -> CGFloat {
-        max(0, timeline.x(for: date) - 6)
+        timeline.x(for: date.addingTimeInterval(-Double(metrics.nowLeadInMinutes) * 60))
     }
 
     /// The initial target, handed to the grid. Bound to the view's captured

--- a/Lume/Views/LiveTV/EPG/EPGGridScroller.swift
+++ b/Lume/Views/LiveTV/EPG/EPGGridScroller.swift
@@ -190,9 +190,20 @@ struct EPGGridScroller: View {
         }
     }
 
-    /// Scroll offset that places "now" just inside the leading edge of the grid.
+    /// Scroll offset that places `date` just inside the leading edge of the
+    /// grid. The lead-in only has to clear the marker's own cap; anything wider
+    /// puts the red line on top of the airing programme's title, which pins to
+    /// the leading edge one block inset in (`EPGStickyText`).
+    private func scrollTarget(forNow date: Date) -> CGFloat {
+        max(0, timeline.x(for: date) - 6)
+    }
+
+    /// The initial target, handed to the grid. Bound to the view's captured
+    /// `now` on purpose: the grid's `Equatable` gate compares it, so a value
+    /// that moved with the wall clock would re-render the whole subtree on
+    /// every parent update. Explicit jumps read the clock instead.
     private var nowScrollTarget: CGFloat {
-        max(0, timeline.x(for: now) - 12)
+        scrollTarget(forNow: now)
     }
 
     /// Asks the grid to scroll. On tvOS the frozen panes' mirror is updated in
@@ -226,7 +237,7 @@ struct EPGGridScroller: View {
             Color.clear
         #else
             Button {
-                requestScroll(to: CGPoint(x: nowScrollTarget, y: sync.offset.y), animated: true)
+                requestScroll(to: CGPoint(x: scrollTarget(forNow: Date()), y: sync.offset.y), animated: true)
             } label: {
                 Label("Now", systemImage: "smallcircle.filled.circle")
                     .font(.subheadline.weight(.semibold))
@@ -340,7 +351,7 @@ struct EPGGridScroller: View {
         /// visible channel, reading as "now" on a channel.
         private func landOnChannel() {
             guard !rows.isEmpty else { return }
-            requestScroll(to: CGPoint(x: nowScrollTarget, y: sync.offset.y), animated: false)
+            requestScroll(to: CGPoint(x: scrollTarget(forNow: Date()), y: sync.offset.y), animated: false)
             preferredX = nil
             virtualFocus = .channel(rowIndex: topVisibleRowIndex)
         }
@@ -502,7 +513,7 @@ struct EPGGridScroller: View {
         /// back to now.
         private func handleExitCommand() {
             guard case let .cell(rowIndex, _) = virtualFocus else { return }
-            requestScroll(to: CGPoint(x: nowScrollTarget, y: sync.offset.y), animated: false)
+            requestScroll(to: CGPoint(x: scrollTarget(forNow: Date()), y: sync.offset.y), animated: false)
             preferredX = nil
             virtualFocus = .channel(rowIndex: rowIndex)
         }

--- a/Lume/Views/LiveTV/EPG/EPGTimeline.swift
+++ b/Lume/Views/LiveTV/EPG/EPGTimeline.swift
@@ -78,6 +78,25 @@ nonisolated struct EPGTimeline: Equatable {
     }
 }
 
+// MARK: - Sticky text
+
+/// How far a programme block's text has to shift to stay inside the viewport.
+///
+/// Blocks sit at their absolute timeline offset and draw their text at their
+/// own leading edge, so a programme that started before the viewport's leading
+/// edge — the in-progress one the guide opens on — would render its title
+/// off-screen. Shifting by the hidden amount pins the text to the visible part
+/// of the block; the cap stops it from sliding out of the block's own trailing
+/// edge as the block scrolls away.
+///
+/// `nonisolated`: called from the `visualEffect` closure, which is `@Sendable`.
+nonisolated enum EPGStickyText {
+    static func shift(blockMinX: CGFloat, blockWidth: CGFloat, inset: CGFloat) -> CGFloat {
+        guard blockMinX < 0 else { return 0 }
+        return min(-blockMinX, max(0, blockWidth - inset * 2))
+    }
+}
+
 // MARK: - Grid model
 
 /// One cell in a channel row: either a real programme or a gap filler that keeps

--- a/LumeTests/Models/EPGStickyTextTests.swift
+++ b/LumeTests/Models/EPGStickyTextTests.swift
@@ -1,0 +1,24 @@
+import CoreGraphics
+import Foundation
+@testable import Lume
+import Testing
+
+struct EPGStickyTextTests {
+    @Test func `a fully visible block does not shift its text`() {
+        #expect(EPGStickyText.shift(blockMinX: 0, blockWidth: 180, inset: 10) == 0)
+        #expect(EPGStickyText.shift(blockMinX: 240, blockWidth: 180, inset: 10) == 0)
+    }
+
+    @Test func `a block scrolled past the leading edge shifts by the hidden amount`() {
+        #expect(EPGStickyText.shift(blockMinX: -40, blockWidth: 180, inset: 10) == 40)
+    }
+
+    @Test func `the shift is capped inside the block`() {
+        // 180 wide, 10 inset either side -> the text never travels past 160.
+        #expect(EPGStickyText.shift(blockMinX: -400, blockWidth: 180, inset: 10) == 160)
+    }
+
+    @Test func `a block narrower than its own insets never shifts`() {
+        #expect(EPGStickyText.shift(blockMinX: -40, blockWidth: 12, inset: 10) == 0)
+    }
+}


### PR DESCRIPTION
## Summary
Opening the Guide parks "now" at the leading edge, but programme titles were drawn at each block's own leading edge — so the in-progress programme, the one the red marker points at, rendered its title off-screen and read as an untitled block. Its text now sticks to the visible part of the block, so the currently-airing show on every channel is legible without scrolling left.

## Implementation
`EPGProgramBlockView` shifts its text right by however much of the block is hidden past the viewport's leading edge, capped so the text stays inside the block. The shift runs inside a `visualEffect` closure reading `proxy.frame(in: .scrollView).minX` rather than off `EPGScrollSync.offset`: the closure re-runs on geometry change without invalidating the block's body, where observing the guide's per-frame scroll offset would re-render every realized cell — the cost the whole grid is built to avoid. The maths lives in `EPGStickyText` in the SwiftUI-free `EPGTimeline.swift` so it is unit-testable.

Second commit, on top: the Guide used to park "now" 12pt inside the leading edge, so the programme in progress showed only what was still to come. It now parks a lead-in expressed in time, alongside the guide's other platform tuning in `EPGMetrics` — 10 minutes on iOS and macOS, 30 on tvOS, where the 10-foot layout fits hours across the screen and needs a wider lead-in to read as the same amount of context. Both values were tuned by eye on the simulator. The explicit jumps to now (the Now button, plus tvOS landing and Menu-collapse) also read the clock now instead of the view's captured `now`, which could be minutes stale and parked the guide in the wrong place; the initial target handed to `EPGGrid` deliberately still uses the captured `now`, because the grid's `Equatable` gate compares it.

Two known cosmetic limitations, both pre-existing in kind:
- A pinned title whose remaining visible width is narrower than the text is hard-clipped at the block's trailing edge rather than truncated with an ellipsis — the text keeps its full-block layout width, and shrinking it with the scroll would mean per-frame layout of every cell. It never bleeds into the neighbouring block.
- With a lead-in, the red now line can cross the airing programme's title, since it sits some minutes into that block. There is no lead-in that both reveals useful elapsed context and keeps the line off the title, so this follows the usual EPG idiom of drawing the marker over the grid. Stepping the pinned title past the marker is possible but would snap every row's title sideways when the live block crosses the viewport edge.

## Testing
- [x] Acceptance criteria met
- [x] Builds clean (XcodeBuildMCP `build_sim` iOS, `build_macos`, `xcodebuild` tvOS)
- [x] Tests pass (`test_sim`, iPhone 17 Pro / iOS 26.4, `-parallel-testing-enabled NO`) — 974 passed, 0 failed
- [x] SwiftLint clean (vendored SwiftFormat + SwiftLint `--strict` via pre-commit)
- [x] Tests added — `LumeTests/Models/EPGStickyTextTests.swift`, 4 cases over the shift maths
- [x] UI verified on simulator — iOS light + dark, and the tvOS Guide; both lead-in values checked by hand

## Platforms
- [x] iOS / iPadOS
- [x] tvOS
- [ ] macOS
- [ ] visionOS
<!-- macOS/visionOS build clean and share the same code path, but were not driven by hand; macOS keeps the iOS lead-in, untuned -->

## Related
Closes #198