### PR TITLE
fix(live-tv): stop overlapping EPG programmes stacking in the Guide

### DIFF
--- a/Lume/Services/Sync/EPGSyncManager.swift
+++ b/Lume/Services/Sync/EPGSyncManager.swift
@@ -8,6 +8,13 @@
 //  stream-parse each source's XMLTV file and insert only programmes whose
 //  channel a stream actually uses.
 //
+//  A channel is guided by exactly one source. Sources are walked oldest-first
+//  and each claims the channels it carries; later sources are then confined to
+//  the channels still unclaimed. Without that, two sources covering the same
+//  channel both survived — the listing id only collapses programmes whose start
+//  matches to the second — and the guide drew their schedules on top of each
+//  other.
+//
 //  Memory stays flat regardless of guide size: files live on disk, and only one
 //  batch of `ParsedProgramme` structs is held at a time.
 //
@@ -45,23 +52,39 @@ actor EPGSyncManager {
         clearListings()
 
         var anySucceeded = false
+        var unclaimedChannelIDs = knownChannelIDs
         for source in sources {
-            let didSync = await sync(sourceID: source.id, url: source.url, knownChannelIDs: knownChannelIDs)
-            anySucceeded = anySucceeded || didSync
+            let result = await sync(sourceID: source.id, url: source.url, knownChannelIDs: unclaimedChannelIDs)
+            unclaimedChannelIDs.subtract(result.claimedChannelIDs)
+            anySucceeded = anySucceeded || result.didSync
         }
         return anySucceeded
     }
 
     // MARK: - Per-source sync
 
-    private func sync(sourceID: UUID, url: String, knownChannelIDs: Set<String>) async -> Bool {
+    /// What one source contributed: whether it synced at all, and which channels
+    /// it now owns for the rest of this refresh.
+    private struct SourceResult {
+        let didSync: Bool
+        let claimedChannelIDs: Set<String>
+    }
+
+    private func sync(sourceID: UUID, url: String, knownChannelIDs: Set<String>) async -> SourceResult {
         let interval = Perf.begin(.epgSourceSync)
         defer { Perf.end(interval) }
 
         markStatus(sourceID, .syncing)
         guard !url.isEmpty else {
             markStatus(sourceID, .error)
-            return false
+            return SourceResult(didSync: false, claimedChannelIDs: [])
+        }
+        guard !knownChannelIDs.isEmpty else {
+            // Every channel this source could guide is already covered by an
+            // earlier one; downloading it would only produce overlaps.
+            Logger.database.info("EPG source \(sourceID, privacy: .public) skipped, all channels already guided")
+            markSynced(sourceID)
+            return SourceResult(didSync: true, claimedChannelIDs: [])
         }
         do {
             let isRemote = !(URL(string: url)?.isFileURL ?? false)
@@ -69,9 +92,9 @@ actor EPGSyncManager {
             defer { if isRemote { try? FileManager.default.removeItem(at: fileURL) } }
 
             let inserted = insertListings(from: fileURL, knownChannelIDs: knownChannelIDs)
-            Logger.database.info("EPG source \(sourceID) inserted \(inserted) listings")
+            Logger.database.info("EPG source \(sourceID) inserted \(inserted.count) listings for \(inserted.channelIDs.count) channels")
             markSynced(sourceID)
-            return true
+            return SourceResult(didSync: true, claimedChannelIDs: inserted.channelIDs)
         } catch {
             // Credential-free detail (never a URL) so it can be public in
             // user-exported diagnostic logs.
@@ -79,7 +102,7 @@ actor EPGSyncManager {
             let detail = (error as? M3UError)?.logDescription ?? "\(nsError.domain) \(nsError.code)"
             Logger.database.warning("EPG source \(sourceID, privacy: .public) sync failed: \(detail, privacy: .public)")
             markStatus(sourceID, .error)
-            return false
+            return SourceResult(didSync: false, claimedChannelIDs: [])
         }
     }
 
@@ -135,17 +158,24 @@ actor EPGSyncManager {
     /// bounded.
     private static let saveThreshold = 10000
 
+    /// What an XMLTV file contributed: how many listings were inserted, and the
+    /// channels they landed on.
+    private struct InsertResult {
+        var count = 0
+        var channelIDs: Set<String> = []
+    }
+
     /// Stream-parses an XMLTV file and inserts every programme on a known
-    /// channel. Returns the number of listings inserted.
+    /// channel.
     ///
     /// Parsing streams in 2000-programme batches to keep `ParsedProgramme`
     /// memory flat, but inserts accumulate on a single context and save only
     /// every `saveThreshold` listings to minimise main-context merges.
-    private func insertListings(from fileURL: URL, knownChannelIDs: Set<String>) -> Int {
+    private func insertListings(from fileURL: URL, knownChannelIDs: Set<String>) -> InsertResult {
         let interval = Perf.begin(.epgIngest)
         defer { Perf.end(interval) }
 
-        var insertedCount = 0
+        var result = InsertResult()
         var pendingInserts = 0
         let context = ModelContext(modelContainer)
         context.autosaveEnabled = false
@@ -162,7 +192,8 @@ actor EPGSyncManager {
                         start: programme.start,
                         end: programme.end
                     ))
-                    insertedCount += 1
+                    result.count += 1
+                    result.channelIDs.insert(programme.channelId)
                     pendingInserts += 1
                 }
                 if pendingInserts >= Self.saveThreshold {
@@ -175,7 +206,7 @@ actor EPGSyncManager {
         if pendingInserts > 0 {
             try? context.save()
         }
-        return insertedCount
+        return result
     }
 
     // MARK: - Status bookkeeping

--- a/Lume/Views/LiveTV/EPG/EPGTimeline.swift
+++ b/Lume/Views/LiveTV/EPG/EPGTimeline.swift
@@ -183,17 +183,40 @@ enum EPGGridBuilder {
         }
     }
 
-    /// Turns a channel's sorted listings into contiguous cells spanning the
-    /// whole window, inserting gap fillers wherever data is missing.
+    /// Anything left of a programme after overlap trimming that is shorter than
+    /// this is treated as debris rather than a cell: it would render a sliver
+    /// too narrow to label, and on tvOS focus could still land on it.
+    private nonisolated static let minimumCellDuration: TimeInterval = 60
+
+    /// Turns a channel's listings into contiguous cells spanning the whole
+    /// window, inserting gap fillers wherever data is missing.
+    ///
+    /// Listings are not assumed to be sorted or disjoint. XMLTV in the wild
+    /// overlaps programmes on the same channel, and cells are placed at their
+    /// absolute timeline offset — so an overlap would draw two blocks on the
+    /// same pixels and smear their titles together. The sweep below resolves
+    /// each contested span in favour of whichever programme starts first
+    /// (shortest first on a tie), trimming the loser's leading edge, so the
+    /// row always comes out sorted, disjoint and edge-to-edge.
+    ///
     /// `nonisolated`: runs on a background task for large categories.
     nonisolated static func cells(for listings: [EPGWindowListing], timeline: EPGTimeline) -> [EPGProgramCell] {
         var cells: [EPGProgramCell] = []
         var cursor = timeline.start
 
-        for listing in listings {
-            let clampedStart = max(listing.start, timeline.start)
+        let ordered = listings.sorted {
+            $0.start == $1.start ? $0.end < $1.end : $0.start < $1.start
+        }
+
+        for listing in ordered {
             let clampedEnd = min(listing.end, timeline.end)
-            guard clampedEnd > clampedStart else { continue }
+            // Already covered by a cell that runs at least this far — the
+            // cursor never moves backwards, so a contained listing is dropped
+            // instead of rewinding the row into a spurious gap.
+            guard clampedEnd > cursor else { continue }
+
+            let clampedStart = max(max(listing.start, timeline.start), cursor)
+            guard clampedEnd.timeIntervalSince(clampedStart) >= minimumCellDuration else { continue }
 
             if clampedStart > cursor {
                 cells.append(gap(from: cursor, to: clampedStart, timeline: timeline))

--- a/LumeTests/Models/EPGGridBuilderTests.swift
+++ b/LumeTests/Models/EPGGridBuilderTests.swift
@@ -1,0 +1,146 @@
+import CoreGraphics
+import Foundation
+@testable import Lume
+import Testing
+
+struct EPGGridBuilderTests {
+    private static let windowStart = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private static let timeline = EPGTimeline(
+        start: windowStart,
+        end: windowStart.addingTimeInterval(4 * 3600),
+        pointsPerMinute: 6
+    )
+
+    private static func listing(
+        _ id: String,
+        _ title: String,
+        startMinutes: Double,
+        endMinutes: Double
+    ) -> EPGWindowListing {
+        EPGWindowListing(
+            id: id,
+            title: title,
+            detail: "",
+            start: windowStart.addingTimeInterval(startMinutes * 60),
+            end: windowStart.addingTimeInterval(endMinutes * 60)
+        )
+    }
+
+    private static func cells(_ listings: [EPGWindowListing]) -> [EPGProgramCell] {
+        EPGGridBuilder.cells(for: listings, timeline: timeline)
+    }
+
+    /// Every row must stay a single edge-to-edge strip: sorted, disjoint, and
+    /// spanning exactly the window — that is what stops blocks drawing on top
+    /// of each other.
+    private static func expectTiled(_ cells: [EPGProgramCell], sourceLocation: SourceLocation = #_sourceLocation) {
+        #expect(cells.first?.start == timeline.start, sourceLocation: sourceLocation)
+        #expect(cells.last?.end == timeline.end, sourceLocation: sourceLocation)
+        for (previous, next) in zip(cells, cells.dropFirst()) {
+            #expect(previous.end == next.start, sourceLocation: sourceLocation)
+        }
+        let total = cells.reduce(0) { $0 + $1.width }
+        #expect(abs(total - timeline.totalWidth) < 0.001, sourceLocation: sourceLocation)
+    }
+
+    @Test func `disjoint listings tile with gap fillers around them`() {
+        let cells = Self.cells([
+            Self.listing("a", "First", startMinutes: 30, endMinutes: 60),
+            Self.listing("b", "Second", startMinutes: 90, endMinutes: 120)
+        ])
+
+        Self.expectTiled(cells)
+        #expect(cells.map(\.isGap) == [true, false, true, false, true])
+        #expect(cells.compactMap { $0.isGap ? nil : $0.title } == ["First", "Second"])
+    }
+
+    @Test func `overlapping listings never occupy the same span`() {
+        // The reported shape: a second source's 13:27 programme landing inside
+        // the first source's 13:00-13:30 block.
+        let cells = Self.cells([
+            Self.listing("a", "First", startMinutes: 0, endMinutes: 30),
+            Self.listing("b", "Second", startMinutes: 27, endMinutes: 60)
+        ])
+
+        Self.expectTiled(cells)
+        let programmes = cells.filter { !$0.isGap }
+        #expect(programmes.map(\.title) == ["First", "Second"])
+        #expect(programmes[0].end == programmes[1].start)
+        #expect(programmes[1].start == Self.windowStart.addingTimeInterval(30 * 60))
+    }
+
+    @Test func `a listing contained in the previous one is dropped, not rewound`() {
+        // Cursor regression used to emit a backwards gap after the container.
+        let cells = Self.cells([
+            Self.listing("a", "Long", startMinutes: 0, endMinutes: 120),
+            Self.listing("b", "Inside", startMinutes: 30, endMinutes: 60),
+            Self.listing("c", "After", startMinutes: 120, endMinutes: 180)
+        ])
+
+        Self.expectTiled(cells)
+        #expect(cells.compactMap { $0.isGap ? nil : $0.title } == ["Long", "After"])
+    }
+
+    @Test func `unsorted listings are ordered before tiling`() {
+        let cells = Self.cells([
+            Self.listing("c", "Third", startMinutes: 120, endMinutes: 180),
+            Self.listing("a", "First", startMinutes: 0, endMinutes: 60),
+            Self.listing("b", "Second", startMinutes: 60, endMinutes: 120)
+        ])
+
+        Self.expectTiled(cells)
+        #expect(cells.compactMap { $0.isGap ? nil : $0.title } == ["First", "Second", "Third"])
+    }
+
+    @Test func `listings sharing a start emit the shorter one first`() {
+        let cells = Self.cells([
+            Self.listing("long", "Long", startMinutes: 0, endMinutes: 120),
+            Self.listing("short", "Short", startMinutes: 0, endMinutes: 30)
+        ])
+
+        Self.expectTiled(cells)
+        #expect(cells.compactMap { $0.isGap ? nil : $0.title } == ["Short", "Long"])
+    }
+
+    @Test func `a sliver left by trimming is discarded`() {
+        let cells = Self.cells([
+            Self.listing("a", "First", startMinutes: 0, endMinutes: 60),
+            Self.listing("b", "Sliver", startMinutes: 59, endMinutes: 60.5),
+            Self.listing("c", "Third", startMinutes: 60, endMinutes: 120)
+        ])
+
+        Self.expectTiled(cells)
+        #expect(cells.compactMap { $0.isGap ? nil : $0.title } == ["First", "Third"])
+    }
+
+    @Test func `listings outside the window are clamped away`() {
+        let cells = Self.cells([
+            Self.listing("before", "Before", startMinutes: -120, endMinutes: -30),
+            Self.listing("across", "Across", startMinutes: -30, endMinutes: 60),
+            Self.listing("after", "After", startMinutes: 300, endMinutes: 360)
+        ])
+
+        Self.expectTiled(cells)
+        #expect(cells.compactMap { $0.isGap ? nil : $0.title } == ["Across"])
+        #expect(cells.first?.start == Self.timeline.start)
+    }
+
+    @Test func `a channel with no listings is one full-window gap`() {
+        let cells = Self.cells([])
+
+        Self.expectTiled(cells)
+        #expect(cells.count == 1)
+        #expect(cells[0].isGap)
+    }
+
+    @Test func `cell ids stay unique so the grid can identify them`() {
+        let cells = Self.cells([
+            Self.listing("a", "First", startMinutes: 0, endMinutes: 30),
+            Self.listing("b", "Second", startMinutes: 15, endMinutes: 90),
+            Self.listing("c", "Third", startMinutes: 60, endMinutes: 150)
+        ])
+
+        #expect(Set(cells.map(\.id)).count == cells.count)
+    }
+}


### PR DESCRIPTION
## Summary

Programme cells for the same channel could overlap and draw their titles and start times on top of each other, leaving Guide rows unreadable (#197). Each channel row now renders one contiguous, non-overlapping strip.

## Implementation

Two independent causes, both fixed.

**Layout — `EPGGridBuilder.cells(for:timeline:)`.** The builder assumed listings arrived sorted and disjoint. An overlapping listing still got its own absolute timeline offset, so two blocks shared pixels; and a listing fully contained in the previous one moved the cursor *backwards*, producing a spurious gap later in the row. It now sweeps the listings sorted by start (shortest first on a tie), trims each contested span in favour of whichever programme starts first, and never lets the cursor regress — so a row is always sorted, disjoint and edge-to-edge. Residual slivers under a minute are dropped rather than rendered as unlabelable (and, on tvOS, focusable) crumbs. This is the defensive half: XMLTV in the wild overlaps programmes even from a single source.

**Data — `EPGSyncManager.syncAllSources()`.** Every enabled source inserted listings for every channel. The listing id (`channelId-startEpoch`) only collapses programmes whose start matches to the second, so two sources covering the same channel both survived and both rendered. Sources are now walked oldest-first and each claims the channels it carries, confining later sources to the channels still unguided; a source with nothing left to guide is skipped without downloading.

No schema change, no new strings.

## Testing

- [x] Acceptance criteria met
- [x] Builds clean (XcodeBuildMCP `build_sim`; tvOS via `xcodebuild`)
- [x] Tests pass (XcodeBuildMCP `test_sim`, iPhone 17 Pro / iOS 26.4 — 9/9)
- [x] SwiftLint clean
- [x] Tests added — `LumeTests/Models/EPGGridBuilderTests.swift`, 9 cases covering overlap, containment, unsorted input, tie-breaking, slivers, window clamping and cell-id uniqueness. Verified as a real regression guard: 5 of the 9 fail against the pre-fix builder, reporting exactly the reported symptom (`previous.end 22:43` vs `next.start 22:40`).
- [x] UI verified on simulator — the example IPTV server was temporarily patched (uncommitted, since reverted) to serve a second 17-minute-shifted schedule on the news channels, reproducing the reported data shape. Before the fix that data smears; after it, rows render as `Night Desk 00:17 | O… | Weather Center 01:17 | O… | Morning Briefing 02:17`, every cell separate and readable.

## Platforms

- [x] iOS / iPadOS
- [x] tvOS
- [ ] macOS
- [ ] visionOS

tvOS verified on an Apple TV 4K sim (tvOS 26.5) with three EPG sources configured and overlapping data ingested via Settings → TV Guide → Sync Now. macOS/visionOS share the same builder and strip; not run separately.

## Related

Closes #197