### PR TITLE
chore(ci): pin sideload builds to LumeEngine v0.1.6

### DIFF
--- a/.github/workflows/sideload-release.yml
+++ b/.github/workflows/sideload-release.yml
@@ -35,7 +35,7 @@ env:
   # Pinned rather than tracking the engine's main: app↔engine commits are paired
   # by hand, so a drifting engine would break this archive with no change on
   # Lume's side. Bump this when a release needs newer engine code.
-  ENGINE_REF: ${{ github.event.inputs.engine_ref || 'v0.1.5' }}
+  ENGINE_REF: ${{ github.event.inputs.engine_ref || 'v0.1.6' }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Unbreaks sideload CI after #211.

`main` now calls `PlayerConfiguration.preferredAudioLanguages`, which landed in LumeEngine via bilipp/LumeEngine#32. `ENGINE_REF` still defaulted to `v0.1.5`, which predates that commit — verified: `git grep preferredAudioLanguages v0.1.5` returns nothing. A sideload release run would have checked out an engine that cannot compile the app.

Bumps the default to `v0.1.6`, tagged at the engine's merge commit and verified to carry the API. The `engine_ref` workflow input still overrides it.

## Why this wasn't caught

Every build in #211 resolved `../LumeEngine` from the local sibling checkout, which already had the change. Nothing in the PR matrix exercises the pinned tag.

## Testing

- [x] `v0.1.6` exists on the engine remote and contains `preferredAudioLanguages`
- [ ] Not run — `sideload-release.yml` is `workflow_dispatch`-only; the next manual run is the real check