### PR TITLE
feat(player): auto-select the viewer's preferred audio language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ xcuserdata/
 
 .env
 
-ExampleData/
+ExampleData
 
 build/
 

--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -2538,6 +2538,58 @@
         }
       }
     },
+    "Add Language" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprache hinzufügen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir idioma"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter une langue"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi lingua"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "言語を追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "언어 추가"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar idioma"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加语言"
+          }
+        }
+      }
+    },
     "Add Playlist" : {
       "localizations" : {
         "de" : {
@@ -3791,6 +3843,58 @@
         }
       }
     },
+    "Audio Languages" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audiosprachen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idiomas de audio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Langues audio"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lingue audio"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音声言語"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오디오 언어"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idiomas de áudio"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音频语言"
+          }
+        }
+      }
+    },
     "Audio Queue Depth" : {
       "localizations" : {
         "de" : {
@@ -3839,6 +3943,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "音频队列深度"
+          }
+        }
+      }
+    },
+    "Audio Track" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tonspur"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pista de audio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piste audio"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traccia audio"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音声トラック"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오디오 트랙"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa de áudio"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音轨"
           }
         }
       }
@@ -7148,6 +7304,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "颜色"
+          }
+        }
+      }
+    },
+    "Common Languages" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Häufige Sprachen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idiomas frecuentes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Langues courantes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lingue comuni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "よく使う言語"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자주 쓰는 언어"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idiomas comuns"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常用语言"
           }
         }
       }
@@ -18151,6 +18359,110 @@
         }
       }
     },
+    "Lume selects the first of these languages the stream offers as an audio track, most preferred at the top. When the audio that plays is in none of them and the stream carries a forced subtitle track, that track is turned on. Applied the next time playback starts." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume wählt die erste dieser Sprachen, die der Stream als Tonspur anbietet – die bevorzugte steht oben. Wenn der abgespielte Ton in keiner davon vorliegt und der Stream eine erzwungene Untertitelspur enthält, wird diese Spur aktiviert. Wird bei der nächsten Wiedergabe angewendet."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume selecciona el primero de estos idiomas que el stream ofrezca como pista de audio; el preferido va arriba. Si el audio que se reproduce no está en ninguno de ellos y el stream incluye una pista de subtítulos forzados, esa pista se activa. Se aplica la próxima vez que se inicie la reproducción."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume choisit la première de ces langues proposée par le flux comme piste audio, la préférée en haut. Si l'audio lu ne correspond à aucune d'elles et que le flux contient une piste de sous-titres forcés, cette piste est activée. Appliqué au prochain démarrage de la lecture."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume seleziona la prima di queste lingue offerta dallo stream come traccia audio; la preferita è in cima. Se l'audio riprodotto non è in nessuna di queste lingue e lo stream contiene una traccia di sottotitoli forzati, quella traccia viene attivata. Applicato al successivo avvio della riproduzione."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume は、ストリームが音声トラックとして提供しているこれらの言語のうち最初のものを選択します。優先度の高いものを上に配置してください。再生される音声がいずれの言語でもなく、ストリームに強制字幕トラックがある場合は、そのトラックがオンになります。次回の再生開始時に適用されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume는 스트림이 오디오 트랙으로 제공하는 언어 중 목록의 첫 번째 언어를 선택합니다. 가장 선호하는 언어를 맨 위에 두세요. 재생되는 오디오가 이 언어 중 어느 것도 아니고 스트림에 강제 자막 트랙이 있으면 해당 트랙이 켜집니다. 다음 재생 시작 시 적용됩니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O Lume seleciona o primeiro destes idiomas que o stream oferecer como faixa de áudio; o preferido fica no topo. Se o áudio reproduzido não estiver em nenhum deles e o stream tiver uma faixa de legendas forçadas, essa faixa é ativada. Aplicado na próxima vez que a reprodução começar."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume 会选择流以音轨形式提供的这些语言中的第一种，最优先的排在最上方。如果播放的音轨不属于其中任何一种语言，且流中包含强制字幕轨道，则会自动开启该轨道。将在下次播放开始时生效。"
+          }
+        }
+      }
+    },
+    "Lume selects the first of these languages the stream offers as an audio track. Drag to reorder. When the audio that plays is in none of them and the stream carries a forced subtitle track, that track is turned on. Applied the next time playback starts." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume wählt die erste dieser Sprachen, die der Stream als Tonspur anbietet. Zum Umsortieren ziehen. Wenn der abgespielte Ton in keiner davon vorliegt und der Stream eine erzwungene Untertitelspur enthält, wird diese Spur aktiviert. Wird bei der nächsten Wiedergabe angewendet."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume selecciona el primero de estos idiomas que el stream ofrezca como pista de audio. Arrastra para reordenar. Si el audio que se reproduce no está en ninguno de ellos y el stream incluye una pista de subtítulos forzados, esa pista se activa. Se aplica la próxima vez que se inicie la reproducción."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume choisit la première de ces langues proposée par le flux comme piste audio. Faites glisser pour réorganiser. Si l'audio lu ne correspond à aucune d'elles et que le flux contient une piste de sous-titres forcés, cette piste est activée. Appliqué au prochain démarrage de la lecture."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume seleziona la prima di queste lingue offerta dallo stream come traccia audio. Trascina per riordinare. Se l'audio riprodotto non è in nessuna di queste lingue e lo stream contiene una traccia di sottotitoli forzati, quella traccia viene attivata. Applicato al successivo avvio della riproduzione."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume は、ストリームが音声トラックとして提供しているこれらの言語のうち最初のものを選択します。ドラッグして並べ替えられます。再生される音声がいずれの言語でもなく、ストリームに強制字幕トラックがある場合は、そのトラックがオンになります。次回の再生開始時に適用されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume는 스트림이 오디오 트랙으로 제공하는 언어 중 목록의 첫 번째 언어를 선택합니다. 드래그하여 순서를 바꾸세요. 재생되는 오디오가 이 언어 중 어느 것도 아니고 스트림에 강제 자막 트랙이 있으면 해당 트랙이 켜집니다. 다음 재생 시작 시 적용됩니다."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O Lume seleciona o primeiro destes idiomas que o stream oferecer como faixa de áudio. Arraste para reordenar. Se o áudio reproduzido não estiver em nenhum deles e o stream tiver uma faixa de legendas forçadas, essa faixa é ativada. Aplicado na próxima vez que a reprodução começar."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lume 会选择流以音轨形式提供的这些语言中的第一种。拖动可重新排序。如果播放的音轨不属于其中任何一种语言，且流中包含强制字幕轨道，则会自动开启该轨道。将在下次播放开始时生效。"
+          }
+        }
+      }
+    },
     "Lume's own FFmpeg 8 engine, in beta. Hardware-accelerated decoding of most formats, built for live-stream stability, with system A/V sync and Picture in Picture." : {
       "comment" : "Description of the Lume Engine, a custom FFmpeg 8 engine.",
       "isCommentAutoGenerated" : true,
@@ -21605,6 +21917,58 @@
         }
       }
     },
+    "No Languages Found" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Sprachen gefunden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron idiomas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune langue trouvée"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna lingua trovata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "言語が見つかりません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "언어를 찾을 수 없음"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum idioma encontrado"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到语言"
+          }
+        }
+      }
+    },
     "No Movies" : {
       "localizations" : {
         "de" : {
@@ -21966,6 +22330,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暂无播放列表。添加您的IPTV服务商即可开始流媒体播放。"
+          }
+        }
+      }
+    },
+    "No Preferred Languages" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine bevorzugten Sprachen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin idiomas preferidos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune langue préférée"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna lingua preferita"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先言語なし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선호 언어 없음"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sem idiomas preferidos"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无首选语言"
           }
         }
       }
@@ -25120,6 +25536,58 @@
         }
       }
     },
+    "Preferred Order" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bevorzugte Reihenfolge"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orden de preferencia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordre de préférence"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordine di preferenza"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先順位"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선호 순서"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordem de preferência"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "优先顺序"
+          }
+        }
+      }
+    },
     "Premium" : {
       "localizations" : {
         "de" : {
@@ -26683,6 +27151,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除"
+          }
+        }
+      }
+    },
+    "Remove %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ entfernen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quitar %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retirer %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuovi %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@を削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 제거"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remover %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除%@"
           }
         }
       }
@@ -29102,6 +29622,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在线搜索…"
+          }
+        }
+      }
+    },
+    "Search to find any other language." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suche nach jeder weiteren Sprache."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Busca para encontrar cualquier otro idioma."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effectuez une recherche pour trouver toute autre langue."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca per trovare qualsiasi altra lingua."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他の言語は検索して見つけてください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다른 언어는 검색으로 찾으세요."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquise para encontrar qualquer outro idioma."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索可查找其他任何语言。"
           }
         }
       }
@@ -32551,6 +33123,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字幕"
+          }
+        }
+      }
+    },
+    "Suggested" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorschläge"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sugeridos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suggestions"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suggerite"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "おすすめ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sugeridos"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推荐"
           }
         }
       }

--- a/Lume/Services/Network/OpenSubtitlesClient.swift
+++ b/Lume/Services/Network/OpenSubtitlesClient.swift
@@ -146,9 +146,7 @@ nonisolated struct OnlineSubtitle: Identifiable, Hashable {
     /// for OpenSubtitles' regional variants (`pt-br`, `zh-cn`) the system
     /// doesn't name.
     var languageName: String {
-        Locale.current.localizedString(forIdentifier: languageCode)
-            ?? Locale.current.localizedString(forLanguageCode: languageCode)
-            ?? languageCode.uppercased()
+        TrackLanguageMatcher.displayName(for: languageCode)
     }
 }
 

--- a/Lume/Services/Player/PlayerEngineOptions.swift
+++ b/Lume/Services/Player/PlayerEngineOptions.swift
@@ -471,6 +471,31 @@ struct LumeEngineOptions {
     }
 }
 
+// MARK: - Preferred track languages
+
+/// A point-in-time read of the engine-independent preferred audio languages,
+/// taken when a stream is configured (the preference is deliberately not
+/// re-read mid-session). An empty list means no preference, and every engine
+/// then leaves track selection exactly as the container asks for it.
+nonisolated struct PlayerLanguageOptions {
+    /// Bare `de`-style codes, normalized on load: `AVMediaSelectionGroup`'s
+    /// preferred-language filter and LumeEngine's `PlayerConfiguration` both
+    /// need real language identifiers rather than something to match on, and
+    /// `TrackLanguageMatcher` normalizes its own input anyway. Entries that
+    /// name no single language are dropped.
+    var preferredAudioLanguages: [String]
+
+    static func load(from defaults: UserDefaults = .standard) -> PlayerLanguageOptions {
+        let stored = PreferredLanguageList.decode(
+            defaults.string(forKey: PlayerSettings.Language.preferredAudioLanguagesKey)
+                ?? PlayerSettings.Language.preferredAudioLanguagesDefault
+        )
+        return PlayerLanguageOptions(
+            preferredAudioLanguages: PreferredLanguageList.normalized(stored.compactMap(TrackLanguageMatcher.normalize))
+        )
+    }
+}
+
 // MARK: - UserDefaults default-aware reads
 
 /// `@AppStorage` writes nothing until the user first changes a control, so a

--- a/Lume/Services/Player/PlayerSettings.swift
+++ b/Lume/Services/Player/PlayerSettings.swift
@@ -103,6 +103,35 @@ enum PlayerEnginePriority {
     }
 }
 
+/// The ordered list of language codes a viewer prefers for a track kind, most
+/// preferred first. Persisted as a comma-separated raw string under
+/// `PlayerSettings.Language`'s keys, because `@AppStorage` cannot bind
+/// `[String]`. An empty list means no preference at all: track selection is
+/// left exactly as the container asks for it.
+nonisolated enum PreferredLanguageList {
+    /// Parse the comma-separated raw value into language codes.
+    static func decode(_ raw: String) -> [String] {
+        normalized(raw.split(separator: ",").map(String.init))
+    }
+
+    static func encode(_ list: [String]) -> String {
+        normalized(list).joined(separator: ",")
+    }
+
+    /// Keep the given order, trimmed of whitespace, without empty tokens or
+    /// case-insensitive duplicates.
+    static func normalized(_ codes: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for code in codes {
+            let trimmed = code.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, seen.insert(trimmed.lowercased()).inserted else { continue }
+            result.append(trimmed)
+        }
+        return result
+    }
+}
+
 enum PlayerSettings {
     static let engineKey = "player.engine"
 
@@ -154,6 +183,23 @@ enum PlayerSettings {
         static var showNextEpisodeButton: Bool {
             UserDefaults.standard.bool(showNextEpisodeButtonKey, default: showNextEpisodeButtonDefault)
         }
+    }
+
+    // MARK: - Preferred track languages
+
+    /// Engine-independent preferred audio track languages: an ordered list of
+    /// bare language codes (`de` matches a `de-AT` track), stored
+    /// comma-separated — see `PreferredLanguageList`.
+    ///
+    /// Defaults to EMPTY, which means no preference and behaviour identical
+    /// to before the setting existed. Nothing is seeded from
+    /// `Locale.preferredLanguages`.
+    nonisolated enum Language {
+        /// Ordered preferred audio languages.
+        static let preferredAudioLanguagesKey = "player.preferredAudioLanguages"
+
+        /// Empty: no preferred language.
+        static let preferredAudioLanguagesDefault = ""
     }
 
     /// Legacy top-level key for VLC's deinterlace toggle, kept stable so the

--- a/Lume/Services/Player/PreferredLanguageCatalog.swift
+++ b/Lume/Services/Player/PreferredLanguageCatalog.swift
@@ -1,0 +1,105 @@
+//
+//  PreferredLanguageCatalog.swift
+//  Lume
+//
+//  The language catalogue behind the preferred audio / subtitle pickers. Built
+//  entirely from `Locale`, never from OpenSubtitles: `OpenSubtitlesClient
+//  .languages()` throws `.notConfigured` without the gitignored `.env` key, so
+//  a network-sourced catalogue would leave the picker empty offline and in any
+//  clone without that file.
+//
+
+import Foundation
+
+/// One selectable language: a bare code plus its name in the viewer's language.
+nonisolated struct PreferredLanguage: Identifiable, Hashable {
+    let code: String
+    let name: String
+
+    var id: String {
+        code
+    }
+
+    init(code: String) {
+        self.code = code
+        name = TrackLanguageMatcher.displayName(for: code)
+    }
+
+    init(code: String, name: String) {
+        self.code = code
+        self.name = name
+    }
+}
+
+nonisolated enum PreferredLanguageCatalog {
+    /// The languages IPTV providers actually ship audio and subtitle tracks in,
+    /// roughly by how often they turn up. Shown up front so the common case
+    /// never needs the search field.
+    static let shortlistCodes: [String] = [
+        "en", "es", "fr", "de", "it", "pt", "ru", "ar", "hi", "zh",
+        "ja", "ko", "tr", "nl", "pl", "sv", "no", "da", "fi", "el",
+        "cs", "sk", "hu", "ro", "bg", "uk", "sr", "hr", "he", "fa",
+        "ur", "bn", "ta", "th", "vi", "id", "ms", "tl", "sw", "af",
+        "ca", "sq"
+    ]
+
+    /// The curated shortlist, named and ordered for display.
+    static let shortlist: [PreferredLanguage] = sortedByName(shortlistCodes.map(PreferredLanguage.init(code:)))
+
+    /// The languages the device is set up for, offered at the top of the add
+    /// picker. A SUGGESTION ONLY — nothing here is ever written to the stored
+    /// preference, which ships empty and stays empty until the viewer picks.
+    static let suggestions: [PreferredLanguage] = {
+        let codes = Locale.preferredLanguages.compactMap(TrackLanguageMatcher.normalize)
+        return PreferredLanguageList.normalized(codes).map(PreferredLanguage.init(code:))
+    }()
+
+    /// What the add picker can still offer, in the two groups it shows: the
+    /// device's own languages, then the curated shortlist minus those. Both
+    /// exclude what the viewer already picked.
+    static func addable(
+        excluding selected: [String]
+    ) -> (suggested: [PreferredLanguage], common: [PreferredLanguage]) {
+        let suggested = available(suggestions, excluding: selected)
+        let offered = Set(suggested.map(\.code))
+        return (suggested, available(shortlist, excluding: selected).filter { !offered.contains($0.code) })
+    }
+
+    /// The subset of `languages` the viewer hasn't already picked.
+    static func available(_ languages: [PreferredLanguage], excluding selected: [String]) -> [PreferredLanguage] {
+        let picked = Set(selected.map { $0.lowercased() })
+        return languages.filter { !picked.contains($0.code.lowercased()) }
+    }
+
+    /// Every ISO language the system can name, plus the shortlist. Backs the
+    /// picker's search field.
+    static let all: [PreferredLanguage] = {
+        var seen = Set<String>()
+        var result: [PreferredLanguage] = []
+        for language in Locale.LanguageCode.isoLanguageCodes {
+            let code = language.identifier(.alpha2) ?? language.identifier
+            guard seen.insert(code).inserted,
+                  let name = Locale.current.localizedString(forLanguageCode: code)
+            else { continue }
+            result.append(PreferredLanguage(code: code, name: name))
+        }
+        for code in shortlistCodes where seen.insert(code).inserted {
+            result.append(PreferredLanguage(code: code))
+        }
+        return sortedByName(result)
+    }()
+
+    /// Name- or code-matched subset of `all`, for the picker's search field.
+    static func search(_ query: String) -> [PreferredLanguage] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        let lowered = trimmed.lowercased()
+        return all.filter {
+            $0.code.hasPrefix(lowered) || $0.name.localizedCaseInsensitiveContains(trimmed)
+        }
+    }
+
+    private static func sortedByName(_ languages: [PreferredLanguage]) -> [PreferredLanguage] {
+        languages.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+}

--- a/Lume/Services/Player/TrackLanguageMatcher.swift
+++ b/Lume/Services/Player/TrackLanguageMatcher.swift
@@ -1,0 +1,286 @@
+//
+//  TrackLanguageMatcher.swift
+//  Lume
+//
+//  Ordered language-preference matching over the audio / subtitle tracks a
+//  container advertises, shared by all four engines.
+//
+//  Foundation only, and deliberately outside every engine-guarded file: the
+//  test target links none of KSPlayer, VLCKit or LumeEngine, so anything that
+//  imported one would be untestable. Each engine adapts its own track type to
+//  `Track` at the call site instead.
+//
+//  A same-named matcher exists inside the LumeEngine package. That one runs
+//  engine-side while the pipeline is being built and takes already-normalised
+//  codes; this is the app-side copy that also has to cope with raw container
+//  tags and free-text track names. They are intentionally separate.
+//
+//  Every entry point is `nonisolated`: matching runs from
+//  `KSOptions.wantedAudio(tracks:)` (an open nonisolated override) and from
+//  VLCKit's own delegate thread.
+//
+
+import Foundation
+
+nonisolated enum TrackLanguageMatcher {
+    /// One track, reduced to what language matching needs.
+    ///
+    /// Both fields matter: KSPlayer puts the container tag on `languageCode`
+    /// and free text like `Deutsch` on `name`, and plenty of IPTV muxes carry
+    /// no tag at all and spell the language out in the title instead.
+    ///
+    /// The container's own default disposition is deliberately not an input —
+    /// a viewer's preference outranks it, so callers apply whatever this
+    /// returns over the default the engine would otherwise have picked.
+    nonisolated struct Track: Equatable {
+        /// The container's language tag, e.g. `ger`, `deu`, `de-AT`.
+        let languageTag: String?
+        /// The track's display name, e.g. `Deutsch`, `GER 5.1`, `English AD`.
+        let label: String?
+
+        init(languageTag: String? = nil, label: String? = nil) {
+            self.languageTag = languageTag
+            self.label = label
+        }
+    }
+
+    // MARK: - Matching
+
+    /// Index of the track that best satisfies an ordered preference list, or
+    /// `nil` when nothing matches.
+    ///
+    /// `nil` means *do nothing*: the container's own selection stands. It must
+    /// never be turned into index 0 by a caller — that would change playback
+    /// for every stream whose languages the viewer never asked about.
+    static func bestMatchIndex(in tracks: [Track], preferring languages: [String]) -> Int? {
+        guard !tracks.isEmpty else { return nil }
+        let wanted = normalizedPreferences(languages)
+        guard !wanted.isEmpty else { return nil }
+
+        var best: (score: Score, index: Int)?
+        for (index, track) in tracks.enumerated() {
+            guard let hit = score(track, order: index, against: wanted) else { continue }
+            if let current = best, current.score <= hit {
+                continue
+            }
+            best = (hit, index)
+        }
+        return best?.index
+    }
+
+    /// Whether the audio that ended up selected is foreign to the viewer,
+    /// which is what gates auto-enabling a forced subtitle track.
+    ///
+    /// With the shipping default — an empty preferred-audio list — nothing is
+    /// ever foreign, so the forced branch is unreachable until the viewer adds
+    /// a language. A track whose language cannot be resolved at all (`und`, a
+    /// bare `Track 1`) is not foreign either: nothing is known, so nothing
+    /// should turn itself on.
+    static func isForeign(_ track: Track, comparedTo preferredAudioLanguages: [String]) -> Bool {
+        let wanted = normalizedPreferences(preferredAudioLanguages)
+        guard !wanted.isEmpty else { return false }
+
+        let tagCode = track.languageTag.flatMap(code(fromTag:))
+        if let tagCode, wanted.contains(tagCode) { return false }
+        let labelCodes = track.label.map(codes(inFreeText:)) ?? []
+        if labelCodes.contains(where: wanted.contains) { return false }
+        return tagCode != nil || !labelCodes.isEmpty
+    }
+
+    // MARK: - Normalization
+
+    /// Reduces anything a container might carry — `ger`, `deu`, `de-DE`,
+    /// `de_DE`, `Deutsch`, `German`, `GER 5.1`, `Audio 1 - English` — to a bare
+    /// `de`-style code, or `nil` when it names no single language.
+    static func normalize(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let code = code(fromTag: trimmed) {
+            return code
+        }
+        return codes(inFreeText: trimmed).first
+    }
+
+    /// The language in the viewer's own language, falling back to the raw code
+    /// for regional variants (`pt-br`, `zh-cn`) the system doesn't name.
+    static func displayName(for code: String) -> String {
+        if let name = Locale.current.localizedString(forIdentifier: code) {
+            return name
+        }
+        if let name = Locale.current.localizedString(forLanguageCode: code) {
+            return name
+        }
+        return code.uppercased()
+    }
+
+    // MARK: - Scoring
+
+    /// Ranked quality of one track↔preference hit. Lower is better, and the
+    /// fields are compared in declaration order:
+    ///
+    /// 1. `rank` — position in the viewer's ordered preference list.
+    /// 2. `penalty` — commentary / audio-description tracks lose to a plain
+    ///    track of the same language.
+    /// 3. `quality` — an exact bare tag beats a regional variant (`de` over
+    ///    `de-AT`), which beats a language found in free text.
+    /// 4. `order` — container order; first match wins all else being equal.
+    private struct Score: Comparable {
+        let rank: Int
+        let penalty: Int
+        let quality: Int
+        let order: Int
+
+        static func < (lhs: Score, rhs: Score) -> Bool {
+            (lhs.rank, lhs.penalty, lhs.quality, lhs.order) < (rhs.rank, rhs.penalty, rhs.quality, rhs.order)
+        }
+    }
+
+    private static func score(_ track: Track, order: Int, against wanted: [String]) -> Score? {
+        let penalty = isDeprioritized(track) ? 1 : 0
+
+        if let tag = track.languageTag, let canonical = code(fromTag: tag), let rank = wanted.firstIndex(of: canonical) {
+            return Score(rank: rank, penalty: penalty, quality: hasSubtags(tag) ? 1 : 0, order: order)
+        }
+
+        if let label = track.label {
+            let ranks = codes(inFreeText: label).compactMap { wanted.firstIndex(of: $0) }
+            if let rank = ranks.min() {
+                return Score(rank: rank, penalty: penalty, quality: 2, order: order)
+            }
+        }
+
+        return nil
+    }
+
+    /// Labels meaning "not the feature audio": director commentary and audio
+    /// description. Matched on the label, because no engine surfaces FFmpeg's
+    /// comment / visual-impaired disposition.
+    private static func isDeprioritized(_ track: Track) -> Bool {
+        guard let label = track.label?.lowercased() else { return false }
+        for phrase in commentaryPhrases where label.contains(phrase) {
+            return true
+        }
+        // "English AD" — the abbreviation counts only as a standalone token.
+        return tokens(of: label).contains("ad")
+    }
+
+    private static let commentaryPhrases = [
+        "commentary", "commentaire", "kommentar", "comentario", "comentário",
+        "commento", "audio description", "audiodescription", "audiodescricao",
+        "audiodescrição", "audiodescripcion", "audiodescripción", "descriptive",
+        "described", "hörfilm"
+    ]
+
+    // MARK: - Language tags
+
+    /// The viewer's preferences as ordered, de-duplicated bare codes.
+    private static func normalizedPreferences(_ languages: [String]) -> [String] {
+        PreferredLanguageList.normalized(languages.compactMap(normalize))
+    }
+
+    /// A single language tag reduced to its primary subtag, or `nil` when it
+    /// carries no usable language.
+    ///
+    /// `Locale.LanguageCode` only knows the ISO 639-2/T terminology codes —
+    /// `Locale.LanguageCode("deu").identifier(.alpha2)` is `de`, but the same
+    /// call on the 639-2/B bibliographic code `ger` is `nil`, and `ger` is what
+    /// MKV and MPEG-TS actually carry. Hence the table below; it covers every
+    /// /B code that differs from its /T form.
+    private static func code(fromTag tag: String) -> String? {
+        let lowered = tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let primary = lowered.split(whereSeparator: { $0 == "-" || $0 == "_" }).first.map(String.init),
+              primary.allSatisfy(\.isLetter),
+              !placeholders.contains(primary)
+        else { return nil }
+
+        switch primary.count {
+        case 2:
+            return Locale.LanguageCode(primary).isISOLanguage ? primary : nil
+        case 3:
+            if let alpha2 = bibliographicAlpha2[primary] {
+                return alpha2
+            }
+            let candidate = Locale.LanguageCode(primary)
+            guard candidate.isISOLanguage else { return nil }
+            return candidate.identifier(.alpha2) ?? primary
+        default:
+            return nil
+        }
+    }
+
+    /// Languages named in a free-text label, best candidate first. Matched per
+    /// token rather than by substring: a bare `de` occurs inside half the
+    /// Romance track titles ever written.
+    private static func codes(inFreeText text: String) -> [String] {
+        let lowered = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !lowered.isEmpty else { return [] }
+        let tokens = tokens(of: lowered)
+
+        var seen = Set<String>()
+        var result: [String] = []
+        func add(_ code: String?) {
+            guard let code, seen.insert(code).inserted else { return }
+            result.append(code)
+        }
+
+        add(languageNamesToCodes[lowered])
+        for token in tokens {
+            add(languageNamesToCodes[token])
+        }
+        for token in tokens {
+            add(code(fromTag: token))
+        }
+        return result
+    }
+
+    /// True when the tag names a region or script beyond the language itself
+    /// (`de-AT`), which loses to an exact `de` when both are present.
+    private static func hasSubtags(_ tag: String) -> Bool {
+        tag.contains("-") || tag.contains("_")
+    }
+
+    private static func tokens(of text: String) -> [String] {
+        text.lowercased().split(whereSeparator: { !$0.isLetter }).map(String.init)
+    }
+
+    /// Tags asserting the absence of one language. `vo` / `vost` are French
+    /// broadcast shorthand for "version originale" (not Volapük, which no IPTV
+    /// provider has ever muxed) and `multi` is the IPTV convention for a
+    /// multiplexed track. All of them mean no match, so the container's own
+    /// choice stands.
+    private static let placeholders: Set<String> = [
+        "und", "mul", "mis", "zxx", "vo", "vos", "vost", "multi", "original", "unknown"
+    ]
+
+    /// ISO 639-2/B → 639-1: exactly the codes `Locale.LanguageCode` cannot
+    /// resolve because it only knows the terminological forms.
+    private static let bibliographicAlpha2: [String: String] = [
+        "alb": "sq", "arm": "hy", "baq": "eu", "bur": "my", "chi": "zh",
+        "cze": "cs", "dut": "nl", "fre": "fr", "geo": "ka", "ger": "de",
+        "gre": "el", "ice": "is", "mac": "mk", "may": "ms", "mao": "mi",
+        "per": "fa", "rum": "ro", "slo": "sk", "tib": "bo", "wel": "cy"
+    ]
+
+    /// Localized language names → bare code, built once from the ISO list in
+    /// English, in the device language, and in each language's own name (a
+    /// German track is labelled `Deutsch` far more often than `German`).
+    /// Roughly 20 ms to build, and only ever touched by the free-text path.
+    private static let languageNamesToCodes: [String: String] = {
+        let sources = [Locale(identifier: "en"), Locale.current]
+        var index: [String: String] = [:]
+        func insert(_ locale: Locale, naming identifier: String, as canonical: String) {
+            guard let name = locale.localizedString(forLanguageCode: identifier)?.lowercased(),
+                  index[name] == nil
+            else { return }
+            index[name] = canonical
+        }
+        for language in Locale.LanguageCode.isoLanguageCodes where language.isISOLanguage {
+            let canonical = language.identifier(.alpha2) ?? language.identifier
+            for locale in sources {
+                insert(locale, naming: language.identifier, as: canonical)
+            }
+            insert(Locale(identifier: canonical), naming: language.identifier, as: canonical)
+        }
+        return index
+    }()
+}

--- a/Lume/Views/Player/AVPlayerControlsOverlay.swift
+++ b/Lume/Views/Player/AVPlayerControlsOverlay.swift
@@ -192,9 +192,15 @@ import SwiftUI
 
         private var secondaryControls: some View {
             HStack(spacing: 4) {
-                if !coordinator.textTrackOptions.isEmpty { subtitleMenu }
-                if coordinator.audioTrackOptions.count > 1 { audioTrackMenu }
-                if !media.isLive { playbackRateMenu }
+                if !coordinator.textTrackOptions.isEmpty {
+                    subtitleMenu
+                }
+                if coordinator.audioTrackOptions.count > 1 {
+                    audioTrackMenu
+                }
+                if !media.isLive {
+                    playbackRateMenu
+                }
                 contentModeButton
                 favoriteButton
             }
@@ -222,20 +228,21 @@ import SwiftUI
                     coordinator.selectTextTrack(id: nil)
                     onResetHideTimer()
                 } label: {
-                    checkmarkLabel("Off", checked: !hasSelection)
+                    playerCheckmarkLabel("Off", checked: !hasSelection)
                 }
                 ForEach(tracks) { track in
                     Button {
                         coordinator.selectTextTrack(id: track.id)
                         onResetHideTimer()
                     } label: {
-                        checkmarkLabel(track.label, checked: track.isSelected)
+                        playerCheckmarkLabel(verbatim: track.label, checked: track.isSelected)
                     }
                 }
             } label: {
                 pillGlyph("captions.bubble.fill", dimmed: !hasSelection)
             }
             .menuIndicator(.hidden)
+            .trackMenuAccessibility("Subtitles", selected: tracks.first(where: \.isSelected)?.label, fallback: "Off")
         }
 
         @ViewBuilder
@@ -247,13 +254,14 @@ import SwiftUI
                         coordinator.selectAudioTrack(id: track.id)
                         onResetHideTimer()
                     } label: {
-                        checkmarkLabel(track.label, checked: track.isSelected)
+                        playerCheckmarkLabel(verbatim: track.label, checked: track.isSelected)
                     }
                 }
             } label: {
                 pillGlyph("waveform")
             }
             .menuIndicator(.hidden)
+            .trackMenuAccessibility("Audio Track", selected: tracks.first(where: \.isSelected)?.label, fallback: "Default")
         }
 
         private var playbackRateMenu: some View {
@@ -263,7 +271,7 @@ import SwiftUI
                         coordinator.playbackRate = rate
                         onResetHideTimer()
                     } label: {
-                        checkmarkLabel(rateString(rate), checked: abs(coordinator.playbackRate - rate) < 0.01)
+                        playerCheckmarkLabel(verbatim: rateString(rate), checked: abs(coordinator.playbackRate - rate) < 0.01)
                     }
                 }
             } label: {
@@ -358,15 +366,6 @@ import SwiftUI
         /// Compact rate label, e.g. `1×`, `1.25×`. `%g` drops trailing zeros.
         private func rateString(_ rate: Float) -> String {
             String(format: "%g×", rate)
-        }
-
-        @ViewBuilder
-        private func checkmarkLabel(_ title: String, checked: Bool) -> some View {
-            if checked {
-                Label(title, systemImage: "checkmark")
-            } else {
-                Text(title)
-            }
         }
 
         private func timeString(from time: TimeInterval) -> String {

--- a/Lume/Views/Player/AVPlayerCoordinator+Languages.swift
+++ b/Lume/Views/Player/AVPlayerCoordinator+Languages.swift
@@ -1,0 +1,106 @@
+//
+//  AVPlayerCoordinator+Languages.swift
+//  Lume
+//
+//  The viewer's preferred audio languages, applied to an AVPlayer item once
+//  its media-selection groups load. Split out of AVPlayerCoordinator to keep
+//  that file within the project's size limit.
+//
+
+import AVFoundation
+import Foundation
+
+extension AVPlayerCoordinator {
+    /// Apply the viewer's ordered audio-language preference to a freshly loaded
+    /// item, once its media-selection groups are known.
+    ///
+    /// The list is empty by default, and that path returns before anything is
+    /// selected — playback then is exactly what AVFoundation would have chosen
+    /// on its own. Not `private`: called from `loadTracks` in
+    /// AVPlayerCoordinator.swift.
+    func applyPreferredLanguages(to item: AVPlayerItem) {
+        guard !hasManualTrackSelection else { return }
+        let audioLanguages = languageOptions.preferredAudioLanguages
+        guard !audioLanguages.isEmpty else { return }
+
+        let audio = selectPreferredAudio(in: item, preferring: audioLanguages)
+
+        // Subtitles already on (the system's caption preferences, or a stream
+        // that forces them) are left exactly as they are: this feature never
+        // re-points a track the viewer can already see.
+        guard let legibleGroup,
+              item.currentMediaSelection.selectedMediaOption(in: legibleGroup) == nil
+        else { return }
+        enableForcedSubtitles(
+            in: item,
+            group: legibleGroup,
+            under: audio,
+            audioLanguages: audioLanguages
+        )
+    }
+
+    /// Select the preferred audio option, and report the option playback will
+    /// actually use — the preferred one when the stream carries it, otherwise
+    /// whatever AVFoundation had already settled on. `nil` when the stream
+    /// advertises no audible selection group.
+    private func selectPreferredAudio(
+        in item: AVPlayerItem,
+        preferring languages: [String]
+    ) -> AVMediaSelectionOption? {
+        guard let audioGroup else { return nil }
+        let current = item.currentMediaSelection.selectedMediaOption(in: audioGroup) ?? audioGroup.defaultOption
+        // No match means the stream carries none of the viewer's languages:
+        // leave the container's own choice alone rather than settle for the
+        // first track.
+        guard let chosen = Self.bestOption(from: audioOptions, preferring: languages) else { return current }
+        item.select(chosen, in: audioGroup)
+        return chosen
+    }
+
+    /// The one case where subtitles turn themselves on: the audio the viewer
+    /// will hear is foreign to their preferred audio languages and the stream
+    /// carries a forced track for the untranslated dialogue. Unreachable while
+    /// the preferred-audio list is empty — nothing is foreign then.
+    private func enableForcedSubtitles(
+        in item: AVPlayerItem,
+        group: AVMediaSelectionGroup,
+        under audio: AVMediaSelectionOption?,
+        audioLanguages: [String]
+    ) {
+        guard let audio,
+              TrackLanguageMatcher.isForeign(Self.matcherTrack(audio), comparedTo: audioLanguages)
+        else { return }
+        let forced = legibleOptions.filter { $0.hasMediaCharacteristic(.containsOnlyForcedSubtitles) }
+        guard let fallback = forced.first else { return }
+        // Preferred audio order first — someone who asked for German audio
+        // reads German signs — then whatever forced track the mux author
+        // expected to be shown.
+        let chosen = Self.bestOption(from: forced, preferring: audioLanguages) ?? fallback
+        item.select(chosen, in: group)
+    }
+
+    /// The option best satisfying an ordered language preference, or `nil` when
+    /// the stream carries none of those languages.
+    ///
+    /// AVFoundation's own filter runs first — it resolves regional variants the
+    /// way the rest of the system does — and the shared matcher then breaks the
+    /// ties it leaves, so a commentary or audio-description track loses to a
+    /// plain track of the same language here exactly as on the other engines.
+    private static func bestOption(
+        from options: [AVMediaSelectionOption],
+        preferring languages: [String]
+    ) -> AVMediaSelectionOption? {
+        guard !languages.isEmpty else { return nil }
+        let candidates = AVMediaSelectionGroup.mediaSelectionOptions(
+            from: options,
+            filteredAndSortedAccordingToPreferredLanguages: languages
+        )
+        guard let first = candidates.first else { return nil }
+        let index = TrackLanguageMatcher.bestMatchIndex(in: candidates.map(matcherTrack), preferring: languages)
+        return index.map { candidates[$0] } ?? first
+    }
+
+    private nonisolated static func matcherTrack(_ option: AVMediaSelectionOption) -> TrackLanguageMatcher.Track {
+        TrackLanguageMatcher.Track(languageTag: languageTag(of: option), label: option.displayName)
+    }
+}

--- a/Lume/Views/Player/AVPlayerCoordinator.swift
+++ b/Lume/Views/Player/AVPlayerCoordinator.swift
@@ -117,10 +117,24 @@ final class AVPlayerCoordinator: NSObject, ObservableObject {
 
     // Cached media-selection groups so the overlay can map an opaque option id
     // back to the `AVMediaSelectionOption` to select.
-    private var audioGroup: AVMediaSelectionGroup?
-    private var legibleGroup: AVMediaSelectionGroup?
-    private var audioOptions: [AVMediaSelectionOption] = []
-    private var legibleOptions: [AVMediaSelectionOption] = []
+    // Not `private`: read by the AVPlayerCoordinator+Languages extension
+    // (separate file).
+    var audioGroup: AVMediaSelectionGroup?
+    var legibleGroup: AVMediaSelectionGroup?
+    var audioOptions: [AVMediaSelectionOption] = []
+    var legibleOptions: [AVMediaSelectionOption] = []
+
+    /// The viewer's ordered preferred track languages, snapshotted when a
+    /// stream starts. Deliberately not re-read mid-session: changing the
+    /// setting applies the next time playback starts. Not `private`: read by
+    /// the AVPlayerCoordinator+Languages extension (separate file).
+    var languageOptions = PlayerLanguageOptions(preferredAudioLanguages: [])
+    /// A manual pick in the audio or subtitle menu outranks the preference for
+    /// the rest of this stream. Kept across a same-URL rebuild (Try Again,
+    /// stall recovery) and cleared when the URL changes, so it can never leak
+    /// into the next channel or episode. Persisted nowhere. Not `private`:
+    /// read by the AVPlayerCoordinator+Languages extension (separate file).
+    var hasManualTrackSelection = false
 
     private var timeObserver: Any?
     private var statusObservation: NSKeyValueObservation?
@@ -181,6 +195,10 @@ final class AVPlayerCoordinator: NSObject, ObservableObject {
         teardownItemObservers()
         trackLoadTask?.cancel()
 
+        if media.url != currentMedia?.url {
+            hasManualTrackSelection = false
+        }
+        languageOptions = PlayerLanguageOptions.load()
         currentMedia = media
         isLive = media.isLive
         startTime = media.startTime
@@ -323,6 +341,7 @@ final class AVPlayerCoordinator: NSObject, ObservableObject {
 
     func selectAudioTrack(id: String) {
         guard let audioGroup, let index = Int(id), audioOptions.indices.contains(index) else { return }
+        hasManualTrackSelection = true
         item?.select(audioOptions[index], in: audioGroup)
         refreshTrackSelection()
     }
@@ -330,6 +349,7 @@ final class AVPlayerCoordinator: NSObject, ObservableObject {
     /// `nil` disables subtitles ("Off").
     func selectTextTrack(id: String?) {
         guard let legibleGroup else { return }
+        hasManualTrackSelection = true
         if let id, let index = Int(id), legibleOptions.indices.contains(index) {
             item?.select(legibleOptions[index], in: legibleGroup)
         } else {
@@ -349,6 +369,7 @@ final class AVPlayerCoordinator: NSObject, ObservableObject {
                 legibleGroup = legible
                 audioOptions = audio?.options ?? []
                 legibleOptions = legible?.options ?? []
+                applyPreferredLanguages(to: item)
                 refreshTrackSelection()
             }
         }
@@ -380,6 +401,15 @@ final class AVPlayerCoordinator: NSObject, ObservableObject {
         } else {
             textTrackOptions = []
         }
+    }
+
+    /// Raw BCP-47 tag for a selection option. `extendedLanguageTag` keeps the
+    /// region ("pt-BR"); `locale` is the fallback for options that only carry
+    /// one. Handed on un-normalized — `TrackLanguageMatcher` does that.
+    /// Not `private`: read by the AVPlayerCoordinator+Languages extension
+    /// (separate file).
+    nonisolated static func languageTag(of option: AVMediaSelectionOption) -> String? {
+        option.extendedLanguageTag ?? option.locale?.identifier
     }
 
     // MARK: - Content mode

--- a/Lume/Views/Player/KSPlayerControlsOverlay.swift
+++ b/Lume/Views/Player/KSPlayerControlsOverlay.swift
@@ -216,9 +216,15 @@ import SwiftUI
 
         private var secondaryControls: some View {
             HStack(spacing: 4) {
-                if !subtitleTracks.isEmpty || onSearchSubtitles != nil { subtitleMenu }
-                if audioTracks.count > 1 { audioTrackMenu }
-                if !media.isLive { playbackRateMenu }
+                if !subtitleTracks.isEmpty || onSearchSubtitles != nil {
+                    subtitleMenu
+                }
+                if audioTracks.count > 1 {
+                    audioTrackMenu
+                }
+                if !media.isLive {
+                    playbackRateMenu
+                }
                 contentModeButton
                 favoriteButton
             }
@@ -245,14 +251,14 @@ import SwiftUI
                     coordinator.subtitleModel.selectedSubtitleInfo = nil
                     onResetHideTimer()
                 } label: {
-                    checkmarkLabel("Off", checked: !hasSelection)
+                    playerCheckmarkLabel("Off", checked: !hasSelection)
                 }
                 ForEach(subtitleTracks, id: \.subtitleID) { track in
                     Button {
                         coordinator.subtitleModel.selectedSubtitleInfo = track
                         onResetHideTimer()
                     } label: {
-                        checkmarkLabel(track.name, checked: selectedSubtitle?.subtitleID == track.subtitleID)
+                        playerCheckmarkLabel(verbatim: track.name, checked: selectedSubtitle?.subtitleID == track.subtitleID)
                     }
                 }
                 if let onSearchSubtitles {
@@ -268,6 +274,7 @@ import SwiftUI
                 pillGlyph("captions.bubble.fill", dimmed: !hasSelection)
             }
             .menuIndicator(.hidden)
+            .trackMenuAccessibility("Subtitles", selected: selectedSubtitle?.name, fallback: "Off")
         }
 
         /// KSPlayer exposes the demuxed audio streams on the player itself —
@@ -285,17 +292,18 @@ import SwiftUI
             Menu {
                 ForEach(Array(tracks.enumerated()), id: \.offset) { _, track in
                     Button {
-                        coordinator.playerLayer?.player.select(track: track)
+                        coordinator.selectAudioTrack(track)
                         coordinator.objectWillChange.send()
                         onResetHideTimer()
                     } label: {
-                        checkmarkLabel(track.name, checked: track.isEnabled)
+                        playerCheckmarkLabel(verbatim: track.name, checked: track.isEnabled)
                     }
                 }
             } label: {
                 pillGlyph("waveform")
             }
             .menuIndicator(.hidden)
+            .trackMenuAccessibility("Audio Track", selected: tracks.first(where: \.isEnabled)?.name, fallback: "Default")
         }
 
         private var playbackRateMenu: some View {
@@ -305,7 +313,7 @@ import SwiftUI
                         coordinator.playbackRate = rate
                         onResetHideTimer()
                     } label: {
-                        checkmarkLabel(rateString(rate), checked: abs(coordinator.playbackRate - rate) < 0.01)
+                        playerCheckmarkLabel(verbatim: rateString(rate), checked: abs(coordinator.playbackRate - rate) < 0.01)
                     }
                 }
             } label: {
@@ -380,15 +388,6 @@ import SwiftUI
         /// Compact rate label, e.g. `1×`, `1.25×`. `%g` drops trailing zeros.
         private func rateString(_ rate: Float) -> String {
             String(format: "%g×", rate)
-        }
-
-        @ViewBuilder
-        private func checkmarkLabel(_ title: String, checked: Bool) -> some View {
-            if checked {
-                Label(title, systemImage: "checkmark")
-            } else {
-                Text(title)
-            }
         }
     }
 

--- a/Lume/Views/Player/KSPlayerEngineView+Options.swift
+++ b/Lume/Views/Player/KSPlayerEngineView+Options.swift
@@ -9,7 +9,69 @@
 
 import Foundation
 import KSPlayer
+import os
 import SwiftUI
+
+/// `KSOptions` that resolves the viewer's preferred audio language while the
+/// stream is being opened.
+///
+/// `wantedAudio(tracks:)` is the only sanctioned pre-selection hook: KSPlayer
+/// consults it inside `MEPlayerItem`'s open, before any decoder exists, so no
+/// track ever starts and gets swapped. `player.select(track:)` stays reserved
+/// for manual picks, and re-preparing a running layer to apply a language is a
+/// documented use-after-free.
+///
+/// Only audio. KSPlayer declares no wanted-subtitle counterpart and reports no
+/// forced disposition, so subtitle pre-selection and forced-subtitle handling
+/// are not available on this engine. The hook also lives on the FFmpeg engine
+/// alone — `KSAVPlayer` never reads it.
+final nonisolated class LumeKSOptions: KSOptions {
+    private let preferredAudioLanguages: [String]
+
+    /// A manual pick wins for the rest of the stream. `rebuildStream(on:)` and
+    /// `reconnect()` re-open with this very options instance, which would
+    /// otherwise re-assert the preference over the viewer's choice on every
+    /// live zap, stall recovery and reconnect. Scoped to one stream: the
+    /// coordinator builds a fresh options object whenever the URL changes, so
+    /// the flag cannot leak into the next channel or episode.
+    ///
+    /// Written from the main actor, read on KSPlayer's open thread.
+    private let hasManualAudioSelection = OSAllocatedUnfairLock(initialState: false)
+
+    init(preferredAudioLanguages: [String]) {
+        self.preferredAudioLanguages = preferredAudioLanguages
+        super.init()
+    }
+
+    /// Call from every manual audio-track pick, before `select(track:)`.
+    func noteManualAudioSelection() {
+        hasManualAudioSelection.withLock { $0 = true }
+    }
+
+    /// `nil` leaves KSPlayer's own choice (`av_find_best_stream`) untouched —
+    /// never index 0, which would change playback for streams whose languages
+    /// the viewer never asked about.
+    override func wantedAudio(tracks: [MediaPlayerTrack]) -> Int? {
+        guard !preferredAudioLanguages.isEmpty else { return nil }
+        guard !hasManualAudioSelection.withLock({ $0 }) else { return nil }
+        return TrackLanguageMatcher.bestMatchIndex(
+            in: tracks.map { TrackLanguageMatcher.Track(languageTag: $0.languageCode, label: $0.name) },
+            preferring: preferredAudioLanguages
+        )
+    }
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+extension KSVideoPlayer.Coordinator {
+    /// The one sanctioned way to pick an audio track by hand: the
+    /// preferred-audio-language pass has to stand down for the rest of the
+    /// stream, which every overlay would otherwise have to remember. Callers
+    /// publish their own change afterwards.
+    func selectAudioTrack(_ track: MediaPlayerTrack) {
+        (playerLayer?.options as? LumeKSOptions)?.noteManualAudioSelection()
+        playerLayer?.player.select(track: track)
+    }
+}
 
 /// Turns the user's saved KSPlayer settings into a `KSOptions` for one stream.
 /// Shared by the full-screen engine view and the Multi-View tiles, which need
@@ -45,7 +107,9 @@ enum KSPlayerOptionsFactory {
         KSOptions.useSystemHTTPProxy = settings.systemProxy
         KSOptions.firstPlayerType = settings.primaryEngine == .ffmpeg ? KSMEPlayer.self : KSAVPlayer.self
 
-        let options = KSOptions()
+        let options = LumeKSOptions(
+            preferredAudioLanguages: PlayerLanguageOptions.load().preferredAudioLanguages
+        )
         // Now Playing metadata + remote commands are owned by
         // `NowPlayingService` for all engines; KSPlayer's built-in
         // registration would double-handle every command.

--- a/Lume/Views/Player/KSTVPlaybackEngine.swift
+++ b/Lume/Views/Player/KSTVPlaybackEngine.swift
@@ -96,9 +96,10 @@
         }
 
         func selectAudioTrack(id: String) {
-            guard let player = coordinator?.playerLayer?.player,
-                  let track = player.tracks(mediaType: .audio).first(where: { String($0.trackID) == id }) else { return }
-            player.select(track: track)
+            guard let coordinator,
+                  let track = coordinator.playerLayer?.player
+                  .tracks(mediaType: .audio).first(where: { String($0.trackID) == id }) else { return }
+            coordinator.selectAudioTrack(track)
             objectWillChange.send()
         }
 

--- a/Lume/Views/Player/LumeEngineControlsOverlay.swift
+++ b/Lume/Views/Player/LumeEngineControlsOverlay.swift
@@ -214,9 +214,15 @@ import SwiftUI
             let hasRate = !media.isLive
 
             return HStack(spacing: 4) {
-                if hasText { subtitleMenu }
-                if hasAudio { audioTrackMenu }
-                if hasRate { playbackRateMenu }
+                if hasText {
+                    subtitleMenu
+                }
+                if hasAudio {
+                    audioTrackMenu
+                }
+                if hasRate {
+                    playbackRateMenu
+                }
                 favoriteButton
             }
             .padding(.horizontal, 4)
@@ -243,14 +249,14 @@ import SwiftUI
                     coordinator.selectTextTrack(id: nil)
                     onResetHideTimer()
                 } label: {
-                    checkmarkLabel("Off", checked: !hasSelection)
+                    playerCheckmarkLabel("Off", checked: !hasSelection)
                 }
                 ForEach(tracks) { track in
                     Button {
                         coordinator.selectTextTrack(id: track.id)
                         onResetHideTimer()
                     } label: {
-                        checkmarkLabel(track.label, checked: track.isSelected)
+                        playerCheckmarkLabel(verbatim: track.label, checked: track.isSelected)
                     }
                 }
                 if let onSearchSubtitles {
@@ -266,6 +272,7 @@ import SwiftUI
                 pillGlyph("captions.bubble.fill", dimmed: !hasSelection)
             }
             .menuIndicator(.hidden)
+            .trackMenuAccessibility("Subtitles", selected: tracks.first(where: \.isSelected)?.label, fallback: "Off")
         }
 
         @ViewBuilder
@@ -277,13 +284,14 @@ import SwiftUI
                         coordinator.selectAudioTrack(id: track.id)
                         onResetHideTimer()
                     } label: {
-                        checkmarkLabel(track.label, checked: track.isSelected)
+                        playerCheckmarkLabel(verbatim: track.label, checked: track.isSelected)
                     }
                 }
             } label: {
                 pillGlyph("waveform")
             }
             .menuIndicator(.hidden)
+            .trackMenuAccessibility("Audio Track", selected: tracks.first(where: \.isSelected)?.label, fallback: "Default")
         }
 
         private var playbackRateMenu: some View {
@@ -293,7 +301,7 @@ import SwiftUI
                         coordinator.playbackRate = rate
                         onResetHideTimer()
                     } label: {
-                        checkmarkLabel(rateString(rate), checked: abs(coordinator.playbackRate - rate) < 0.01)
+                        playerCheckmarkLabel(verbatim: rateString(rate), checked: abs(coordinator.playbackRate - rate) < 0.01)
                     }
                 }
             } label: {
@@ -353,15 +361,6 @@ import SwiftUI
         /// Compact rate label, e.g. `1×`, `1.25×`. `%g` drops trailing zeros.
         private func rateString(_ rate: Float) -> String {
             String(format: "%g×", rate)
-        }
-
-        @ViewBuilder
-        private func checkmarkLabel(_ title: String, checked: Bool) -> some View {
-            if checked {
-                Label(title, systemImage: "checkmark")
-            } else {
-                Text(title)
-            }
         }
     }
 

--- a/Lume/Views/Player/LumeEngineCoordinator.swift
+++ b/Lume/Views/Player/LumeEngineCoordinator.swift
@@ -100,7 +100,18 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
     private var tickCount = 0
     private var startupTask: Task<Void, Never>?
     private var reportedFailure = false
+    /// Mirrors `PlayerSession.selectedAudioTrackIndex`, read back after `open`
+    /// rather than assumed: the engine starts on its own preferred/default
+    /// pick, which is not necessarily the first track.
+    private var selectedAudioID: String?
     private var selectedSubtitleID: String?
+    /// A manual pick in the audio or subtitle menu outranks the preferred
+    /// languages for the rest of this stream: the engine has no rebuild in
+    /// place, so a stall recovery re-opens through `makeConfiguration` and
+    /// would otherwise re-assert the preference over the viewer's choice.
+    /// Cleared when the URL changes, so it cannot leak into the next channel
+    /// or episode. Persisted nowhere.
+    private var hasManualTrackSelection = false
     /// The sidecar subtitle file loaded from the OpenSubtitles search, if any.
     /// Kept so the track survives a switch to an embedded track and back — the
     /// engine's sidecar loader is a one-shot parse, so re-selecting means
@@ -111,6 +122,9 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
 
     func configure(media: PlayableMedia) {
         tearDown()
+        if media.url != currentMedia?.url {
+            hasManualTrackSelection = false
+        }
         currentMedia = media
         reportedFailure = false
         // After `tearDown` (which closes any previous session) so a reload counts
@@ -140,6 +154,11 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
             do {
                 let info = try await session.open(url: media.url.absoluteString)
                 self.mediaInfo = info
+                self.selectedAudioID = await session.selectedAudioTrackIndex.map { String($0) }
+                // Non-nil only when the engine turned a forced track on by
+                // itself because the chosen audio is foreign to the viewer;
+                // embedded subtitles otherwise start off as they always have.
+                self.selectedSubtitleID = await session.selectedSubtitleTrackIndex.map { String($0) }
                 self.publishTracks(info: info)
                 self.publishVideoInfo(info: info)
                 if !self.isEmbedded {
@@ -219,6 +238,7 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
         // The sidecar lane belongs to the session that just went away; a fresh
         // session starts with no cues, so the menu must not keep advertising it.
         externalSubtitle = nil
+        selectedAudioID = nil
         selectedSubtitleID = nil
         isPipActive = false
     }
@@ -260,14 +280,17 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
 
     func selectAudioTrack(id: String) {
         guard let index = Int32(id) else { return }
+        hasManualTrackSelection = true
         let session = session
         Task { await session?.selectAudioTrack(index) }
+        selectedAudioID = id
         if let info = mediaInfo {
-            publishTracks(info: info, selectedAudioID: id)
+            publishTracks(info: info)
         }
     }
 
     func selectTextTrack(id: String?) {
+        hasManualTrackSelection = true
         selectedSubtitleID = id
         if let external = externalSubtitle, id == Self.externalTrackID {
             loadExternalSubtitleFile(external)
@@ -303,6 +326,20 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
         configuration.videoQueueDepth = options.videoQueueDepth
         configuration.audioQueueDepth = options.audioQueueDepth
         configuration.stallThreshold = Double(options.stallThreshold)
+        // Resolved engine-side while the pipeline is built, before the demuxer
+        // streams a byte: selecting after `open()` would route through a seek
+        // that discards `startPosition` on a VOD resume and that many live IPTV
+        // endpoints do not survive. Empty lists (the default, and what a manual
+        // pick leaves for the rest of this stream) mean the engine keeps the
+        // container's own selection.
+        if !hasManualTrackSelection {
+            let languages = PlayerLanguageOptions.load()
+            configuration.preferredAudioLanguages = languages.preferredAudioLanguages
+            // Subtitling untranslated dialogue is Lume's rule, not the
+            // engine's — the same one `AVPlayerCoordinator+Languages` applies
+            // on AVFoundation.
+            configuration.autoEnableForcedSubtitlesForForeignAudio = true
+        }
         configuration.demuxer.enableReconnect = options.httpReconnect
         configuration.demuxer.ioTimeout = options.ioTimeout
         // The open timeout stays tied to the engine-fallback budget rather than
@@ -398,14 +435,18 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
         }
     }
 
-    private func publishTracks(info: MediaInfo, selectedAudioID: String? = nil) {
+    private func publishTracks(info: MediaInfo) {
+        // `selectedAudioID` mirrors the engine's own `selectedAudioTrackIndex`,
+        // which it sets whenever an audio track exists. Falling back to the
+        // first row while it is still nil keeps the menu from rendering with no
+        // checkmark at all.
+        let audioFallsBackToFirst = selectedAudioID == nil
         audioTrackOptions = info.audioTracks.enumerated().map { position, track in
             let id = String(track.index)
-            let fallbackSelected = selectedAudioID == nil && position == 0
             return PlayerTrackOption(
                 id: id,
                 label: trackLabel(track, fallback: "Audio \(position + 1)"),
-                isSelected: selectedAudioID.map { $0 == id } ?? fallbackSelected
+                isSelected: selectedAudioID == id || (audioFallsBackToFirst && position == 0)
             )
         }
         var options = info.subtitleTracks.enumerated().map { position, track in
@@ -441,7 +482,7 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
             return title
         }
         if let language = track.language, !language.isEmpty {
-            return Locale.current.localizedString(forLanguageCode: language) ?? language
+            return TrackLanguageMatcher.displayName(for: language)
         }
         return fallback
     }

--- a/Lume/Views/Player/PlayerVideoInfo.swift
+++ b/Lume/Views/Player/PlayerVideoInfo.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 /// Resolution / frame-rate / codec snapshot for the current video track.
 ///
@@ -11,7 +12,9 @@ import Foundation
 /// Engine-agnostic and unguarded by platform: the shared tvOS overlay
 /// (`TVPlayerControlsOverlay`) and the AVPlayer iOS / macOS overlay both consume
 /// it, and the AVPlayer coordinator produces it on every platform.
-struct PlayerTrackOption: Identifiable, Hashable {
+/// `nonisolated` because the language matcher reads these off the main actor
+/// (KSPlayer's `wantedAudio` override, VLCKit's delegate thread).
+nonisolated struct PlayerTrackOption: Identifiable, Hashable {
     /// Opaque, engine-defined identifier handed back to `select…Track(id:)`.
     let id: String
     let label: String
@@ -46,8 +49,12 @@ struct PlayerVideoInfo: Equatable {
     /// `["4K", "H264", "24 fps"]`.
     var captionParts: [String] {
         var parts: [String] = []
-        if !qualityTag.isEmpty { parts.append(qualityTag) }
-        if let codec, !codec.isEmpty { parts.append(codec.uppercased()) }
+        if !qualityTag.isEmpty {
+            parts.append(qualityTag)
+        }
+        if let codec, !codec.isEmpty {
+            parts.append(codec.uppercased())
+        }
         if fps > 0 {
             let rounded = (fps * 100).rounded() / 100
             let text = rounded.truncatingRemainder(dividingBy: 1) == 0
@@ -56,5 +63,40 @@ struct PlayerVideoInfo: Equatable {
             parts.append("\(text) fps")
         }
         return parts
+    }
+}
+
+/// A track-menu entry: the title, with a leading checkmark when it is the
+/// selected one. Shared by every engine overlay's subtitle / audio / rate menu.
+@ViewBuilder
+func playerCheckmarkLabel(_ title: LocalizedStringKey, checked: Bool) -> some View {
+    if checked {
+        Label(title, systemImage: "checkmark")
+    } else {
+        Text(title)
+    }
+}
+
+/// Engine-supplied track names and rate numbers must never reach a
+/// localization lookup — this overload is the verbatim one.
+@ViewBuilder
+func playerCheckmarkLabel(verbatim title: String, checked: Bool) -> some View {
+    if checked {
+        Label { Text(verbatim: title) } icon: { Image(systemName: "checkmark") }
+    } else {
+        Text(verbatim: title)
+    }
+}
+
+extension View {
+    /// VoiceOver label and value for a track menu: the enabled track's own
+    /// name, or the menu's own no-selection wording.
+    func trackMenuAccessibility(
+        _ label: LocalizedStringKey,
+        selected: String?,
+        fallback: LocalizedStringKey
+    ) -> some View {
+        accessibilityLabel(label)
+            .accessibilityValue(selected.flatMap { $0.isEmpty ? nil : Text(verbatim: $0) } ?? Text(fallback))
     }
 }

--- a/Lume/Views/Player/SubtitleSearchView.swift
+++ b/Lume/Views/Player/SubtitleSearchView.swift
@@ -75,11 +75,7 @@ struct SubtitleSearchView: View {
     }
 
     var languageSummary: String {
-        let names = service.preferredLanguages.map { code in
-            Locale.current.localizedString(forIdentifier: code)
-                ?? Locale.current.localizedString(forLanguageCode: code)
-                ?? code.uppercased()
-        }
+        let names = service.preferredLanguages.map { TrackLanguageMatcher.displayName(for: $0) }
         return names.isEmpty ? String(localized: "Any") : names.joined(separator: ", ")
     }
 

--- a/Lume/Views/Player/TVPlaybackEngine.swift
+++ b/Lume/Views/Player/TVPlaybackEngine.swift
@@ -82,21 +82,21 @@
             }
         }
 
+        /// Manual picks route through the coordinator's `select…Track(_:)`
+        /// entry points, which are what tell the preferred-language pass to
+        /// stand down for the rest of this stream.
         func selectAudioTrack(id: String) {
             guard let index = Int(id), mediaPlayer.audioTracks.indices.contains(index) else { return }
-            mediaPlayer.audioTracks[index].isSelectedExclusively = true
-            objectWillChange.send()
+            selectAudioTrack(mediaPlayer.audioTracks[index])
         }
 
         func selectTextTrack(id: String?) {
             guard let id else {
-                mediaPlayer.deselectAllTextTracks()
-                objectWillChange.send()
+                selectTextTrack(nil)
                 return
             }
             guard let index = Int(id), mediaPlayer.textTracks.indices.contains(index) else { return }
-            mediaPlayer.textTracks[index].isSelectedExclusively = true
-            objectWillChange.send()
+            selectTextTrack(mediaPlayer.textTracks[index])
         }
     }
 

--- a/Lume/Views/Player/TVPlayerControlsOverlay.swift
+++ b/Lume/Views/Player/TVPlayerControlsOverlay.swift
@@ -101,7 +101,9 @@
                 // While scrubbing, left/right step the playhead; vertical moves
                 // are swallowed so focus can't escape the bar.
                 if isScrubbing {
-                    if direction == .left || direction == .right { moveScrub(direction) }
+                    if direction == .left || direction == .right {
+                        moveScrub(direction)
+                    }
                     return
                 }
                 // With the controls up, up/down still surf channels — but only
@@ -113,7 +115,11 @@
             // The host bumps `panelCloseToken` on a Menu/back press. Mid-scrub
             // that cancels the scrub; otherwise it closes an open panel.
             .onChange(of: panelCloseToken) {
-                if isScrubbing { cancelScrub() } else { closePanel() }
+                if isScrubbing {
+                    cancelScrub()
+                } else {
+                    closePanel()
+                }
             }
             .task(id: media.id) { resolveContent() }
             .onAppear {
@@ -243,10 +249,14 @@
         // MARK: - Tabs
 
         var tabKinds: [TabKind] {
-            if isSeries { return [.episodes, .info] }
+            if isSeries {
+                return [.episodes, .info]
+            }
             // The recents rail only earns a tab once there's somewhere to switch
             // to — i.e. a channel beyond the one playing now.
-            if media.isLive, recentChannels.count > 1 { return [.recent, .info] }
+            if media.isLive, recentChannels.count > 1 {
+                return [.recent, .info]
+            }
             return [.info]
         }
 
@@ -303,7 +313,9 @@
         private var leadingTransportButton: some View {
             if isSeries {
                 circleButton(systemImage: "backward.fill", focus: .previousItem, enabled: previousEpisode != nil) {
-                    if let previousEpisode { select(episode: previousEpisode) }
+                    if let previousEpisode {
+                        select(episode: previousEpisode)
+                    }
                 }
             } else {
                 circleButton(systemImage: "backward.fill", focus: .previousItem) {
@@ -317,7 +329,9 @@
         private var trailingTransportButton: some View {
             if isSeries {
                 circleButton(systemImage: "forward.fill", focus: .nextItem, enabled: nextEpisode != nil) {
-                    if let nextEpisode { select(episode: nextEpisode) }
+                    if let nextEpisode {
+                        select(episode: nextEpisode)
+                    }
                 }
             } else {
                 circleButton(systemImage: "forward.fill", focus: .nextItem) {
@@ -387,6 +401,7 @@
                 .menuIndicator(.hidden)
                 .buttonStyle(TVPlayerCircleButtonStyle())
                 .focused($focus, equals: .audio)
+                .trackMenuAccessibility("Audio Track", selected: tracks.first(where: \.isSelected)?.label, fallback: "Default")
             }
         }
 
@@ -431,6 +446,7 @@
                 .menuIndicator(.hidden)
                 .buttonStyle(TVPlayerCircleButtonStyle())
                 .focused($focus, equals: .subtitles)
+                .trackMenuAccessibility("Subtitles", selected: tracks.first(where: \.isSelected)?.label, fallback: "Off")
             }
         }
 
@@ -527,12 +543,16 @@
         }
 
         private var leadingTimeLabel: String {
-            if isLive, let epgNow { return Self.wallClock(epgNow.start) }
+            if isLive, let epgNow {
+                return Self.wallClock(epgNow.start)
+            }
             return Self.timeString(isScrubbing ? scrubTarget : clock.current)
         }
 
         private var trailingTimeLabel: String {
-            if isLive, let epgNow { return Self.wallClock(epgNow.end) }
+            if isLive, let epgNow {
+                return Self.wallClock(epgNow.end)
+            }
             let reference = isScrubbing ? scrubTarget : clock.current
             return "-" + Self.timeString(max(clock.duration - reference, 0))
         }

--- a/Lume/Views/Player/VLCPlayerControlsOverlay.swift
+++ b/Lume/Views/Player/VLCPlayerControlsOverlay.swift
@@ -204,9 +204,15 @@ struct VLCPlayerControlsOverlay: View {
         let hasRate = !media.isLive
 
         return HStack(spacing: 4) {
-            if hasText { subtitleMenu }
-            if hasAudio { audioTrackMenu }
-            if hasRate { playbackRateMenu }
+            if hasText {
+                subtitleMenu
+            }
+            if hasAudio {
+                audioTrackMenu
+            }
+            if hasRate {
+                playbackRateMenu
+            }
             favoriteButton
         }
         .padding(.horizontal, 4)
@@ -233,14 +239,14 @@ struct VLCPlayerControlsOverlay: View {
                 coordinator.selectTextTrack(nil)
                 onResetHideTimer()
             } label: {
-                checkmarkLabel("Off", checked: !hasSelection)
+                playerCheckmarkLabel("Off", checked: !hasSelection)
             }
             ForEach(Array(tracks.enumerated()), id: \.offset) { _, track in
                 Button {
                     coordinator.selectTextTrack(track)
                     onResetHideTimer()
                 } label: {
-                    checkmarkLabel(track.trackName, checked: track.isSelectedExclusively)
+                    playerCheckmarkLabel(verbatim: track.trackName, checked: track.isSelectedExclusively)
                 }
             }
             if let onSearchSubtitles {
@@ -256,6 +262,7 @@ struct VLCPlayerControlsOverlay: View {
             pillGlyph("captions.bubble.fill", dimmed: !hasSelection)
         }
         .menuIndicator(.hidden)
+        .trackMenuAccessibility("Subtitles", selected: tracks.first(where: \.isSelectedExclusively)?.trackName, fallback: "Off")
     }
 
     @ViewBuilder
@@ -267,13 +274,14 @@ struct VLCPlayerControlsOverlay: View {
                     coordinator.selectAudioTrack(track)
                     onResetHideTimer()
                 } label: {
-                    checkmarkLabel(track.trackName, checked: track.isSelectedExclusively)
+                    playerCheckmarkLabel(verbatim: track.trackName, checked: track.isSelectedExclusively)
                 }
             }
         } label: {
             pillGlyph("waveform")
         }
         .menuIndicator(.hidden)
+        .trackMenuAccessibility("Audio Track", selected: tracks.first(where: \.isSelectedExclusively)?.trackName, fallback: "Default")
     }
 
     private var playbackRateMenu: some View {
@@ -283,7 +291,7 @@ struct VLCPlayerControlsOverlay: View {
                     coordinator.playbackRate = rate
                     onResetHideTimer()
                 } label: {
-                    checkmarkLabel(rateString(rate), checked: abs(coordinator.playbackRate - rate) < 0.01)
+                    playerCheckmarkLabel(verbatim: rateString(rate), checked: abs(coordinator.playbackRate - rate) < 0.01)
                 }
             }
         } label: {
@@ -381,15 +389,6 @@ struct VLCPlayerControlsOverlay: View {
     /// Compact rate label, e.g. `1×`, `1.25×`. `%g` drops trailing zeros.
     private func rateString(_ rate: Float) -> String {
         String(format: "%g×", rate)
-    }
-
-    @ViewBuilder
-    private func checkmarkLabel(_ title: String, checked: Bool) -> some View {
-        if checked {
-            Label(title, systemImage: "checkmark")
-        } else {
-            Text(title)
-        }
     }
 
     private func timeString(from time: TimeInterval) -> String {

--- a/Lume/Views/Player/VLCPlayerCoordinator+Languages.swift
+++ b/Lume/Views/Player/VLCPlayerCoordinator+Languages.swift
@@ -1,0 +1,90 @@
+//
+//  VLCPlayerCoordinator+Languages.swift
+//  Lume
+//
+//  The viewer's preferred audio languages, applied to the VLCKit player once
+//  libvlc has parsed the stream's tracks, plus the manual picks that outrank
+//  them. Split out of VLCPlayerCoordinator to keep that file within the
+//  project's size limit.
+//
+
+import Combine
+import Foundation
+import VLCKit
+
+extension VLCPlayerCoordinator {
+    // MARK: - Tracks
+
+    var audioTracks: [VLCMediaPlayer.Track] {
+        mediaPlayer.audioTracks
+    }
+
+    var textTracks: [VLCMediaPlayer.Track] {
+        mediaPlayer.textTracks
+    }
+
+    /// Manual audio pick. Outranks the preferred audio language for the rest of
+    /// this stream, including across the rebuilds a reconnect or a Try Again
+    /// performs.
+    func selectAudioTrack(_ track: VLCMediaPlayer.Track) {
+        hasManualTrackSelection = true
+        track.isSelectedExclusively = true
+        objectWillChange.send()
+    }
+
+    /// Manual subtitle pick; `nil` is "Off".
+    func selectTextTrack(_ track: VLCMediaPlayer.Track?) {
+        hasManualTrackSelection = true
+        if let track {
+            track.isSelectedExclusively = true
+        } else {
+            mediaPlayer.deselectAllTextTracks()
+        }
+        objectWillChange.send()
+    }
+
+    // MARK: - Preferred languages
+
+    /// Apply the viewer's ordered audio-language preference to the tracks
+    /// libvlc has parsed.
+    ///
+    /// Driven from `mediaPlayerStateChanged(_:)`'s main hop: tracks arrive
+    /// asynchronously and the coordinator implements no track-added callback,
+    /// so there is no earlier hook. The one-shot flag is set only once audio
+    /// tracks actually exist — the state change fires on every transition and
+    /// libvlc parses elementary streams progressively, so latching earlier
+    /// would skip the pass for the whole stream. It also stops the pass
+    /// fighting the viewer's later picks.
+    ///
+    /// The list is empty by default and that path returns before touching the
+    /// player, so selection stays exactly what libvlc chose.
+    ///
+    /// There is no forced-subtitle branch: `VLCMediaTrack` carries no forced
+    /// disposition, so the rule the other engines apply when the audio turns
+    /// out foreign cannot be evaluated on VLCKit.
+    ///
+    /// Not `private`: called from VLCPlayerCoordinator.swift.
+    func applyPreferredLanguagesIfNeeded() {
+        guard !didApplyPreferredLanguages, !hasManualTrackSelection else { return }
+        let audioLanguages = languageOptions.preferredAudioLanguages
+        guard !audioLanguages.isEmpty else { return }
+
+        let tracks = mediaPlayer.audioTracks
+        guard !tracks.isEmpty else { return }
+        didApplyPreferredLanguages = true
+
+        // No match means the stream carries none of the viewer's languages:
+        // leave libvlc's own choice alone rather than settle for the first
+        // track.
+        guard let index = TrackLanguageMatcher.bestMatchIndex(
+            in: tracks.map(Self.matcherTrack),
+            preferring: audioLanguages
+        ), !tracks[index].isSelectedExclusively else { return }
+        tracks[index].isSelectedExclusively = true
+        objectWillChange.send()
+    }
+
+    private nonisolated static func matcherTrack(_ track: VLCMediaPlayer.Track) -> TrackLanguageMatcher.Track {
+        TrackLanguageMatcher.Track(languageTag: track.language, label: track.trackName)
+    }
+}

--- a/Lume/Views/Player/VLCPlayerCoordinator.swift
+++ b/Lume/Views/Player/VLCPlayerCoordinator.swift
@@ -77,6 +77,21 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
     /// time a stream is configured or reloaded.
     private var options = VLCPlayerOptions.load()
 
+    /// Snapshot of the viewer's preferred track languages, refreshed each time
+    /// a stream is configured or reloaded — never mid-session, so a change in
+    /// Settings applies the next time playback starts.
+    var languageOptions = PlayerLanguageOptions(preferredAudioLanguages: [])
+
+    /// Holds the preferred-language pass to once per opened stream; it is
+    /// driven from the state change, which fires on every transition. Reset
+    /// wherever the media is rebuilt, which hands libvlc fresh tracks.
+    var didApplyPreferredLanguages = false
+
+    /// A manual audio / subtitle pick outranks the preference for the rest of
+    /// this stream. Kept across a same-URL rebuild (reconnect, Try Again) and
+    /// cleared when the URL changes, so it cannot leak into the next channel.
+    var hasManualTrackSelection = false
+
     private var needsResume = false
     private var didSeekResume = false
     private var resumeLanded = false
@@ -138,6 +153,7 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
         startTime = media.startTime
         needsResume = !media.isLive && media.startTime > 1
         options = VLCPlayerOptions.load()
+        languageOptions = PlayerLanguageOptions.load()
         mediaURL = media.url
         retry.reset()
         hasStartedPlayback = false
@@ -146,9 +162,7 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
         startStartupWatchdog()
         mediaPlayer.delegate = self
 
-        let vlcMedia = VLCMedia(url: media.url)
-        applyMediaOptions(to: vlcMedia, isLive: media.isLive)
-        mediaPlayer.media = vlcMedia
+        installMedia(media.url, isLive: media.isLive)
         let deinterlaceOn = options.deinterlace
         // swiftlint:disable:next line_length
         Logger.player.log("configure: live=\(media.isLive, privacy: .public) startTime=\(media.startTime, format: .fixed(precision: 1), privacy: .public)s deinterlace=\(deinterlaceOn, privacy: .public) url=\(media.url.absoluteString, privacy: .private(mask: .hash))")
@@ -156,6 +170,15 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
         applyDeinterlace()
         isPlaying = true
         startStatsLogging()
+    }
+
+    /// Every rebuild path goes through here: a fresh `VLCMedia` invalidates the
+    /// track list, so the preferred-language latch must reset with it.
+    private func installMedia(_ url: URL, isLive: Bool) {
+        let media = VLCMedia(url: url)
+        applyMediaOptions(to: media, isLive: isLive)
+        mediaPlayer.media = media
+        didApplyPreferredLanguages = false
     }
 
     private func applyMediaOptions(to media: VLCMedia?, isLive: Bool) {
@@ -200,6 +223,8 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
         resumeLanded = false
         videoInfo = nil
         options = VLCPlayerOptions.load()
+        languageOptions = PlayerLanguageOptions.load()
+        if media.url != mediaURL { hasManualTrackSelection = false }
         mediaURL = media.url
         lastKnownTime = 0
         retry.reset()
@@ -208,9 +233,7 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
         PlaybackQoE.shared.beginStartup(engine: .vlcKit, isLive: media.isLive)
         startStartupWatchdog()
 
-        let vlcMedia = VLCMedia(url: media.url)
-        applyMediaOptions(to: vlcMedia, isLive: media.isLive)
-        mediaPlayer.media = vlcMedia
+        installMedia(media.url, isLive: media.isLive)
         let deinterlaceOn = options.deinterlace
         // swiftlint:disable:next line_length
         Logger.player.log("reload: live=\(media.isLive, privacy: .public) startTime=\(media.startTime, format: .fixed(precision: 1), privacy: .public)s deinterlace=\(deinterlaceOn, privacy: .public) url=\(media.url.absoluteString, privacy: .private(mask: .hash))")
@@ -299,9 +322,7 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
         retry.reset()
         startStartupWatchdog()
 
-        let vlcMedia = VLCMedia(url: mediaURL)
-        applyMediaOptions(to: vlcMedia, isLive: isLive)
-        mediaPlayer.media = vlcMedia
+        installMedia(mediaURL, isLive: isLive)
         mediaPlayer.play()
         applyDeinterlace()
         isPlaying = true
@@ -322,9 +343,7 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
             resumeLanded = false
         }
 
-        let vlcMedia = VLCMedia(url: mediaURL)
-        applyMediaOptions(to: vlcMedia, isLive: isLive)
-        mediaPlayer.media = vlcMedia
+        installMedia(mediaURL, isLive: isLive)
         mediaPlayer.play()
         applyDeinterlace()
         isPlaying = true
@@ -437,29 +456,7 @@ final class VLCPlayerCoordinator: NSObject, ObservableObject {
         }
     }
 
-    // MARK: - Tracks
-
-    var audioTracks: [VLCMediaPlayer.Track] {
-        mediaPlayer.audioTracks
-    }
-
-    var textTracks: [VLCMediaPlayer.Track] {
-        mediaPlayer.textTracks
-    }
-
-    func selectAudioTrack(_ track: VLCMediaPlayer.Track) {
-        track.isSelectedExclusively = true
-        objectWillChange.send()
-    }
-
-    func selectTextTrack(_ track: VLCMediaPlayer.Track?) {
-        if let track {
-            track.isSelectedExclusively = true
-        } else {
-            mediaPlayer.deselectAllTextTracks()
-        }
-        objectWillChange.send()
-    }
+    // Track listing and selection live in VLCPlayerCoordinator+Languages.
 }
 
 // MARK: - VLCMediaPlayerDelegate
@@ -478,6 +475,7 @@ extension VLCPlayerCoordinator: VLCMediaPlayerDelegate {
             isPipSupported = pipController != nil
             pipController?.invalidatePlaybackState()
             refreshVideoInfo()
+            applyPreferredLanguagesIfNeeded()
         }
     }
 

--- a/Lume/Views/Settings/OpenSubtitlesIntegrationView.swift
+++ b/Lume/Views/Settings/OpenSubtitlesIntegrationView.swift
@@ -156,7 +156,7 @@ struct OpenSubtitlesSignInSection: View {
 
         private var languageSummary: String {
             service.preferredLanguages
-                .map { Locale.current.localizedString(forIdentifier: $0) ?? $0.uppercased() }
+                .map { TrackLanguageMatcher.displayName(for: $0) }
                 .joined(separator: ", ")
         }
     }

--- a/Lume/Views/Settings/SettingsView+Language.swift
+++ b/Lume/Views/Settings/SettingsView+Language.swift
@@ -1,0 +1,264 @@
+//
+//  SettingsView+Language.swift
+//  Lume
+//
+//  The preferred audio language list (iOS, macOS, visionOS). Split out of
+//  SettingsView, which is already at the file-length limit.
+//
+//  The list ships EMPTY, which means "no preference" and behaves exactly as
+//  Lume did before the setting existed.
+//
+
+import SwiftUI
+
+#if !os(tvOS)
+
+    // MARK: - Settings row
+
+    extension SettingsView {
+        var preferredAudioLanguageRow: some View {
+            NavigationLink {
+                PreferredLanguageListView()
+            } label: {
+                PreferredLanguageRowLabel(codes: PreferredLanguageList.decode(preferredAudioLanguagesRaw))
+            }
+        }
+    }
+
+    // MARK: - Row label
+
+    private struct PreferredLanguageRowLabel: View {
+        let codes: [String]
+
+        var body: some View {
+            HStack {
+                Text("Audio Languages")
+                Spacer()
+                Group {
+                    if codes.isEmpty {
+                        Text("Automatic")
+                    } else {
+                        Text(verbatim: codes.map { TrackLanguageMatcher.displayName(for: $0) }.joined(separator: ", "))
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            }
+        }
+    }
+
+    // MARK: - Ordered list
+
+    /// Drag-to-reorder list of preferred audio languages, most-preferred first.
+    /// Empty is the shipped default and means Lume leaves the stream's own
+    /// track selection alone.
+    struct PreferredLanguageListView: View {
+        @AppStorage(PlayerSettings.Language.preferredAudioLanguagesKey)
+        private var raw = PlayerSettings.Language.preferredAudioLanguagesDefault
+        @State private var isAddingLanguage = false
+
+        private var codes: [String] {
+            PreferredLanguageList.decode(raw)
+        }
+
+        var body: some View {
+            List {
+                Section {
+                    if codes.isEmpty {
+                        Text("No Preferred Languages")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(codes, id: \.self) { code in
+                            let language = PreferredLanguage(code: code)
+                            PreferredLanguageRow(language: language)
+                                .macRemoveButton(named: language.name) { remove(code) }
+                                // macOS never enters edit mode (see
+                                // `alwaysReorderable`), so `onDelete` alone
+                                // leaves its rows unremovable.
+                                .contextMenu {
+                                    Button(role: .destructive) {
+                                        remove(code)
+                                    } label: {
+                                        Label(
+                                            "Remove \(language.name)",
+                                            systemImage: "trash"
+                                        )
+                                    }
+                                }
+                        }
+                        .onMove(perform: move)
+                        .onDelete(perform: delete)
+                    }
+                } footer: {
+                    // swiftlint:disable:next line_length
+                    Text("Lume selects the first of these languages the stream offers as an audio track. Drag to reorder. When the audio that plays is in none of them and the stream carries a forced subtitle track, that track is turned on. Applied the next time playback starts.")
+                }
+            }
+            .platformNavigationTitle("Audio Languages")
+            // The list is held in edit mode so rows are always draggable, and a
+            // row inside an editing List takes no taps — hence the toolbar
+            // button rather than an "Add Language" row.
+            .alwaysReorderable()
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        isAddingLanguage = true
+                    } label: {
+                        Label("Add Language", systemImage: "plus")
+                    }
+                }
+            }
+            .navigationDestination(isPresented: $isAddingLanguage) {
+                AddPreferredLanguageView(selected: codes, onAdd: add)
+            }
+        }
+
+        private func move(from offsets: IndexSet, to destination: Int) {
+            var list = codes
+            list.move(fromOffsets: offsets, toOffset: destination)
+            raw = PreferredLanguageList.encode(list)
+        }
+
+        private func remove(_ code: String) {
+            raw = PreferredLanguageList.encode(codes.filter { $0 != code })
+        }
+
+        private func delete(at offsets: IndexSet) {
+            var list = codes
+            list.remove(atOffsets: offsets)
+            raw = PreferredLanguageList.encode(list)
+        }
+
+        private func add(_ code: String) {
+            raw = PreferredLanguageList.encode(codes + [code])
+        }
+    }
+
+    // MARK: - Add picker
+
+    /// The curated shortlist up front, the viewer's own device languages on top
+    /// of it, and every ISO language behind the search field. Sourced from
+    /// `Locale` alone — see `PreferredLanguageCatalog`.
+    struct AddPreferredLanguageView: View {
+        let selected: [String]
+        let onAdd: (String) -> Void
+
+        @Environment(\.dismiss) private var dismiss
+        @State private var searchText = ""
+
+        private var results: [PreferredLanguage] {
+            PreferredLanguageCatalog.available(PreferredLanguageCatalog.search(searchText), excluding: selected)
+        }
+
+        var body: some View {
+            let matches = results
+            return List {
+                if searchText.isEmpty {
+                    let addable = PreferredLanguageCatalog.addable(excluding: selected)
+                    if !addable.suggested.isEmpty {
+                        Section {
+                            rows(addable.suggested)
+                        } header: {
+                            Text("Suggested")
+                        }
+                    }
+
+                    Section {
+                        rows(addable.common)
+                    } header: {
+                        Text("Common Languages")
+                    } footer: {
+                        Text("Search to find any other language.")
+                    }
+                } else if matches.isEmpty {
+                    Text("No Languages Found")
+                        .foregroundStyle(.secondary)
+                } else {
+                    rows(matches)
+                }
+            }
+            .platformNavigationTitle("Add Language")
+            .searchable(text: $searchText, prompt: "Search languages")
+        }
+
+        private func rows(_ languages: [PreferredLanguage]) -> some View {
+            ForEach(languages) { language in
+                Button {
+                    onAdd(language.code)
+                    dismiss()
+                } label: {
+                    PreferredLanguageRow(language: language)
+                        // `.plain` shrinks a List button's hit area to the text
+                        // itself; without this the gap between name and code
+                        // takes no tap.
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Shared row
+
+    private struct PreferredLanguageRow: View {
+        let language: PreferredLanguage
+
+        var body: some View {
+            HStack {
+                Text(verbatim: language.name)
+                Spacer()
+                Text(verbatim: language.code.uppercased())
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Platform helpers
+
+    private extension View {
+        /// Keeps the list permanently in edit mode so rows are always
+        /// draggable — no Edit button to enter reorder mode first. Written as a
+        /// modifier rather than an inline `#if` in the chain: SwiftFormat
+        /// reindents adjacent `#if` blocks there and has broken the build.
+        ///
+        /// macOS is deliberately absent: it has no `EditMode`, and an AppKit
+        /// `List` makes `onMove` rows draggable on its own, so the footer's
+        /// "Drag to reorder" holds there without this.
+        func alwaysReorderable() -> some View {
+            #if os(iOS) || os(visionOS)
+                environment(\.editMode, .constant(.active))
+            #else
+                self
+            #endif
+        }
+
+        /// macOS gets neither the edit-mode delete badge (`alwaysReorderable`
+        /// excludes it) nor a swipe, so without this the context menu is the
+        /// only way to remove a language and nothing on screen says so.
+        func macRemoveButton(named name: String, remove: @escaping () -> Void) -> some View {
+            #if os(macOS)
+                HStack(spacing: 8) {
+                    self
+                    Button(action: remove) {
+                        Image(systemName: "minus.circle.fill")
+                    }
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("Remove \(name)")
+                }
+            #else
+                self
+            #endif
+        }
+    }
+
+    #Preview {
+        NavigationStack {
+            PreferredLanguageListView()
+        }
+    }
+
+#endif

--- a/Lume/Views/Settings/SettingsView+Player.swift
+++ b/Lume/Views/Settings/SettingsView+Player.swift
@@ -1,0 +1,75 @@
+//
+//  SettingsView+Player.swift
+//  Lume
+//
+//  The iOS / macOS / visionOS Player settings groups: the engine priority and
+//  per-engine options links, the preferred audio language row, and the external
+//  player hand-off. Split out of SettingsView to keep that file within the
+//  project's line-count cap; tvOS builds its own pane in SettingsView+TVPlayer.
+//
+
+#if !os(tvOS)
+
+    import SwiftUI
+
+    extension SettingsView {
+        /// Not `private`: composed by `standardBody` in SettingsView.swift.
+        var playerSection: some View {
+            Section {
+                NavigationLink {
+                    PlayerEnginePriorityView()
+                } label: {
+                    HStack {
+                        Text("Player Engines")
+                        Spacer()
+                        Text(enginePriority.map(\.displayName).joined(separator: " › "))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
+
+                preferredAudioLanguageRow
+
+                NavigationLink("VLCKit Options") { VLCEngineSettingsScreen() }
+                NavigationLink("KSPlayer Options") { KSEngineSettingsScreen() }
+                NavigationLink("Lume Engine Options") { LumeEngineSettingsScreen() }
+            } header: {
+                Text("Player")
+            } footer: {
+                Text("Lume plays each stream with your preferred engine and falls back to the next if it can't be played.")
+            }
+        }
+
+        /// Hand-off to a third-party player. Its own group — this bypasses the
+        /// engines above rather than configuring them — but headerless, so it
+        /// still reads as part of the Player block.
+        var externalPlayerSection: some View {
+            Section {
+                Picker("External Player", selection: $externalPlayerRaw) {
+                    Text("Off").tag("")
+                    ForEach(ExternalPlayer.allCases) { player in
+                        Text(player.displayName).tag(player.rawValue)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                // Only meaningful once a player is selected — some players
+                // (Infuse, for one) handle VOD but not live streams.
+                if ExternalPlayer(rawValue: externalPlayerRaw) != nil {
+                    Picker("Use For", selection: $externalPlayerScopeRaw) {
+                        ForEach(ExternalPlayerScope.allCases) { scope in
+                            Text(scope.displayName).tag(scope.rawValue)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                }
+            } footer: {
+                // swiftlint:disable:next line_length
+                Text("Streams open in the selected external app instead of Lume's player, when it is installed. Some apps — Infuse among them — play movies and series but no live channels, so you can limit the hand-off to one or the other.")
+            }
+        }
+    }
+
+#endif

--- a/Lume/Views/Settings/SettingsView+TVHome.swift
+++ b/Lume/Views/Settings/SettingsView+TVHome.swift
@@ -38,7 +38,11 @@ import SwiftUI
                 return
             }
             var disabled = HomeLayoutSettings.decodeDisabled(homeDisabledSectionsRaw)
-            if disabled.contains(section) { disabled.remove(section) } else { disabled.insert(section) }
+            if disabled.contains(section) {
+                disabled.remove(section)
+            } else {
+                disabled.insert(section)
+            }
             homeDisabledSectionsRaw = HomeLayoutSettings.encodeDisabled(disabled)
         }
 
@@ -46,9 +50,7 @@ import SwiftUI
         /// order. Mirrors `moveEngine` in the player pane.
         private func moveSection(at index: Int, by offset: Int) {
             var list = homeSections
-            let target = index + offset
-            guard list.indices.contains(index), list.indices.contains(target) else { return }
-            list.swapAt(index, target)
+            guard list.move(at: index, by: offset) else { return }
             homeSectionOrderRaw = HomeLayoutSettings.encode(HomeLayoutSettings.normalized(list))
         }
 
@@ -75,53 +77,33 @@ import SwiftUI
         /// `tvEnginePriorityRow`.
         private func tvHomeSectionRow(section: HomeSection, index: Int) -> some View {
             let enabled = isHomeSectionEnabled(section)
-            return HStack(spacing: 16) {
-                Button {
-                    toggleHomeSection(section)
-                } label: {
-                    Image(systemName: enabled ? "checkmark.circle.fill" : "circle")
+            return TVSettingsReorderRow(
+                name: section.displayName,
+                index: index,
+                count: homeSections.count,
+                onMove: { moveSection(at: index, by: $0) },
+                leading: {
+                    Button {
+                        toggleHomeSection(section)
+                    } label: {
+                        Image(systemName: enabled ? "checkmark.circle.fill" : "circle")
+                    }
+                    .buttonStyle(TVContentIconButtonStyle())
+                    .accessibilityLabel(section.displayName)
+                    .accessibilityValue(enabled ? Text("On") : Text("Off"))
+
+                    Label(section.title, systemImage: section.systemImage)
+                        .font(.system(size: TVSettingsMetrics.rowFontSize))
+                        .foregroundStyle(enabled ? .primary : .secondary)
+
+                    // "For You" is a Lume Pro feature; badge it for free users
+                    // (Sideload/owned builds are always premium, so this never shows).
+                    if section == .forYou, !premium.isPremium {
+                        Image(systemName: "crown.fill")
+                            .font(.system(size: 20))
+                            .foregroundStyle(.tint)
+                    }
                 }
-                .buttonStyle(TVContentIconButtonStyle())
-                .accessibilityLabel(section.displayName)
-                .accessibilityValue(enabled ? Text("On") : Text("Off"))
-
-                Label(section.title, systemImage: section.systemImage)
-                    .font(.system(size: TVSettingsMetrics.rowFontSize))
-                    .foregroundStyle(enabled ? .primary : .secondary)
-
-                // "For You" is a Lume Pro feature; badge it for free users
-                // (Sideload/owned builds are always premium, so this never shows).
-                if section == .forYou, !premium.isPremium {
-                    Image(systemName: "crown.fill")
-                        .font(.system(size: 20))
-                        .foregroundStyle(.tint)
-                }
-
-                Spacer(minLength: 0)
-
-                Button {
-                    moveSection(at: index, by: -1)
-                } label: {
-                    Image(systemName: "chevron.up")
-                }
-                .buttonStyle(TVContentIconButtonStyle())
-                .disabled(index == 0)
-                .accessibilityLabel("Move \(section.displayName) up")
-
-                Button {
-                    moveSection(at: index, by: 1)
-                } label: {
-                    Image(systemName: "chevron.down")
-                }
-                .buttonStyle(TVContentIconButtonStyle())
-                .disabled(index == homeSections.count - 1)
-                .accessibilityLabel("Move \(section.displayName) down")
-            }
-            .padding(.horizontal, TVSettingsMetrics.rowHPadding)
-            .padding(.vertical, TVSettingsMetrics.rowVPadding)
-            .background(
-                RoundedRectangle(cornerRadius: TVSettingsMetrics.rowCornerRadius, style: .continuous)
-                    .fill(Color.white.opacity(0.05))
             )
         }
     }

--- a/Lume/Views/Settings/SettingsView+TVPlayer.swift
+++ b/Lume/Views/Settings/SettingsView+TVPlayer.swift
@@ -24,9 +24,7 @@ import SwiftUI
         /// sync with the primary so other readers (and a downgrade) still resolve it.
         private func moveEngine(at index: Int, by offset: Int) {
             var list = enginePriority
-            let target = index + offset
-            guard list.indices.contains(index), list.indices.contains(target) else { return }
-            list.swapAt(index, target)
+            guard list.move(at: index, by: offset) else { return }
             let normalized = PlayerEnginePriority.normalized(list)
             enginePriorityRaw = PlayerEnginePriority.encode(normalized)
             engineRaw = normalized.first?.rawValue ?? PlayerEngineKind.defaultValue.rawValue
@@ -54,6 +52,19 @@ import SwiftUI
                             }
                         }
                         .buttonStyle(TVSettingsRowButtonStyle())
+                    }
+                }
+
+                // Second in the pane, right under Playback: this is a
+                // viewer-facing playback preference (and the one that otherwise
+                // costs a menu trip on every zap), where everything below —
+                // engine order, hand-off, per-engine options — is technical
+                // setup touched once.
+                VStack(alignment: .leading, spacing: 8) {
+                    TVSettingsSectionLabel("Languages")
+
+                    VStack(spacing: 2) {
+                        tvPreferredLanguageRow()
                     }
                 }
 
@@ -138,42 +149,222 @@ import SwiftUI
         /// One row of the tvOS engine-priority list: the engine name, a "Primary"
         /// tag on the top entry, and up / down controls that reorder the list.
         private func tvEnginePriorityRow(kind: PlayerEngineKind, index: Int) -> some View {
-            HStack(spacing: 16) {
-                Text(kind.displayName)
-                    .font(.system(size: TVSettingsMetrics.rowFontSize))
+            TVSettingsReorderRow(
+                name: kind.displayName,
+                index: index,
+                count: enginePriority.count,
+                onMove: { moveEngine(at: index, by: $0) },
+                leading: {
+                    Text(kind.displayName)
+                        .font(.system(size: TVSettingsMetrics.rowFontSize))
 
-                if index == 0 {
-                    Text("Primary")
-                        .font(.system(size: 18, weight: .semibold))
-                        .foregroundStyle(.secondary)
+                    if index == 0 {
+                        Text("Primary")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
                 }
-
-                Spacer(minLength: 0)
-
-                Button {
-                    moveEngine(at: index, by: -1)
-                } label: {
-                    Image(systemName: "chevron.up")
-                }
-                .buttonStyle(TVContentIconButtonStyle())
-                .disabled(index == 0)
-                .accessibilityLabel("Move \(kind.displayName) up")
-
-                Button {
-                    moveEngine(at: index, by: 1)
-                } label: {
-                    Image(systemName: "chevron.down")
-                }
-                .buttonStyle(TVContentIconButtonStyle())
-                .disabled(index == enginePriority.count - 1)
-                .accessibilityLabel("Move \(kind.displayName) down")
-            }
-            .padding(.horizontal, TVSettingsMetrics.rowHPadding)
-            .padding(.vertical, TVSettingsMetrics.rowVPadding)
-            .background(
-                RoundedRectangle(cornerRadius: TVSettingsMetrics.rowCornerRadius, style: .continuous)
-                    .fill(Color.white.opacity(0.05))
             )
+        }
+
+        // MARK: - Preferred languages
+
+        /// The stored list, most-preferred first. Empty is the shipped default
+        /// and means "no preference".
+        private var preferredLanguageCodes: [String] {
+            PreferredLanguageList.decode(preferredAudioLanguagesRaw)
+        }
+
+        /// Deferred: the reorder and remove buttons run inside the focus
+        /// engine's animated context, and rewriting the list rebuilds the
+        /// `ForEach` under it. Mutating on the next turn lets the engine finish
+        /// the move it is already animating and keeps focus on the row.
+        private func setPreferredLanguageCodes(_ codes: [String]) {
+            let encoded = PreferredLanguageList.encode(codes)
+            Task { preferredAudioLanguagesRaw = encoded }
+        }
+
+        private func movePreferredLanguage(at index: Int, by offset: Int) {
+            var list = preferredLanguageCodes
+            guard list.move(at: index, by: offset) else { return }
+            setPreferredLanguageCodes(list)
+        }
+
+        private func removePreferredLanguage(at index: Int) {
+            var list = preferredLanguageCodes
+            guard list.indices.contains(index) else { return }
+            list.remove(at: index)
+            setPreferredLanguageCodes(list)
+        }
+
+        /// A drill-in row that replaces the player detail with the language
+        /// list in place, mirroring `tvEngineOptionsRow`.
+        private func tvPreferredLanguageRow() -> some View {
+            Button {
+                preferredLanguagePane = .list
+            } label: {
+                HStack(spacing: 16) {
+                    Text("Audio Languages")
+                    Spacer(minLength: 16)
+                    tvPreferredLanguageValue
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .buttonStyle(TVSettingsRowButtonStyle())
+        }
+
+        /// The row's trailing summary. `.opacity` rather than `.secondary`: the
+        /// focused row's label turns black, which a secondary style washes out.
+        @ViewBuilder
+        private var tvPreferredLanguageValue: some View {
+            let codes = preferredLanguageCodes
+            Group {
+                if codes.isEmpty {
+                    Text("Automatic")
+                } else {
+                    Text(verbatim: codes.map { TrackLanguageMatcher.displayName(for: $0) }.joined(separator: ", "))
+                }
+            }
+            .font(.system(size: TVSettingsMetrics.secondaryFontSize))
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .opacity(0.6)
+        }
+
+        /// The drilled-in pane for the language list: the ordered list itself,
+        /// or the add picker one level deeper.
+        @ViewBuilder
+        func tvPreferredLanguageDetail(_ pane: PreferredLanguagePane) -> some View {
+            switch pane {
+            case .list: tvPreferredLanguageOrderDetail()
+            case .add: tvAddPreferredLanguageDetail()
+            }
+        }
+
+        private func tvPreferredLanguageOrderDetail() -> some View {
+            let codes = preferredLanguageCodes
+            return VStack(alignment: .leading, spacing: 28) {
+                Text("Audio Languages")
+                    .font(.system(size: 34, weight: .bold))
+                    .padding(.horizontal, TVSettingsMetrics.rowHPadding)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    TVSettingsSectionLabel("Preferred Order")
+
+                    if codes.isEmpty {
+                        Text("No Preferred Languages")
+                            .tvSettingsSecondaryText()
+                    } else {
+                        VStack(spacing: 2) {
+                            ForEach(Array(codes.enumerated()), id: \.element) { index, code in
+                                tvPreferredLanguageOrderRow(code: code, index: index, count: codes.count)
+                            }
+                        }
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Button {
+                        preferredLanguagePane = .add
+                    } label: {
+                        HStack(spacing: 16) {
+                            Text("Add Language")
+                            Spacer(minLength: 0)
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 20, weight: .semibold))
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                    .buttonStyle(TVSettingsRowButtonStyle())
+
+                    Text(tvPreferredLanguageFooter)
+                        .font(.system(size: 20))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, TVSettingsMetrics.rowHPadding)
+                        .padding(.top, 6)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        private var tvPreferredLanguageFooter: LocalizedStringKey {
+            // swiftlint:disable:next line_length
+            "Lume selects the first of these languages the stream offers as an audio track, most preferred at the top. When the audio that plays is in none of them and the stream carries a forced subtitle track, that track is turned on. Applied the next time playback starts."
+        }
+
+        /// One row of the ordered list: the language's name, reorder controls
+        /// and a remove button.
+        private func tvPreferredLanguageOrderRow(
+            code: String,
+            index: Int,
+            count: Int
+        ) -> some View {
+            let name = TrackLanguageMatcher.displayName(for: code)
+            return TVSettingsReorderRow(
+                name: name,
+                index: index,
+                count: count,
+                onMove: { movePreferredLanguage(at: index, by: $0) },
+                onRemove: { removePreferredLanguage(at: index) },
+                leading: {
+                    Text(verbatim: name)
+                        .font(.system(size: TVSettingsMetrics.rowFontSize))
+                }
+            )
+        }
+
+        /// The add picker: the device's own languages first, then the curated
+        /// shortlist. Deliberately not the full ISO list — several hundred
+        /// focusable rows is a scroll and VoiceOver hazard on tvOS, and this
+        /// pane has no search field.
+        private func tvAddPreferredLanguageDetail() -> some View {
+            let addable = PreferredLanguageCatalog.addable(excluding: preferredLanguageCodes)
+
+            return VStack(alignment: .leading, spacing: 28) {
+                Text("Add Language")
+                    .font(.system(size: 34, weight: .bold))
+                    .padding(.horizontal, TVSettingsMetrics.rowHPadding)
+
+                if !addable.suggested.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        TVSettingsSectionLabel("Suggested")
+                        VStack(spacing: 2) {
+                            ForEach(addable.suggested) { tvAddPreferredLanguageRow($0) }
+                        }
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    TVSettingsSectionLabel("Common Languages")
+                    if addable.common.isEmpty {
+                        Text("No Languages Found")
+                            .tvSettingsSecondaryText()
+                    } else {
+                        VStack(spacing: 2) {
+                            ForEach(addable.common) { tvAddPreferredLanguageRow($0) }
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        private func tvAddPreferredLanguageRow(_ language: PreferredLanguage) -> some View {
+            Button {
+                setPreferredLanguageCodes(preferredLanguageCodes + [language.code])
+                preferredLanguagePane = .list
+            } label: {
+                HStack(spacing: 16) {
+                    Text(verbatim: language.name)
+                    Spacer(minLength: 16)
+                    Text(verbatim: language.code.uppercased())
+                        .font(.system(size: TVSettingsMetrics.secondaryFontSize).monospaced())
+                        .opacity(0.6)
+                }
+            }
+            .buttonStyle(TVSettingsRowButtonStyle())
         }
     }
 

--- a/Lume/Views/Settings/SettingsView.swift
+++ b/Lume/Views/Settings/SettingsView.swift
@@ -38,6 +38,8 @@ struct SettingsView: View {
     var showNextEpisodeButton = PlayerSettings.Playback.showNextEpisodeButtonDefault
     @AppStorage(PlayerSettings.Playback.showSkipIntroButtonKey)
     var showSkipIntroButton = PlayerSettings.Playback.showSkipIntroButtonDefault
+    /// Comma-separated preferred languages, empty meaning no preference (see `PreferredLanguageList`). Not `private`: read by the SettingsView+Language extension (separate file).
+    @AppStorage(PlayerSettings.Language.preferredAudioLanguagesKey) var preferredAudioLanguagesRaw = PlayerSettings.Language.preferredAudioLanguagesDefault
     @AppStorage(SearchSettings.searchAllPlaylistsKey)
     private var searchAllPlaylists = SearchSettings.searchAllPlaylistsDefault
     #if !os(tvOS)
@@ -79,6 +81,17 @@ struct SettingsView: View {
         /// replacing the player detail in place (same reasoning as `selectedPlaylist`).
         /// Not `private`: read by the SettingsView+TVPlayer extension (separate file).
         @State var selectedEngineOptions: PlayerEngineKind?
+        /// Which preferred-language pane is drilled into within the Player
+        /// category — the ordered list, or its add picker one level deeper —
+        /// replacing the player detail in place (same reasoning as
+        /// `selectedEngineOptions`). Not `private`: read by the
+        /// SettingsView+TVPlayer extension (separate file).
+        @State var preferredLanguagePane: PreferredLanguagePane?
+
+        enum PreferredLanguagePane {
+            case list, add
+        }
+
         /// Home layout preferences, shown in the Home category. Not `private`: read
         /// by the SettingsView+TVHome extension (separate file). The iOS/macOS build
         /// has its own `HomeLayoutSettingsView`, so these live in the tvOS block.
@@ -353,61 +366,6 @@ struct SettingsView: View {
             }
         }
 
-        private var playerSection: some View {
-            Section {
-                NavigationLink {
-                    PlayerEnginePriorityView()
-                } label: {
-                    HStack {
-                        Text("Player Engines")
-                        Spacer()
-                        Text(enginePriority.map(\.displayName).joined(separator: " › "))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    }
-                }
-
-                NavigationLink("VLCKit Options") { VLCEngineSettingsScreen() }
-                NavigationLink("KSPlayer Options") { KSEngineSettingsScreen() }
-                NavigationLink("Lume Engine Options") { LumeEngineSettingsScreen() }
-            } header: {
-                Text("Player")
-            } footer: {
-                Text("Lume plays each stream with your preferred engine and falls back to the next if it can't be played.")
-            }
-        }
-
-        /// Hand-off to a third-party player. Its own group — this bypasses the
-        /// engines above rather than configuring them — but headerless, so it
-        /// still reads as part of the Player block.
-        private var externalPlayerSection: some View {
-            Section {
-                Picker("External Player", selection: $externalPlayerRaw) {
-                    Text("Off").tag("")
-                    ForEach(ExternalPlayer.allCases) { player in
-                        Text(player.displayName).tag(player.rawValue)
-                    }
-                }
-                .pickerStyle(.menu)
-
-                // Only meaningful once a player is selected — some players
-                // (Infuse, for one) handle VOD but not live streams.
-                if ExternalPlayer(rawValue: externalPlayerRaw) != nil {
-                    Picker("Use For", selection: $externalPlayerScopeRaw) {
-                        ForEach(ExternalPlayerScope.allCases) { scope in
-                            Text(scope.displayName).tag(scope.rawValue)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                }
-            } footer: {
-                // swiftlint:disable:next line_length
-                Text("Streams open in the selected external app instead of Lume's player, when it is installed. Some apps — Infuse among them — play movies and series but no live channels, so you can limit the hand-off to one or the other.")
-            }
-        }
-
         private var storageSection: some View {
             Section {
                 NavigationLink {
@@ -469,6 +427,7 @@ struct SettingsView: View {
                         // pane reverts to its top-level list.
                         selectedPlaylist = nil
                         selectedEngineOptions = nil
+                        preferredLanguagePane = nil
                     }
                 }
                 .fullScreenCover(isPresented: $showingAddPlaylist) {
@@ -550,6 +509,8 @@ struct SettingsView: View {
                     case .player:
                         if let selectedEngineOptions {
                             tvEngineOptionsDetail(for: selectedEngineOptions)
+                        } else if let preferredLanguagePane {
+                            tvPreferredLanguageDetail(preferredLanguagePane)
                         } else {
                             tvPlayerDetail
                         }

--- a/Lume/Views/Settings/TVSettingsComponents.swift
+++ b/Lume/Views/Settings/TVSettingsComponents.swift
@@ -144,6 +144,93 @@
         }
     }
 
+    // MARK: - Reorderable row
+
+    /// One row of a reorderable tvOS settings list: caller-supplied leading
+    /// content, then up / down controls and an optional remove button. The row
+    /// is a full-width focus band — a narrow target wouldn't catch "down" from
+    /// the row above.
+    ///
+    /// `onMove` receives the offset (-1 / +1); `name` is only used for the
+    /// controls' VoiceOver labels.
+    struct TVSettingsReorderRow<Leading: View>: View {
+        private let name: String
+        private let index: Int
+        private let count: Int
+        private let onMove: (Int) -> Void
+        private let onRemove: (() -> Void)?
+        private let leading: Leading
+
+        init(
+            name: String,
+            index: Int,
+            count: Int,
+            onMove: @escaping (Int) -> Void,
+            onRemove: (() -> Void)? = nil,
+            @ViewBuilder leading: () -> Leading
+        ) {
+            self.name = name
+            self.index = index
+            self.count = count
+            self.onMove = onMove
+            self.onRemove = onRemove
+            self.leading = leading()
+        }
+
+        var body: some View {
+            HStack(spacing: 16) {
+                leading
+
+                Spacer(minLength: 0)
+
+                Button {
+                    onMove(-1)
+                } label: {
+                    Image(systemName: "chevron.up")
+                }
+                .buttonStyle(TVContentIconButtonStyle())
+                .disabled(index == 0)
+                .accessibilityLabel("Move \(name) up")
+
+                Button {
+                    onMove(1)
+                } label: {
+                    Image(systemName: "chevron.down")
+                }
+                .buttonStyle(TVContentIconButtonStyle())
+                .disabled(index == count - 1)
+                .accessibilityLabel("Move \(name) down")
+
+                if let onRemove {
+                    Button(action: onRemove) {
+                        Image(systemName: "minus")
+                    }
+                    .buttonStyle(TVContentIconButtonStyle())
+                    .accessibilityLabel("Remove \(name)")
+                }
+            }
+            .padding(.horizontal, TVSettingsMetrics.rowHPadding)
+            .padding(.vertical, TVSettingsMetrics.rowVPadding)
+            .background(
+                RoundedRectangle(cornerRadius: TVSettingsMetrics.rowCornerRadius, style: .continuous)
+                    .fill(Color.white.opacity(0.05))
+            )
+        }
+    }
+
+    // MARK: - Reordering
+
+    extension Array {
+        /// Swaps the element at `index` with the one `offset` slots away,
+        /// reporting whether the move was in bounds.
+        mutating func move(at index: Int, by offset: Int) -> Bool {
+            let target = index + offset
+            guard indices.contains(index), indices.contains(target) else { return false }
+            swapAt(index, target)
+            return true
+        }
+    }
+
     // MARK: - Button styles
 
     /// A minimal sidebar category row: transparent by default, a faint fill when

--- a/LumeTests/Services/PlayerSettingsTests.swift
+++ b/LumeTests/Services/PlayerSettingsTests.swift
@@ -128,3 +128,149 @@ struct PlayerEnginePriorityTests {
         #expect(resolved == [.ksPlayer, .vlcKit, .avPlayer, .lumeEngine])
     }
 }
+
+// MARK: - Preferred track languages
+
+struct PreferredLanguageStorageTests {
+    /// Both lists are device-local `UserDefaults`, so every case runs against
+    /// its own suite — `UserDefaults.standard` is shared with the rest of the
+    /// suite and races itself.
+    private func withSuite(_ body: (UserDefaults) throws -> Void) rethrows {
+        let name = "PreferredLanguageStorageTests-\(UUID().uuidString)"
+        defer { UserDefaults.standard.removePersistentDomain(forName: name) }
+        guard let defaults = UserDefaults(suiteName: name) else { return }
+        try body(defaults)
+    }
+
+    @Test func `storage key`() {
+        #expect(PlayerSettings.Language.preferredAudioLanguagesKey == "player.preferredAudioLanguages")
+    }
+
+    @Test func `the list ships empty`() {
+        // The shipped default is "no preference at all": every engine then
+        // leaves track selection exactly as the container asks for it.
+        #expect(PlayerSettings.Language.preferredAudioLanguagesDefault == "")
+    }
+
+    @Test func `load yields an empty array for an untouched key`() {
+        withSuite { defaults in
+            let options = PlayerLanguageOptions.load(from: defaults)
+            #expect(options.preferredAudioLanguages.isEmpty)
+        }
+    }
+
+    @Test func `load reads the stored list in order`() {
+        withSuite { defaults in
+            defaults.set("de,en", forKey: PlayerSettings.Language.preferredAudioLanguagesKey)
+            let options = PlayerLanguageOptions.load(from: defaults)
+            #expect(options.preferredAudioLanguages == ["de", "en"])
+        }
+    }
+
+    @Test func `an empty stored string still means no preference`() {
+        withSuite { defaults in
+            defaults.set("", forKey: PlayerSettings.Language.preferredAudioLanguagesKey)
+            #expect(PlayerLanguageOptions.load(from: defaults).preferredAudioLanguages.isEmpty)
+        }
+    }
+}
+
+struct PreferredLanguageListTests {
+    @Test func `encode and decode round-trip`() {
+        let list = ["de", "en", "ja"]
+        #expect(PreferredLanguageList.encode(list) == "de,en,ja")
+        #expect(PreferredLanguageList.decode("de,en,ja") == list)
+    }
+
+    @Test func `an empty list encodes and decodes to nothing`() {
+        #expect(PreferredLanguageList.encode([]) == "")
+        #expect(PreferredLanguageList.decode("") == [])
+    }
+
+    @Test func `decode trims whitespace around each token`() {
+        #expect(PreferredLanguageList.decode(" de , en ,\tja ") == ["de", "en", "ja"])
+    }
+
+    @Test func `decode drops empty tokens`() {
+        #expect(PreferredLanguageList.decode(",de,,en,") == ["de", "en"])
+        #expect(PreferredLanguageList.decode("  ,  ") == [])
+    }
+
+    @Test func `normalized dedupes case-insensitively, keeping the first spelling`() {
+        #expect(PreferredLanguageList.normalized(["de", "DE", "De"]) == ["de"])
+        #expect(PreferredLanguageList.normalized(["EN", "de", "en"]) == ["EN", "de"])
+    }
+
+    @Test func `normalized preserves the given order`() {
+        #expect(PreferredLanguageList.normalized(["ja", "de", "en"]) == ["ja", "de", "en"])
+    }
+
+    @Test func `encode normalizes what it stores`() {
+        #expect(PreferredLanguageList.encode([" de ", "DE", "", "en"]) == "de,en")
+    }
+}
+
+/// The feature's user-facing literals. `String(localized:)` can't prove a key
+/// is in the catalog — an English key resolves to itself either way — so the
+/// catalog is read directly.
+struct PreferredLanguageStringsTests {
+    private static let expectedLanguages: Set<String> = ["de", "es", "fr", "it", "ja", "ko", "pt", "zh-Hans"]
+
+    /// Keys the preferred-language feature added.
+    private static let addedKeys = [
+        "Audio Languages",
+        "Preferred Order",
+        "No Preferred Languages",
+        "Add Language",
+        "Common Languages",
+        "Suggested",
+        "No Languages Found",
+        "Search to find any other language.",
+        "Remove %@",
+        "Audio Track",
+        "Lume selects the first of these languages the stream offers as an audio track. Drag to reorder. "
+            + "When the audio that plays is in none of them and the stream carries a forced subtitle track, "
+            + "that track is turned on. Applied the next time playback starts.",
+        "Lume selects the first of these languages the stream offers as an audio track, most preferred at the top. "
+            + "When the audio that plays is in none of them and the stream carries a forced subtitle track, "
+            + "that track is turned on. Applied the next time playback starts."
+    ]
+
+    /// Keys the feature reuses deliberately rather than adding near-duplicates.
+    private static let reusedKeys = [
+        "Languages",
+        "Search languages",
+        "Automatic",
+        "Default",
+        "Subtitles",
+        "Off",
+        "Any",
+        "Move %@ up",
+        "Move %@ down"
+    ]
+
+    private static var allKeys: [String] {
+        addedKeys + reusedKeys
+    }
+
+    @Test func `literals resolve to a non empty string`() {
+        for key in Self.allKeys {
+            let resolved = String(localized: String.LocalizationValue(key))
+            #expect(!resolved.isEmpty, "\(key) resolved to an empty string")
+        }
+    }
+
+    @Test func `literals are translated in every locale`() throws {
+        let catalog = try StringCatalog.localizable()
+        for key in Self.allKeys {
+            let localizations = try #require(catalog.localizations(for: key), "\(key) is not in the catalog")
+            #expect(
+                Self.expectedLanguages.isSubset(of: Set(localizations.keys)),
+                "\(key) is missing locales: \(Self.expectedLanguages.subtracting(localizations.keys).sorted())"
+            )
+            for (language, value) in localizations {
+                #expect(!value.isEmpty, "\(key) is untranslated in \(language)")
+            }
+        }
+    }
+}

--- a/LumeTests/Services/TrackLanguageMatcherTests.swift
+++ b/LumeTests/Services/TrackLanguageMatcherTests.swift
@@ -1,0 +1,181 @@
+//
+//  TrackLanguageMatcherTests.swift
+//  LumeTests
+//
+//  Covers the engine-independent track language matcher: what a container tag
+//  or a free-text track name normalizes to, and which track an ordered
+//  preference list picks. The critical invariant is that "no match" stays
+//  `nil` — an unmatched stream must keep the container's own selection, never
+//  fall back to the first track.
+//
+
+import Foundation
+@testable import Lume
+import Testing
+
+struct TrackLanguageMatcherTests {
+    private typealias Track = TrackLanguageMatcher.Track
+
+    // MARK: - Normalization
+
+    @Test(
+        arguments: [
+            ("ger", "de"), ("fre", "fr"), ("chi", "zh"), ("cze", "cs"), ("dut", "nl"),
+            ("gre", "el"), ("ice", "is"), ("mac", "mk"), ("may", "ms"), ("per", "fa"),
+            ("rum", "ro"), ("slo", "sk"), ("tib", "bo"), ("wel", "cy"), ("arm", "hy"),
+            ("baq", "eu"), ("bur", "my"), ("geo", "ka"), ("alb", "sq")
+        ]
+    )
+    func `bibliographic ISO 639-2/B tags normalize`(raw: String, expected: String) {
+        #expect(TrackLanguageMatcher.normalize(raw) == expected)
+    }
+
+    @Test(
+        arguments: [("deu", "de"), ("fra", "fr"), ("eng", "en"), ("spa", "es"), ("jpn", "ja"), ("nld", "nl")]
+    )
+    func `terminological ISO 639-2/T tags normalize`(raw: String, expected: String) {
+        #expect(TrackLanguageMatcher.normalize(raw) == expected)
+    }
+
+    @Test
+    func `a three-letter code with no two-letter form stays itself`() {
+        #expect(TrackLanguageMatcher.normalize("fil") == "fil")
+    }
+
+    @Test(
+        arguments: [("de-DE", "de"), ("de_DE", "de"), ("de-AT", "de"), ("pt-BR", "pt"), ("zh-Hans", "zh"), ("EN-gb", "en")]
+    )
+    func `region and script subtags are dropped`(raw: String, expected: String) {
+        #expect(TrackLanguageMatcher.normalize(raw) == expected)
+    }
+
+    @Test(
+        arguments: [
+            ("Deutsch", "de"), ("German", "de"), ("français", "fr"), ("español", "es"),
+            ("日本語", "ja"), ("GER 5.1", "de"), ("Audio 1 - English", "en"),
+            ("English AD", "en"), ("Italiano (Commentary)", "it")
+        ]
+    )
+    func `free-text track names normalize`(raw: String, expected: String) {
+        #expect(TrackLanguageMatcher.normalize(raw) == expected)
+    }
+
+    @Test(
+        arguments: ["und", "mul", "mis", "zxx", "VO", "VOST", "Multi", "Original", "unknown", "", "   ", "xx", "Track 1", "5.1"]
+    )
+    func `placeholders and junk name no language`(raw: String) {
+        #expect(TrackLanguageMatcher.normalize(raw) == nil)
+    }
+
+    // MARK: - Best match
+
+    @Test
+    func `an empty preference list changes nothing`() {
+        let tracks = [Track(languageTag: "eng"), Track(languageTag: "ger")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: []) == nil)
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["   ", ""]) == nil)
+    }
+
+    @Test
+    func `no match returns nil rather than the first track`() {
+        let tracks = [Track(languageTag: "eng"), Track(languageTag: "fre"), Track(languageTag: "und", label: "Multi")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["ja"]) == nil)
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: [], preferring: ["de"]) == nil)
+    }
+
+    @Test
+    func `earlier preference entries beat later ones`() {
+        let tracks = [Track(languageTag: "eng"), Track(languageTag: "ger"), Track(languageTag: "ita")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["de", "en"]) == 1)
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["en", "de"]) == 0)
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["it", "de", "en"]) == 2)
+    }
+
+    @Test
+    func `an exact bare code beats a regional variant of the same language`() {
+        let variantFirst = [Track(languageTag: "de-AT"), Track(languageTag: "de")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: variantFirst, preferring: ["de"]) == 1)
+
+        let variantOnly = [Track(languageTag: "eng"), Track(languageTag: "pt-BR")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: variantOnly, preferring: ["pt"]) == 1)
+    }
+
+    @Test
+    func `within one language the first container track wins`() {
+        let tracks = [Track(languageTag: "ger", label: "Deutsch Stereo"), Track(languageTag: "ger", label: "Deutsch 5.1")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["de"]) == 0)
+    }
+
+    @Test
+    func `a container tag beats the same language found in free text`() {
+        let tracks = [Track(languageTag: "und", label: "Deutsch"), Track(languageTag: "ger")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["de"]) == 1)
+    }
+
+    @Test
+    func `commentary and audio-description tracks are de-prioritised`() {
+        let commentary = [Track(languageTag: "eng", label: "English Commentary"), Track(languageTag: "eng", label: "English")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: commentary, preferring: ["en"]) == 1)
+
+        let described = [Track(languageTag: "eng", label: "English AD"), Track(languageTag: "eng", label: "English")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: described, preferring: ["en"]) == 1)
+
+        let german = [Track(languageTag: "ger", label: "Deutsch (Kommentar)"), Track(languageTag: "ger", label: "Deutsch")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: german, preferring: ["de"]) == 1)
+    }
+
+    @Test
+    func `a commentary track still wins when it is the only match`() {
+        let tracks = [Track(languageTag: "eng"), Track(languageTag: "ger", label: "Deutsch Audiokommentar")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["de"]) == 1)
+    }
+
+    @Test
+    func `the preference beats the container's default track`() {
+        // The default disposition is deliberately not an input: track 0 is what
+        // the container would have played, and the preference overrules it.
+        let tracks = [Track(languageTag: "eng", label: "English (Default)"), Track(languageTag: "ger")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["de"]) == 1)
+    }
+
+    @Test
+    func `free-text-only tracks still match`() {
+        let tracks = [Track(label: "Audio 1 - English"), Track(label: "Audio 2 - Deutsch 5.1")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["de"]) == 1)
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["en"]) == 0)
+    }
+
+    @Test
+    func `preferences given as names or bibliographic codes work too`() {
+        let tracks = [Track(languageTag: "eng"), Track(languageTag: "ger")]
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["ger"]) == 1)
+        #expect(TrackLanguageMatcher.bestMatchIndex(in: tracks, preferring: ["German"]) == 1)
+    }
+
+    // MARK: - Foreign audio
+
+    @Test
+    func `nothing is foreign without a preference`() {
+        #expect(TrackLanguageMatcher.isForeign(Track(languageTag: "eng"), comparedTo: []) == false)
+    }
+
+    @Test
+    func `foreign audio is audio in no preferred language`() {
+        #expect(TrackLanguageMatcher.isForeign(Track(languageTag: "eng"), comparedTo: ["de"]))
+        #expect(TrackLanguageMatcher.isForeign(Track(languageTag: "de-AT"), comparedTo: ["de"]) == false)
+        #expect(TrackLanguageMatcher.isForeign(Track(label: "Deutsch"), comparedTo: ["de"]) == false)
+    }
+
+    @Test
+    func `an unknown language is not foreign`() {
+        #expect(TrackLanguageMatcher.isForeign(Track(languageTag: "und", label: "Track 1"), comparedTo: ["de"]) == false)
+    }
+
+    // MARK: - Display names
+
+    @Test
+    func `display names resolve, and fall back to the raw code`() {
+        #expect(TrackLanguageMatcher.displayName(for: "de") != "DE")
+        #expect(TrackLanguageMatcher.displayName(for: "qqq") == "QQQ")
+    }
+}


### PR DESCRIPTION
## Summary

Multi-audio streams started on whatever track the container listed first, so anyone whose provider ships English-first mixes had to re-open the overlay and re-pick their language on every title, episode and channel zap — worst on live TV, where the cost is per-zap.

Settings → Player now carries an ordered preferred-audio-language list. Playback picks the first of those languages the stream offers; when nothing matches it leaves the container's own choice untouched rather than settling for track 0. The list **ships empty**, so behaviour is unchanged until the viewer opts in.

## Implementation

Applied at the cheapest point each engine offers, which mattered more than the matching itself:

| Engine | Where |
|---|---|
| KSPlayer | `LumeKSOptions` overrides `wantedAudio(tracks:)` — chosen *while opening* |
| LumeEngine | `PlayerConfiguration.preferredAudioLanguages`, resolved before `demuxer.resume()` |
| AVPlayer | inside the `loadTracks` continuation, guarded by item identity |
| VLCKit | from `mediaPlayerStateChanged`, latching only once audio tracks exist |

Selecting *after* open was rejected deliberately: on LumeEngine it calls `seek(to: position)` where `position` is 0 until the first frame, silently wiping a `startPosition` VOD resume, and `MediaInfo.isSeekable` is true for many live IPTV endpoints that providers then drop. On KSPlayer, `prepareToPlay()` on a running session is a documented UAF, so `select(track:)` stays for manual picks only.

`TrackLanguageMatcher` carries a hand-written ISO 639-2/B alias table because Foundation returns nil for the bibliographic codes IPTV actually ships — `Locale.LanguageCode("ger").identifier(.alpha2)` is nil while `"deu"` resolves. It matches free-text titles per token (never substring), de-prioritises commentary and audio-description tracks, and prefers an exact code over a regional variant (`de` accepts `de-AT`).

A manual pick wins for the rest of that stream and re-asserts on the next one, surviving the rebuilds that reconnect and stall recovery perform without leaking into the next channel.

Forced subtitles turn themselves on when the audio that plays is foreign to the preference — the one case where subtitles appear unasked. **AVPlayer and LumeEngine only**; KSPlayer and VLCKit report no forced disposition.

**Deliberately not included:** a preferred *subtitle* language list. It was built, then cut — `KSOptions` exposes no wanted-subtitle hook, so it was a no-op on the default engine, and on VLCKit it required an already-selected text track that VLC essentially never has. Shipping a setting that does nothing for most users was worse than not shipping it. Unrelated to the existing OpenSubtitles "Subtitle Languages" search-scope setting, which is untouched.

Incidental cleanups the change made unavoidable: three near-duplicate language display-name chains, five copies of `trackAccessibilityValue` and four of `checkmarkLabel` folded into shared helpers; the VoiceOver labels those track menus never had; and `"Off"` no longer shipping untranslated through the verbatim `Text(String)` initializer.

## Testing

- [x] Acceptance criteria met
- [x] Builds clean — iOS, tvOS, macOS
- [x] Tests pass — 1018/1018 `LumeTests`, iPhone 17 Pro / iOS 26.4
- [x] SwiftLint clean — `--strict` silent; pinned SwiftFormat 0.61.1 reports 0/29
- [x] Tests added — `TrackLanguageMatcherTests` (21 tests / 54 parameterized cases) plus storage-key and string-catalog coverage
- [ ] UI verified on simulator — **not done**, see below

> `LumeTests` needs `-parallel-testing-enabled NO`; with parallel sim cloning 281 tests phantom-fail at 0.000s.

## Platforms

- [x] iOS / iPadOS — builds clean
- [x] tvOS — builds clean
- [x] macOS — builds clean
- [ ] visionOS — **unverified**: the platform is not installed on this machine. Source-compatible (shares the `#if !os(tvOS)` Settings body) but never compiled.

## Reviewer notes

Three things worth a second pair of eyes:

1. **No simulator verification.** Green builds are not evidence the Settings UI works. The tvOS reorder pane deserves a manual pass in particular — it has no automated coverage, and `LumeUITests` never targets tvOS.
2. **Paired engine commit.** Requires bilipp/LumeEngine@`feature/200-preferred-audio-language`; `../LumeEngine` is a local SPM package, so this branch will not build against an older sibling checkout. Sideload CI needs an `ENGINE_REF` bump once the engine is tagged.
3. **One out-of-scope line.** `.gitignore`'s `ExampleData/` → `ExampleData`: the trailing slash did not match the symlink every git worktree needs, so `git add -A` would have committed an absolute-path symlink into the repo.

## Related

Closes #200