### PR TITLE
feat(live-tv): support catch-up on M3U playlists

### DIFF
--- a/Lume/Models/LiveStream.swift
+++ b/Lume/Models/LiveStream.swift
@@ -32,6 +32,15 @@ final class LiveStream {
     var customSid: String?
     var tvArchive: Int
     var tvArchiveDuration: Int
+    /// The catch-up dialect an m3u playlist declared for this channel
+    /// (`catchup="…"`), folded to its canonical spelling by the importer, which
+    /// writes it only for a dialect it can build a URL for. Optional and outside
+    /// `#Index` on purpose: the app ships without a `SchemaMigrationPlan`, so
+    /// every new column has to stay lightweight-migratable.
+    var catchupTypeRaw: String?
+    /// The verbatim `catchup-source` template. Expanded at play time, never at
+    /// import time — expanding on import would bake in a stale `now`.
+    var catchupSource: String?
     var isAdult: Int
     var num: Int
 
@@ -71,7 +80,9 @@ final class LiveStream {
         tvArchiveDuration: Int = 0,
         isAdult: Int = 0,
         num: Int = 0,
-        categoryId: String? = nil
+        categoryId: String? = nil,
+        catchupTypeRaw: String? = nil,
+        catchupSource: String? = nil
     ) {
         self.id = id
         self.streamId = streamId
@@ -85,5 +96,57 @@ final class LiveStream {
         self.isAdult = isAdult
         self.num = num
         self.categoryId = categoryId
+        self.catchupTypeRaw = catchupTypeRaw
+        self.catchupSource = catchupSource
     }
+}
+
+extension LiveStream {
+    /// The catch-up dialect declared for this channel, or `nil` when the
+    /// playlist declared none or one we cannot build a URL for.
+    var catchupType: CatchupType? {
+        get { CatchupType.parse(catchupTypeRaw) }
+        set { catchupTypeRaw = newValue?.rawValue }
+    }
+}
+
+/// The catch-up (archive) dialects an m3u playlist can declare through
+/// `catchup="…"`. Raw values are the canonical spellings; `parse` folds in the
+/// aliases seen in the wild.
+nonisolated enum CatchupType: String {
+    case `default`
+    case append
+    case flussonic
+    // swiftlint:disable:next identifier_name - `xc` is the spelling playlists ship.
+    case xc
+    case shift
+}
+
+nonisolated extension CatchupType {
+    /// Tolerant of the spellings playlists actually ship: `fs`, `flussonic-hls`,
+    /// `xtream`, and the bare enable-flags `1`/`true` used by `tvg-rec`. The
+    /// hls-flavoured Flussonic spellings fold into `flussonic`: the archive URL
+    /// is the same filename rewrite, and the container stays whatever the live
+    /// URL already carried.
+    static func parse(_ raw: String?) -> CatchupType? {
+        guard let raw else { return nil }
+        let key = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !key.isEmpty else { return nil }
+        if let exact = CatchupType(rawValue: key) { return exact }
+        switch key {
+        case "fs", "flussonic-hls", "flussonic_hls", "flussonichls": return .flussonic
+        case "xtream", "xtreamcodes", "xtream-codes": return .xc
+        case "timeshift": return .shift
+        default: return isEnableFlag(key) ? .default : nil
+        }
+    }
+
+    /// The truthy spellings `tvg-rec` uses to declare an archive without naming
+    /// a dialect. Shared with `M3UParser` so the parser and the model can never
+    /// disagree on what counts as "on".
+    static func isEnableFlag(_ raw: String) -> Bool {
+        enableFlags.contains(raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
+    }
+
+    private static let enableFlags: Set<String> = ["1", "true", "yes"]
 }

--- a/Lume/Models/Playlist.swift
+++ b/Lume/Models/Playlist.swift
@@ -132,15 +132,27 @@ nonisolated enum PlaylistStreamFormat: String, CaseIterable, Identifiable, Codab
     /// alone rather than guessed at, so a mismatched setting can never break a
     /// channel that was playing before.
     func applied(to url: URL) -> URL {
-        guard let target = xtreamFormat?.rawValue,
+        guard let target = xtreamFormat,
               var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              let dot = components.path.lastIndex(of: "."),
-              !components.path[dot...].contains("/")
+              let live = components.liveContainer,
+              live.format != target
         else { return url }
-        let current = components.path[components.path.index(after: dot)...].lowercased()
-        guard current == "m3u8" || current == "ts", current != target else { return url }
-        components.path = String(components.path[..<dot]) + "." + target
+        components.path = String(live.stem) + "." + target.rawValue
         return components.url ?? url
+    }
+}
+
+nonisolated extension URLComponents {
+    /// The interchangeable live container this URL's filename names, plus the
+    /// path up to the dot. `nil` for anything that is not a filename ending in
+    /// one of the two Xtream-style live extensions — a bare path, an `index.*`
+    /// segment manifest, a VOD file.
+    var liveContainer: (format: StreamFormat, stem: Substring)? {
+        guard let dot = path.lastIndex(of: "."),
+              !path[dot...].contains("/"),
+              let format = StreamFormat(rawValue: path[path.index(after: dot)...].lowercased())
+        else { return nil }
+        return (format, path[..<dot])
     }
 }
 

--- a/Lume/PreviewData.swift
+++ b/Lume/PreviewData.swift
@@ -238,4 +238,35 @@ private func insertLiveStreams(into container: ModelContainer, categories: [Cate
     liveArchive.isFavorite = true
     liveArchive.categoryId = categories[2].id
     container.mainContext.insert(liveArchive)
+
+    // An m3u channel: catch-up is decided from the dialect plus the raw live
+    // URL, not from the absence of a `directURL`, so the previews have to carry
+    // a channel that only passes the gate through `catchupTypeRaw`.
+    let liveM3UArchive = PreviewData.sampleLiveStream
+    liveM3UArchive.id = "\(PreviewData.samplePlaylistID)-live-3"
+    liveM3UArchive.streamId = 102
+    liveM3UArchive.name = "Sky News (m3u)"
+    liveM3UArchive.epgChannelId = "SKYNEWS"
+    liveM3UArchive.directURL = "http://example.com:8080/skynews/video.m3u8"
+    liveM3UArchive.catchupType = .flussonic
+    liveM3UArchive.tvArchive = 1
+    liveM3UArchive.tvArchiveDuration = 3
+    liveM3UArchive.categoryId = categories[2].id
+    container.mainContext.insert(liveM3UArchive)
+
+    // Declared catch-up with no day count (`catchup="fs"` on its own): a stored
+    // duration of 0 means "depth unknown" and every badge must render its
+    // day-less variant instead of claiming a zero-day archive.
+    let liveM3UUnknownDepth = PreviewData.sampleLiveStream
+    liveM3UUnknownDepth.id = "\(PreviewData.samplePlaylistID)-live-4"
+    liveM3UUnknownDepth.streamId = 103
+    liveM3UUnknownDepth.name = "Euronews (m3u)"
+    liveM3UUnknownDepth.epgChannelId = "EURONEWS"
+    liveM3UUnknownDepth.directURL = "http://example.com:8080/live/euronews.m3u8"
+    liveM3UUnknownDepth.catchupType = .default
+    liveM3UUnknownDepth.catchupSource = "http://example.com:8080/live/euronews.m3u8?utc={utc}&lutc={now}"
+    liveM3UUnknownDepth.tvArchive = 1
+    liveM3UUnknownDepth.tvArchiveDuration = 0
+    liveM3UUnknownDepth.categoryId = categories[2].id
+    container.mainContext.insert(liveM3UUnknownDepth)
 }

--- a/Lume/Services/Network/M3UCatchupURL.swift
+++ b/Lume/Services/Network/M3UCatchupURL.swift
@@ -1,0 +1,311 @@
+//
+//  M3UCatchupURL.swift
+//  Lume
+//
+//  Catch-up (archive) URL construction for m3u channels
+//
+
+import Foundation
+
+/// Builds catch-up (archive) URLs for channels that came from an m3u playlist.
+///
+/// m3u providers describe their archive with a `catchup` dialect plus an
+/// optional `catchup-source` template instead of Xtream credentials, so there is
+/// nothing to ask a client for: every dialect is a pure rewrite of the channel's
+/// own live URL. Modelled on `XtreamClient.buildCatchupURL`, and on the
+/// parse-with-`URLComponents`-or-bail style of `PlaylistStreamFormat.applied(to:)`
+/// — anything that does not match a known shape returns `nil` rather than a
+/// guess.
+///
+/// Timestamps are raw UTC unix epochs and `{duration}` is **seconds**. The
+/// minutes-and-wall-clock convention of `XtreamClient.timeshiftStartString`
+/// exists to keep XC panels from answering 400 and is only reached through the
+/// `xc` dialect below.
+nonisolated enum M3UCatchupURL {
+    /// Catch-up URL for the programme running `start ..< end` on the channel
+    /// whose live URL is `liveURL`.
+    ///
+    /// `liveURL` must be the **raw** `LiveStream.directURL`, never the result of
+    /// `PlaylistStreamFormat.applied(to:)`: that rewrite swaps `.m3u8` ⇄ `.ts` on
+    /// live URLs and would turn a Flussonic archive URL into a 404 for everyone
+    /// who set the playlist to MPEG-TS.
+    static func build(
+        liveURL: URL,
+        type: CatchupType,
+        source: String?,
+        start: Date,
+        end: Date,
+        now: Date = Date()
+    ) -> URL? {
+        let duration = Int(end.timeIntervalSince(start).rounded())
+        guard duration > 0 else { return nil }
+        let template = source?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let expanded = { template.flatMap { $0.isEmpty ? nil : expand($0, start: start, end: end, now: now, duration: duration) } }
+
+        let built: URL? = switch type {
+        case .flussonic:
+            // `catchup="flussonic"` paired with an explicit `catchup-source` is a
+            // common shipping combination, and an explicit template is the
+            // provider telling us where its archive actually lives — it wins over
+            // the filename convention. The convention is the fallback, for the
+            // (equally common) channels that ship the dialect on its own or ship
+            // a template we cannot turn into a playable URL.
+            expanded().flatMap { playable(resolve($0, against: liveURL, bareToken: .reject)) }
+                ?? flussonicURL(liveURL: liveURL, start: start, duration: duration)
+        case .append:
+            expanded().flatMap { resolve($0, against: liveURL, bareToken: .append) }
+        case .default, .shift:
+            expanded().flatMap { resolve($0, against: liveURL, bareToken: .reject) }
+        case .xc:
+            xcURL(liveURL: liveURL, start: start, end: end)
+        }
+        return playable(built)
+    }
+
+    /// The player can only open an absolute http(s) URL, and `canBuild` is what
+    /// the importer persists as `tvArchive` — so a dialect that produced
+    /// something else (`plugin://…`, a bare query, a path with no host) has to
+    /// read as *not buildable* here rather than badge a channel whose catch-up
+    /// tap is dead.
+    private static func playable(_ url: URL?) -> URL? {
+        guard let url,
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host()?.isEmpty == false
+        else { return nil }
+        return url
+    }
+
+    /// What a `catchup-source` that is neither a whole URL nor a query fragment
+    /// means: for `append` the provider wrote a suffix to glue on, everywhere
+    /// else only an explicitly relative path counts.
+    private enum BareTokenPolicy {
+        case append
+        case reject
+    }
+
+    /// `catchup-source` is often written relative to the channel's own live URL
+    /// rather than as a whole URL: a bare query fragment merges onto the live
+    /// URL the way `append` does, and a path resolves against it. Anything
+    /// already carrying a scheme — or a network-path reference (`//host/path`)
+    /// that borrows the live URL's scheme — is taken as written, including under
+    /// `.append`, where concatenating it would produce
+    /// `http://live/ch.tshttp://archive/x.m3u8`: still http, still with a host,
+    /// and so a dead tap that `playable` cannot catch.
+    ///
+    /// Under `.reject` the shape test is deliberately a positive one.
+    /// `URL(string:relativeTo:)` resolves *any* scheme-less string against the
+    /// live URL, so a bare token (`garbage`, a stray provider comment) would come
+    /// back as a path on the live host — absolute, http, with a host, and so
+    /// waved through by `playable` into a catch-up badge whose tap 404s.
+    private static func resolve(_ expanded: String, against liveURL: URL, bareToken: BareTokenPolicy) -> URL? {
+        if absoluteScheme(of: expanded) != nil {
+            return URL(string: expanded)
+        }
+        if expanded.hasPrefix("//") {
+            return URL(string: expanded, relativeTo: liveURL)?.absoluteURL
+        }
+        if expanded.hasPrefix("?") || expanded.hasPrefix("&") {
+            return appending(expanded, to: liveURL)
+        }
+        switch bareToken {
+        case .append:
+            return appending(expanded, to: liveURL)
+        case .reject:
+            guard expanded.hasPrefix("/") || expanded.hasPrefix("./") || expanded.hasPrefix("../") else { return nil }
+            return URL(string: expanded, relativeTo: liveURL)?.absoluteURL
+        }
+    }
+
+    /// The RFC 3986 scheme prefix of `string`, lowercased, or `nil` when it has
+    /// none. Not `URL(string:)?.scheme`: that parser rejects strings a template
+    /// legitimately expands to (spaces, stray braces) and would then read them
+    /// as scheme-less relative paths.
+    private static func absoluteScheme(of string: String) -> String? {
+        guard let colon = string.firstIndex(of: ":") else { return nil }
+        let scheme = string[..<colon]
+        guard let first = scheme.first, first.isASCII, first.isLetter,
+              scheme.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "+" || $0 == "-" || $0 == ".") })
+        else { return nil }
+        return scheme.lowercased()
+    }
+
+    /// Whether `build` would produce a URL for this channel, without keeping
+    /// one. **Import-time only** — the sole caller is
+    /// `ContentSyncManager+M3U.importLive`, which persists the answer as
+    /// `tvArchive`. It costs a full URL construction, so no view, cell body,
+    /// focus handler or guide-row snapshot may call it: those read the persisted
+    /// `tvArchive`/`catchupTypeRaw` through `PlayableMedia.isCatchupCapable`
+    /// instead, which is what keeps SwiftData from faulting per render.
+    ///
+    /// It has to agree with `build` exactly, which is why it *is* `build`, run
+    /// against a throwaway one-hour window.
+    static func canBuild(type: CatchupType, source: String?, liveURL: URL) -> Bool {
+        let probe = Date(timeIntervalSince1970: 1_700_000_000)
+        return build(
+            liveURL: liveURL,
+            type: type,
+            source: source,
+            start: probe,
+            end: probe.addingTimeInterval(3600),
+            now: probe.addingTimeInterval(7200)
+        ) != nil
+    }
+
+    // MARK: - Dialects
+
+    /// Flussonic serves an archive from the same path as the live stream, with
+    /// the window encoded into the filename: `…/video.m3u8` becomes
+    /// `…/video-{utc}-{seconds}.m3u8` (the `index.m3u8` and `.ts` spellings work
+    /// the same way). Any query the live URL carries — usually a token — is kept.
+    ///
+    /// Deliberate limitation: a live URL with no filename extension (`…/ch1/mpegts`,
+    /// which Flussonic also serves) has nothing to rewrite, and the archive path
+    /// for it is not derivable — such a channel is unbuildable and correctly ends
+    /// up with no catch-up badge unless the provider ships a `catchup-source`.
+    private static func flussonicURL(liveURL: URL, start: Date, duration: Int) -> URL? {
+        guard var components = URLComponents(url: liveURL, resolvingAgainstBaseURL: false),
+              let live = components.liveContainer,
+              !live.stem.isEmpty, live.stem.last != "/"
+        else { return nil }
+        components.path = "\(live.stem)-\(epoch(start))-\(duration).\(live.format.rawValue)"
+        return components.url
+    }
+
+    /// `append` glues the expanded template onto the live URL. Providers write
+    /// the template as a query fragment (`?utc={utc}&lutc={now}`), so a live URL
+    /// that already carries a query has to be merged with `&` instead — and a
+    /// template that is a path suffix rather than a query is concatenated as-is.
+    private static func appending(_ suffix: String, to liveURL: URL) -> URL? {
+        let hasQuery = URLComponents(url: liveURL, resolvingAgainstBaseURL: false)?.query?.isEmpty == false
+        let base = liveURL.absoluteString
+        let joined: String = switch suffix.first {
+        case "?": hasQuery ? base + "&" + suffix.dropFirst() : base + suffix
+        case "&": hasQuery ? base + suffix : base + "?" + suffix.dropFirst()
+        default: base + suffix
+        }
+        return URL(string: joined)
+    }
+
+    /// An m3u playlist pointed at an Xtream panel: the credentials and the real
+    /// provider stream id are in the channel URL path, not on the `Playlist`
+    /// (which holds the playlist URL and no credentials) or on the `LiveStream`
+    /// (whose `streamId` is an FNV hash for m3u sources). Recover them from
+    /// `…/live/{user}/{pass}/{id}.{ext}` — or the `live`-less `…/{user}/{pass}/{id}.{ext}`
+    /// variant — and hand off to the Xtream timeshift builder, which is the one
+    /// path that legitimately wants minutes and wall clock.
+    private static func xcURL(liveURL: URL, start: Date, end: Date) -> URL? {
+        guard var components = URLComponents(url: liveURL, resolvingAgainstBaseURL: false) else { return nil }
+        // Panels that front their streams with a per-session token carry it as a
+        // query on the live URL; dropping it makes the rebuilt timeshift URL a
+        // 403. Read it percent-encoded so the token reaches the server verbatim.
+        let liveQuery = components.percentEncodedQuery
+        var parts = components.path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        guard parts.count >= 3 else { return nil }
+        let file = parts.removeLast()
+        let password = parts.removeLast()
+        let username = parts.removeLast()
+        guard !username.isEmpty, !password.isEmpty else { return nil }
+        if parts.last?.lowercased() == "live" { parts.removeLast() }
+
+        guard let dot = file.lastIndex(of: "."),
+              let streamId = Int(file[..<dot])
+        else { return nil }
+        let ext = file[file.index(after: dot)...].lowercased()
+        // The container the provider already hands out for live; the m3u path
+        // deliberately never rewrites containers. Anything exotic falls back to
+        // MPEG-TS, which is what panels serve catch-up as by default.
+        let container = (StreamFormat(rawValue: String(ext)) ?? .tsStream).rawValue
+
+        components.path = parts.isEmpty ? "" : "/" + parts.joined(separator: "/")
+        components.query = nil
+        components.fragment = nil
+        guard let base = components.string else { return nil }
+
+        let timeshift = XtreamClient.buildCatchupURL(
+            XtreamClient.TimeshiftTarget(
+                serverURL: base,
+                username: username,
+                password: password,
+                streamId: streamId,
+                container: container,
+                // Not an oversight: an m3u `Playlist` stores only the playlist
+                // URL, so there is no `serverTimezone` to read here and no
+                // request that could learn one — `xc` reaches this builder from
+                // an m3u channel only. `.current` is the same device-clock
+                // fallback `XtreamClient.buildCatchupURL(for:playlist:…)` uses
+                // when a panel does not advertise a timezone, so a wall-clock
+                // panel behaves identically whether it was added as m3u or as
+                // Xtream. Do not "fix" this to UTC.
+                timeZone: .current
+            ),
+            start: start,
+            end: end
+        )
+        return carryingQuery(liveQuery, onto: timeshift)
+    }
+
+    /// Re-attaches the live URL's query to a rebuilt URL, merging with `&` if the
+    /// builder produced one of its own. The fragment stays dropped: it is a
+    /// client-side anchor, never part of what the panel authorises.
+    private static func carryingQuery(_ query: String?, onto url: URL?) -> URL? {
+        guard let url else { return nil }
+        guard let query, !query.isEmpty else { return url }
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+        if let existing = components.percentEncodedQuery, !existing.isEmpty {
+            components.percentEncodedQuery = existing + "&" + query
+        } else {
+            components.percentEncodedQuery = query
+        }
+        return components.url
+    }
+
+    // MARK: - Template expansion
+
+    /// Expands a verbatim `catchup-source` template. Templates are stored as the
+    /// provider wrote them and expanded here, at play time — expanding at import
+    /// time would bake in a stale `now`. Unrecognised placeholders are left
+    /// standing rather than treated as an error, so a provider extension we do
+    /// not know about still reaches the server intact.
+    private static func expand(_ template: String, start: Date, end: Date, now: Date, duration: Int) -> String {
+        var result = ""
+        var index = template.startIndex
+        while let open = template[index...].firstIndex(of: "{"),
+              let close = template[open...].firstIndex(of: "}")
+        {
+            let name = template[template.index(after: open) ..< close].lowercased()
+            if let value = placeholderValue(for: name, start: start, end: end, now: now, duration: duration) {
+                // `${utc}` is the same placeholder as `{utc}`; swallow the `$`.
+                let literalEnd = (open > index && template[template.index(before: open)] == "$")
+                    ? template.index(before: open) : open
+                result += template[index ..< literalEnd] + value
+            } else {
+                result += template[index ... close]
+            }
+            index = template.index(after: close)
+        }
+        result += template[index...]
+        return result
+    }
+
+    private static func placeholderValue(
+        for name: String,
+        start: Date,
+        end: Date,
+        now: Date,
+        duration: Int
+    ) -> String? {
+        switch name {
+        case "utc", "start": epoch(start)
+        case "end", "utcend": epoch(end)
+        case "duration": String(duration)
+        case "offset": String(Int(now.timeIntervalSince(start).rounded()))
+        case "now", "lutc", "timestamp": epoch(now)
+        default: nil
+        }
+    }
+
+    private static func epoch(_ date: Date) -> String {
+        String(Int(date.timeIntervalSince1970))
+    }
+}

--- a/Lume/Services/Network/M3UParser.swift
+++ b/Lume/Services/Network/M3UParser.swift
@@ -32,6 +32,15 @@ nonisolated struct M3UEntry {
     /// when present. Some providers serve live and on-demand through identical
     /// URLs and only this attribute distinguishes them.
     var type: String?
+    /// Raw catch-up dialect (`catchup-type` / `catchup`), kept verbatim —
+    /// `CatchupType.parse` folds in the wild spellings.
+    var catchupTypeRaw: String?
+    /// Archive depth in days, when the channel declares one. `nil` means the
+    /// channel declares catch-up without a depth.
+    var catchupDays: Int?
+    /// `catchup-source` template, kept verbatim: it carries `{utc}`-style
+    /// placeholders that must be expanded at play time, never at import time.
+    var catchupSource: String?
 }
 
 // MARK: - Parser
@@ -146,7 +155,17 @@ nonisolated enum M3UParser {
                 // Plain (non-extended) m3u: a bare URL with no metadata.
                 guard looksLikeURL(line) else { return nil }
                 let fallbackName = URL(string: line)?.deletingPathExtension().lastPathComponent ?? line
-                return M3UEntry(name: fallbackName, url: line, tvgId: nil, logo: nil, group: pendingGroup, type: nil)
+                return M3UEntry(
+                    name: fallbackName,
+                    url: line,
+                    tvgId: nil,
+                    logo: nil,
+                    group: pendingGroup,
+                    type: nil,
+                    catchupTypeRaw: nil,
+                    catchupDays: nil,
+                    catchupSource: nil
+                )
             }
 
             let name = info.name.isEmpty ? (info.tvgName ?? line) : info.name
@@ -156,7 +175,10 @@ nonisolated enum M3UParser {
                 tvgId: info.tvgId,
                 logo: info.logo,
                 group: info.group ?? pendingGroup,
-                type: info.type
+                type: info.type,
+                catchupTypeRaw: info.catchupTypeRaw,
+                catchupDays: info.catchupDays,
+                catchupSource: info.catchupSource
             )
         }
 
@@ -174,28 +196,34 @@ nonisolated enum M3UParser {
         var logo: String?
         var group: String?
         var type: String?
+        var catchupTypeRaw: String?
+        var catchupDays: Int?
+        var catchupSource: String?
     }
 
     /// Parses `#EXTINF:-1 tvg-id="..." tvg-logo="..." group-title="...",Name`.
     ///
-    /// Attribute values may contain commas, so the display name is whatever
-    /// follows the first comma *after* the last quoted attribute value.
+    /// Attribute values may contain commas, so the display name starts at the
+    /// first comma reached *outside* a quoted value — where the attribute scan
+    /// stops.
     static func parseExtInf(_ line: String) -> ExtInf {
         let body = String(line.dropFirst("#EXTINF:".count))
 
-        let attributes = parseAttributes(body)
+        let (attributes, stop) = scanAttributes(body)
 
-        // Name: after the first comma past the end of the last quoted value.
+        // Name: after the comma the attribute scan stopped on.
         var name = ""
-        let searchStart: String.Index = if let lastQuote = body.lastIndex(of: "\"") {
-            body.index(after: lastQuote)
-        } else {
-            body.startIndex
-        }
-        if let comma = body[searchStart...].firstIndex(of: ",") {
+        if let comma = body[stop...].firstIndex(of: ",") {
             name = String(body[body.index(after: comma)...])
                 .trimmingCharacters(in: .whitespaces)
         }
+
+        // `tvg-rec` is an enable flag, not a dialect: only its truthy spellings
+        // stand in for a missing `catchup`/`catchup-type`, and such a flag
+        // carries no day count.
+        let rec = nonEmpty(attributes["tvg-rec"])
+        let recIsFlag = rec.map(CatchupType.isEnableFlag) ?? false
+        let recDays = recIsFlag ? nil : rec.flatMap { Int($0) }
 
         return ExtInf(
             name: name,
@@ -203,7 +231,12 @@ nonisolated enum M3UParser {
             tvgName: nonEmpty(attributes["tvg-name"]),
             logo: nonEmpty(attributes["tvg-logo"]),
             group: nonEmpty(attributes["group-title"]),
-            type: nonEmpty(attributes["type"])
+            type: nonEmpty(attributes["type"]),
+            catchupTypeRaw: nonEmpty(attributes["catchup-type"]) ?? nonEmpty(attributes["catchup"]) ?? (recIsFlag ? rec : nil),
+            catchupDays: positive(attributes["catchup-days"].flatMap { Int($0) })
+                ?? positive(attributes["timeshift"].flatMap { Int($0) })
+                ?? positive(recDays),
+            catchupSource: nonEmpty(attributes["catchup-source"])
         )
     }
 
@@ -212,20 +245,31 @@ nonisolated enum M3UParser {
         return M3UHeader(epgURL: nonEmpty(attributes["url-tvg"]) ?? nonEmpty(attributes["x-tvg-url"]))
     }
 
-    /// Extracts `key="value"` pairs (the only attribute form the IPTV dialect
-    /// uses in practice). A single manual scan — no regex — because this runs
-    /// once per line on playlists with hundreds of thousands of lines.
+    /// Extracts `key="value"` pairs plus the bare `key=value` form providers
+    /// emit for numeric attributes (`catchup-days=1`, `timeshift=2`). A single
+    /// manual scan — no regex — because this runs once per line on playlists
+    /// with hundreds of thousands of lines.
+    ///
+    /// Scanning stops at the first comma reached outside a quoted value: on an
+    /// `#EXTINF` line that comma starts the display name, and a name like
+    /// `Sky F1=HD` must not contribute an attribute. Commas inside a quoted
+    /// value are consumed with the value, so this is the same boundary
+    /// `parseExtInf` uses to find the name.
     static func parseAttributes(_ text: String) -> [String: String] {
+        scanAttributes(text).attributes
+    }
+
+    /// `parseAttributes` plus the index the scan stopped on, so `parseExtInf`
+    /// does not have to locate the display-name comma a second time.
+    private static func scanAttributes(_ text: String) -> (attributes: [String: String], stop: String.Index) {
         var result: [String: String] = [:]
         var index = text.startIndex
 
         while index < text.endIndex {
-            guard let equals = text[index...].firstIndex(of: "=") else { break }
+            guard let equals = nextEquals(in: text, from: index) else { break }
             let valueStart = text.index(after: equals)
-            guard valueStart < text.endIndex, text[valueStart] == "\"" else {
-                index = valueStart
-                continue
-            }
+            guard valueStart < text.endIndex else { break }
+
             // Key: identifier characters immediately before '='.
             var keyStart = equals
             while keyStart > index {
@@ -236,18 +280,49 @@ nonisolated enum M3UParser {
             }
             let key = String(text[keyStart ..< equals])
 
-            let quoteStart = text.index(after: valueStart)
-            guard let quoteEnd = text[quoteStart...].firstIndex(of: "\"") else { break }
-            if !key.isEmpty {
-                result[key] = String(text[quoteStart ..< quoteEnd])
+            if text[valueStart] == "\"" {
+                let quoteStart = text.index(after: valueStart)
+                guard let quoteEnd = text[quoteStart...].firstIndex(of: "\"") else { break }
+                if !key.isEmpty {
+                    result[key] = String(text[quoteStart ..< quoteEnd])
+                }
+                index = text.index(after: quoteEnd)
+            } else {
+                // An unquoted value ends at the next space or at the comma that
+                // starts the display name; a value carrying either must be quoted.
+                var valueEnd = valueStart
+                while valueEnd < text.endIndex, !text[valueEnd].isWhitespace, text[valueEnd] != "," {
+                    valueEnd = text.index(after: valueEnd)
+                }
+                if !key.isEmpty, valueStart < valueEnd {
+                    result[key] = String(text[valueStart ..< valueEnd])
+                }
+                index = valueEnd
             }
-            index = text.index(after: quoteEnd)
         }
-        return result
+        return (result, index)
+    }
+
+    /// Index of the next `=` at or after `start`, or `nil` once the scan hits a
+    /// comma — the display-name boundary — or the end of the text.
+    private static func nextEquals(in text: String, from start: String.Index) -> String.Index? {
+        var cursor = start
+        while cursor < text.endIndex {
+            let char = text[cursor]
+            if char == "," { return nil }
+            if char == "=" { return cursor }
+            cursor = text.index(after: cursor)
+        }
+        return nil
     }
 
     private static func nonEmpty(_ value: String?) -> String? {
         guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+
+    private static func positive(_ value: Int?) -> Int? {
+        guard let value, value > 0 else { return nil }
         return value
     }
 }

--- a/Lume/Services/Network/XtreamClient.swift
+++ b/Lume/Services/Network/XtreamClient.swift
@@ -466,12 +466,44 @@ class XtreamClient: APIClient {
     /// path. The value is wall-clock time in the timezone advertised by the
     /// account. Fall back to the device timezone for older panels that omit it,
     /// preserving Lume's historical behaviour for those providers.
-    private nonisolated static func timeshiftStartString(for start: Date, playlist: Playlist) -> String {
+    private nonisolated static func timeshiftStartString(for start: Date, timeZone: TimeZone) -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd:HH-mm"
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = playlist.serverTimezone.flatMap(TimeZone.init(identifier:)) ?? .current
+        formatter.timeZone = timeZone
         return formatter.string(from: start)
+    }
+
+    /// Everything a timeshift URL needs that is not the programme window.
+    ///
+    /// Exists so the m3u `xc` catch-up dialect can reach the builder below: those
+    /// channels hit an Xtream panel, but their credentials and provider stream id
+    /// live in the channel URL path rather than on the models (an m3u `Playlist`
+    /// has no credentials and `LiveStream.streamId` is an FNV hash).
+    nonisolated struct TimeshiftTarget {
+        let serverURL: String
+        let username: String
+        let password: String
+        let streamId: Int
+        let container: String
+        let timeZone: TimeZone
+    }
+
+    /// The timeshift path itself, without a `Playlist`/`LiveStream` pair.
+    /// `M3UCatchupURL` calls straight through here so both sources build one
+    /// path shape.
+    ///
+    /// The programme window arrives as its two dates and the minutes convention
+    /// lives here alone: panels answer 400 on a zero-minute request, so a window
+    /// shorter than a minute rounds up to one rather than becoming unplayable.
+    nonisolated static func buildCatchupURL(
+        _ target: TimeshiftTarget,
+        start: Date,
+        end: Date
+    ) -> URL? {
+        let durationMinutes = max(1, Int((end.timeIntervalSince(start) / 60).rounded(.up)))
+        let startString = timeshiftStartString(for: start, timeZone: target.timeZone)
+        return URL(string: "\(target.serverURL)/timeshift/\(target.username)/\(target.password)/\(durationMinutes)/\(startString)/\(target.streamId).\(target.container)")
     }
 
     /// Builds a catch-up / timeshift URL for a past programme on a live stream.
@@ -485,16 +517,25 @@ class XtreamClient: APIClient {
         for stream: LiveStream,
         playlist: Playlist,
         start: Date,
-        durationMinutes: Int,
+        end: Date,
         format: StreamFormat? = nil
     ) -> URL? {
-        guard durationMinutes > 0 else { return nil }
         // Xtream-compatible panels commonly expose catch-up as an MPEG-TS
         // resource even when normal live playback defaults to HLS. Respect an
         // explicit playlist/argument choice, but prefer TS when it is unknown.
         let ext = Self.resolvedFormat(format, playlist: playlist, fallback: .tsStream).rawValue
-        let startString = Self.timeshiftStartString(for: start, playlist: playlist)
-        return URL(string: "\(playlist.serverURL)/timeshift/\(playlist.username)/\(playlist.password)/\(durationMinutes)/\(startString)/\(stream.streamId).\(ext)")
+        return Self.buildCatchupURL(
+            TimeshiftTarget(
+                serverURL: playlist.serverURL,
+                username: playlist.username,
+                password: playlist.password,
+                streamId: stream.streamId,
+                container: ext,
+                timeZone: playlist.serverTimezone.flatMap(TimeZone.init(identifier:)) ?? .current
+            ),
+            start: start,
+            end: end
+        )
     }
 }
 

--- a/Lume/Services/Player/PlayableMedia.swift
+++ b/Lume/Services/Player/PlayableMedia.swift
@@ -219,22 +219,89 @@ extension PlayableMedia {
         )
     }
 
+    /// The single capability rule: whether this channel can serve catch-up at
+    /// all. Every affordance in the app gates on this — a tap must never reach a
+    /// URL builder that then answers `nil`.
+    ///
+    /// Runs from lazily-rendered cell bodies, so it stays a stored-property test:
+    /// the m3u import already ran `M3UCatchupURL.canBuild` and persisted the
+    /// answer as `tvArchive`, and this must trust that rather than fault
+    /// `catchupSource`/`directURL` and rebuild a probe URL per render.
+    ///
+    /// The source type needs no argument: only a buildable m3u import writes
+    /// `catchupTypeRaw`, and an Xtream channel carries no `directURL`. A Stalker
+    /// channel has neither — its importer writes no `tvArchive` at all and puts a
+    /// `create_link` command in `directURL` (`ContentSyncManager+Stalker.swift`)
+    /// rather than a playable URL.
+    static func isCatchupCapable(stream: LiveStream) -> Bool {
+        guard stream.tvArchive > 0 else { return false }
+        return stream.catchupTypeRaw != nil || stream.directURL == nil
+    }
+
+    /// How far back to offer the archive for `stream`.
+    ///
+    /// `unknownArchiveDays` applies to exactly one case: an m3u
+    /// channel that named a catch-up dialect but no day count, where a stored 0
+    /// means "declared, depth unknown". Every other source — Xtream included —
+    /// keeps the historical `max(1, …)` coercion, so an Xtream panel that
+    /// advertises `tv_archive = 1` with `tv_archive_duration = 0` still offers
+    /// one day and still fetches one day of guide.
+    ///
+    /// Tests the stored column rather than the tolerant `catchupType`
+    /// accessor, so it agrees with `isCatchupCapable` row for row and stays
+    /// allocation-free on the guide's per-row path (`EPGGridBuilder.rows`).
+    static func archiveWindowDays(for stream: LiveStream) -> Int {
+        if stream.tvArchiveDuration == 0, stream.catchupTypeRaw != nil {
+            return unknownArchiveDays
+        }
+        return max(1, stream.tvArchiveDuration)
+    }
+
+    /// The window to offer when a channel declares catch-up but no depth
+    /// (`tvArchiveDuration == 0`). The store keeps 0 to mean "declared, depth
+    /// unknown" rather than inventing a provider number; this is only the
+    /// browsing window we are willing to guess, and a request outside the
+    /// provider's real archive fails in the normal player error path.
+    static let unknownArchiveDays = 7
+
+    /// The depth a catch-up badge may name, or `nil` for a channel whose stored
+    /// duration is 0 — "declared, depth unknown", where the badge shows its
+    /// glyph alone rather than claiming an archive of zero days.
+    static func archiveBadgeDays(for stream: LiveStream) -> Int? {
+        stream.tvArchiveDuration > 0 ? stream.tvArchiveDuration : nil
+    }
+
+    /// Ceiling on a guide's reach-back, independent of the depth a provider
+    /// declares. A guide widens its `EPGListing` predicate — the largest table
+    /// in the store — by that many days on the main actor, and the in-player
+    /// guide re-runs the fetch on every 150 ms-debounced channel-focus move
+    /// while video is playing. An m3u channel advertising `catchup-days="30"`
+    /// must not turn that sweep into a month-wide fetch per row. 14 days clears
+    /// every depth providers actually serve, so no real Xtream archive is
+    /// narrowed by it.
+    static let maxGuideArchiveDays = 14
+
+    /// `archiveWindowDays` bounded for guide fetches. Both guides — the grid
+    /// (`EPGGridBuilder.rows`) and the in-player channel browser — must use
+    /// this one accessor so they agree on how far back a row offers replay.
+    /// The playback-offer predicate `isCatchupAvailable` deliberately does not:
+    /// a channel really does serve deeper than the guide reaches.
+    static func guideArchiveWindowDays(for stream: LiveStream) -> Int {
+        min(archiveWindowDays(for: stream), maxGuideArchiveDays)
+    }
+
     /// Whether a programme that started at `start` is still replayable from the
-    /// channel's catch-up archive at `now`. Mirrors the guards in
-    /// `catchup(stream:...)` so UI can offer the action only where construction
-    /// would succeed: catch-up needs Xtream credentials (no direct URL), an
-    /// advertised archive, and a start inside the archive window.
+    /// channel's catch-up archive at `now`: the channel is catch-up capable and
+    /// the start lies inside the archive window.
     static func isCatchupAvailable(stream: LiveStream, start: Date, now: Date) -> Bool {
-        guard stream.tvArchive > 0, stream.directURL == nil else { return false }
-        let archiveDays = max(1, stream.tvArchiveDuration)
-        return start >= now.addingTimeInterval(-TimeInterval(archiveDays) * 86400)
+        guard isCatchupCapable(stream: stream) else { return false }
+        return start >= now.addingTimeInterval(-TimeInterval(archiveWindowDays(for: stream)) * 86400)
     }
 
     /// A past programme played from the channel's catch-up archive. Modelled as
     /// VOD — the archive is a finite, seekable asset, so the player gives it a
     /// scrubber rather than the live banner, and channel surfing stays disabled.
-    /// Returns `nil` for m3u streams (catch-up needs Xtream credentials) or when
-    /// the channel doesn't advertise an archive.
+    /// Returns `nil` for a channel that is not catch-up capable.
     static func catchup(
         stream: LiveStream,
         playlist: Playlist,
@@ -243,11 +310,29 @@ extension PlayableMedia {
         end: Date,
         client: XtreamClient = XtreamClient()
     ) -> PlayableMedia? {
-        guard stream.tvArchive > 0, stream.directURL == nil else { return nil }
-        let durationMinutes = max(1, Int((end.timeIntervalSince(start) / 60).rounded(.up)))
-        guard let url = client.buildCatchupURL(
-            for: stream, playlist: playlist, start: start, durationMinutes: durationMinutes
-        ) else { return nil }
+        guard isCatchupCapable(stream: stream) else { return nil }
+        let url: URL
+        switch playlist.sourceType {
+        case .stalker:
+            return nil
+        case .m3u:
+            // The **raw** `directURL`, deliberately not put through
+            // `playlist.streamFormat.applied(to:)`: that rewrite swaps
+            // `.m3u8` ⇄ `.ts` on live URLs and would turn a Flussonic archive
+            // URL into a 404 for everyone who set the playlist to MPEG-TS.
+            guard let liveURL = stream.directURL.flatMap(URL.init(string:)),
+                  let type = stream.catchupType,
+                  let built = M3UCatchupURL.build(
+                      liveURL: liveURL, type: type, source: stream.catchupSource, start: start, end: end
+                  )
+            else { return nil }
+            url = built
+        case .xtream:
+            guard let built = client.buildCatchupURL(
+                for: stream, playlist: playlist, start: start, end: end
+            ) else { return nil }
+            url = built
+        }
         return PlayableMedia(
             id: "catchup-\(stream.id)-\(Int(start.timeIntervalSince1970))",
             url: url,

--- a/Lume/Services/Sync/ContentSyncManager+M3U.swift
+++ b/Lume/Services/Sync/ContentSyncManager+M3U.swift
@@ -435,6 +435,7 @@ extension ContentSyncManager {
             stream.directURL = entry.url
             stream.num = state.liveNum
             stream.categoryId = categoryId(for: entry.group, type: .live, playlistId: playlistId)
+            Self.applyM3UCatchupFields(from: entry, to: stream)
             state.liveNum += 1
         }
         state.importedLive += entries.count

--- a/Lume/Services/Sync/ContentSyncManager+M3UCatchup.swift
+++ b/Lume/Services/Sync/ContentSyncManager+M3UCatchup.swift
@@ -1,0 +1,46 @@
+//
+//  ContentSyncManager+M3UCatchup.swift
+//  Lume
+//
+//  The catch-up half of the m3u live importer.
+//
+//  m3u channels advertise an archive with a `catchup` dialect and an optional
+//  `catchup-source` template rather than with the numeric `tv_archive` pair an
+//  Xtream panel returns, so the importer has to translate one into the other:
+//  the columns live TV, the guide and the player read are the Xtream ones, and
+//  every consumer stays source-agnostic.
+//
+//  The translation happens exactly once, here, at import time — never per
+//  rendered cell. See `catchupImport(for:)` for why the decision is *buildable*
+//  rather than *declared*.
+//
+
+import Foundation
+import SwiftData
+
+extension ContentSyncManager {
+    /// Writes the catch-up columns for one imported m3u channel.
+    ///
+    /// Assigned on every pass, the absent case included: the prune sweep removes
+    /// vanished rows but never resets columns, so a dropped archive self-clears
+    /// here.
+    static func applyM3UCatchupFields(from entry: M3UEntry, to stream: LiveStream) {
+        let catchup = catchupImport(for: entry)
+        stream.tvArchive = catchup == nil ? 0 : 1
+        stream.tvArchiveDuration = catchup?.days ?? 0
+        stream.catchupType = catchup?.type
+        stream.catchupSource = catchup?.source
+    }
+
+    /// The catch-up decision persisted for an m3u channel, `nil` when it declares
+    /// none we can serve. `tvArchive` records *buildable*, not *declared* — the
+    /// guide's row snapshot cannot run a URL builder per cell, so a scheme we cannot
+    /// expand gets no affordance rather than a dead tap; days 0 is "depth unknown".
+    private static func catchupImport(for entry: M3UEntry) -> (type: CatchupType, days: Int, source: String?)? {
+        guard let type = CatchupType.parse(entry.catchupTypeRaw),
+              let liveURL = URL(string: entry.url),
+              M3UCatchupURL.canBuild(type: type, source: entry.catchupSource, liveURL: liveURL)
+        else { return nil }
+        return (type, entry.catchupDays ?? 0, entry.catchupSource)
+    }
+}

--- a/Lume/Views/Components/CatchupBadge.swift
+++ b/Lume/Views/Components/CatchupBadge.swift
@@ -1,0 +1,37 @@
+//
+//  CatchupBadge.swift
+//  Lume
+//
+//  Shared catch-up (archive) affordance for channel rows and cells
+//
+
+import SwiftUI
+
+/// The archive affordance every channel row and cell shows. Callers apply their
+/// own font and tint.
+struct CatchupBadge: View {
+    /// `nil` where the depth is unknown or the caller wants the glyph alone —
+    /// see `PlayableMedia.archiveBadgeDays(for:)`.
+    let days: Int?
+    var spacing: CGFloat = 4
+
+    var body: some View {
+        HStack(spacing: spacing) {
+            Image(systemName: "clock.arrow.circlepath")
+                .accessibilityLabel(Text("Catch-up available"))
+            if let days {
+                Text("Catchup: \(days)d")
+            }
+        }
+    }
+}
+
+#Preview("Catch-up badge") {
+    VStack(alignment: .leading, spacing: 8) {
+        CatchupBadge(days: 7)
+        CatchupBadge(days: nil)
+    }
+    .font(.caption2)
+    .foregroundStyle(.blue)
+    .padding()
+}

--- a/Lume/Views/Components/LiveStreamCardView.swift
+++ b/Lume/Views/Components/LiveStreamCardView.swift
@@ -92,13 +92,10 @@ struct LiveStreamCardView: View {
                         .foregroundStyle(.secondary)
                 }
 
-                if stream.tvArchive > 0 {
-                    HStack(spacing: 4) {
-                        Image(systemName: "clock.arrow.circlepath")
-                        Text("Catchup: \(stream.tvArchiveDuration)d")
-                    }
-                    .font(.caption2)
-                    .foregroundStyle(.blue)
+                if PlayableMedia.isCatchupCapable(stream: stream) {
+                    CatchupBadge(days: PlayableMedia.archiveBadgeDays(for: stream))
+                        .font(.caption2)
+                        .foregroundStyle(.blue)
                 }
             }
 
@@ -162,4 +159,48 @@ struct LiveStreamCardView: View {
     stream.isFavorite = true
     return LiveStreamCardView(stream: stream)
         .padding()
+}
+
+#Preview("M3U Catch-up") {
+    let flussonic = LiveStream(
+        id: "preview-5",
+        streamId: 5,
+        name: "Sky News (m3u)",
+        tvArchive: 1,
+        tvArchiveDuration: 3,
+        catchupTypeRaw: CatchupType.flussonic.rawValue
+    )
+    flussonic.directURL = "http://example.com:8080/skynews/video.m3u8"
+
+    // Declared catch-up, depth unknown: the badge is glyph-only.
+    let unknownDepth = LiveStream(
+        id: "preview-6",
+        streamId: 6,
+        name: "Euronews (m3u)",
+        tvArchive: 1,
+        tvArchiveDuration: 0,
+        catchupTypeRaw: CatchupType.default.rawValue,
+        catchupSource: "http://example.com:8080/live/euronews.m3u8?utc={utc}"
+    )
+    unknownDepth.directURL = "http://example.com:8080/live/euronews.m3u8"
+
+    // An m3u channel flagged as having an archive but carrying no dialect —
+    // what a row left over from before the import learned `catchupTypeRaw`
+    // looks like. The capability gate reads the dialect, not the flag, so this
+    // gets no affordance at all.
+    let unbuildable = LiveStream(
+        id: "preview-7",
+        streamId: 7,
+        name: "Local News (m3u, no archive)",
+        tvArchive: 1,
+        tvArchiveDuration: 5
+    )
+    unbuildable.directURL = "http://example.com:8080/local/index.m3u8"
+
+    return VStack(alignment: .leading) {
+        LiveStreamCardView(stream: flussonic)
+        LiveStreamCardView(stream: unknownDepth)
+        LiveStreamCardView(stream: unbuildable)
+    }
+    .padding()
 }

--- a/Lume/Views/LiveTV/EPG/EPGComponents.swift
+++ b/Lume/Views/LiveTV/EPG/EPGComponents.swift
@@ -154,10 +154,9 @@ struct EPGChannelCell: View {
             // Flag channels with an archive so the viewer knows the row
             // offers replays — same idiom as the player's channel overlay.
             if row.catchupCapable {
-                Image(systemName: "clock.arrow.circlepath")
+                CatchupBadge(days: nil)
                     .font(catchupFont)
                     .foregroundStyle(catchupColor)
-                    .accessibilityLabel(Text("Catch-up available"))
             }
         }
         .padding(.horizontal, 12)

--- a/Lume/Views/LiveTV/EPG/EPGProgramDetailView.swift
+++ b/Lume/Views/LiveTV/EPG/EPGProgramDetailView.swift
@@ -28,6 +28,15 @@ struct EPGProgramDetailView: View {
             && PlayableMedia.isCatchupAvailable(stream: stream, start: cell.start, now: now)
     }
 
+    @ViewBuilder
+    private var catchupLabel: some View {
+        if let days = PlayableMedia.archiveBadgeDays(for: stream) {
+            Label("Catch-up available for \(days) days", systemImage: "clock.arrow.circlepath")
+        } else {
+            Label("Catch-up available", systemImage: "clock.arrow.circlepath")
+        }
+    }
+
     var body: some View {
         #if os(tvOS)
             tvBody
@@ -70,8 +79,8 @@ struct EPGProgramDetailView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
 
-                        if stream.tvArchive > 0 {
-                            Label("Catch-up available for \(stream.tvArchiveDuration) days", systemImage: "clock.arrow.circlepath")
+                        if PlayableMedia.isCatchupCapable(stream: stream) {
+                            catchupLabel
                                 .font(.subheadline)
                                 .foregroundStyle(.blue)
                         }
@@ -130,8 +139,8 @@ struct EPGProgramDetailView: View {
                                 .frame(maxWidth: 520)
                         }
 
-                        if stream.tvArchive > 0 {
-                            Label("Catch-up available for \(stream.tvArchiveDuration) days", systemImage: "clock.arrow.circlepath")
+                        if PlayableMedia.isCatchupCapable(stream: stream) {
+                            catchupLabel
                                 .font(.system(size: 26))
                                 .foregroundStyle(.blue)
                         }

--- a/Lume/Views/LiveTV/EPG/EPGTimeline.swift
+++ b/Lume/Views/LiveTV/EPG/EPGTimeline.swift
@@ -141,15 +141,20 @@ struct EPGChannelRow: Identifiable {
     let stream: LiveStream
     let name: String
     let logoURL: URL?
-    /// Whether the channel can serve catch-up at all (advertised archive,
-    /// Xtream stream) — mirrors the `PlayableMedia.catchup` guards.
+    /// Whether the channel can serve catch-up at all — snapshotted from
+    /// `PlayableMedia.isCatchupCapable`, the one shared capability rule.
     let catchupCapable: Bool
-    /// How many days the archive reaches back (≥ 1 when `catchupCapable`).
+    /// How many days the archive reaches back (≥ 1 when `catchupCapable`),
+    /// bounded by `PlayableMedia.maxGuideArchiveDays` so a deep declared depth
+    /// cannot widen a day-based guide fetch — `TVChannelBrowserOverlay` is the
+    /// path that fetches by days today.
     let archiveDays: Int
     let cells: [EPGProgramCell]
 
     /// Snapshot equivalent of `PlayableMedia.isCatchupAvailable` for the
-    /// scroll path: whether a programme starting at `start` is replayable.
+    /// scroll path: whether a programme starting at `start` is replayable —
+    /// over the same bounded window, so a row can never offer replay past
+    /// where a day-based guide fetch reaches.
     func isReplayable(start: Date, now: Date) -> Bool {
         catchupCapable && start >= now.addingTimeInterval(-TimeInterval(archiveDays) * 86400)
     }
@@ -176,8 +181,8 @@ enum EPGGridBuilder {
                 stream: stream,
                 name: stream.name,
                 logoURL: URL(string: stream.streamIcon ?? ""),
-                catchupCapable: stream.tvArchive > 0 && stream.directURL == nil,
-                archiveDays: max(1, stream.tvArchiveDuration),
+                catchupCapable: PlayableMedia.isCatchupCapable(stream: stream),
+                archiveDays: PlayableMedia.guideArchiveWindowDays(for: stream),
                 cells: cells
             )
         }

--- a/Lume/Views/LiveTV/LiveTVTVComponents.swift
+++ b/Lume/Views/LiveTV/LiveTVTVComponents.swift
@@ -211,8 +211,8 @@
                                 .foregroundStyle(secondaryColor)
                         }
 
-                        if stream.tvArchive > 0 {
-                            Label("Catchup: \(stream.tvArchiveDuration)d", systemImage: "clock.arrow.circlepath")
+                        if PlayableMedia.isCatchupCapable(stream: stream) {
+                            CatchupBadge(days: PlayableMedia.archiveBadgeDays(for: stream), spacing: 6)
                                 .font(.system(size: 22))
                                 .foregroundStyle(Color.blue)
                         }

--- a/Lume/Views/Player/TVChannelBrowserOverlay.swift
+++ b/Lume/Views/Player/TVChannelBrowserOverlay.swift
@@ -66,22 +66,7 @@
             case guide(String)
         }
 
-        /// A guide programme as plain values, so the trailing column doesn't hold
-        /// managed `EPGListing` objects across focus changes.
-        struct GuideEntry: Identifiable, Equatable {
-            let id: String
-            let title: String
-            let start: Date
-            let end: Date
-
-            func isLive(at now: Date) -> Bool {
-                start <= now && now < end
-            }
-
-            func isPast(at now: Date) -> Bool {
-                end <= now
-            }
-        }
+        typealias GuideEntry = TVPlayerContent.GuideEntry
 
         /// The focused channel's model, resolved from the loaded column — the
         /// source of truth for catch-up availability and building playback.
@@ -262,11 +247,9 @@
 
                 // Flag channels with an archive so the viewer knows the guide
                 // column offers replays before they move into it.
-                if channel.tvArchive > 0 {
-                    Image(systemName: "clock.arrow.circlepath")
+                if PlayableMedia.isCatchupCapable(stream: channel) {
+                    TVBrowserRowAccent { CatchupBadge(days: nil) }
                         .font(.system(size: 18, weight: .semibold))
-                        .foregroundStyle(.blue)
-                        .accessibilityLabel("Catch-up available")
                 }
 
                 if isCurrent {
@@ -286,7 +269,7 @@
                     .padding(.vertical, 40)
             } else {
                 let now = Date()
-                let hasCatchup = (guideStream?.tvArchive ?? 0) > 0
+                let hasCatchup = guideStream.map { PlayableMedia.isCatchupCapable(stream: $0) } ?? false
                 ForEach(guideEntries) { entry in
                     Button {
                         selectGuide(entry)
@@ -324,9 +307,8 @@
                 Spacer(minLength: 0)
 
                 if isPast, hasCatchup {
-                    Image(systemName: "play.circle")
+                    TVBrowserRowAccent { Image(systemName: "play.circle") }
                         .font(.system(size: 24, weight: .semibold))
-                        .foregroundStyle(.blue)
                 } else if isLive {
                     Image(systemName: "dot.radiowaves.left.and.right")
                         .font(.system(size: 20, weight: .semibold))
@@ -377,7 +359,10 @@
             // Fill the guide column with the playing channel up front, so the
             // third column isn't blank before focus first settles on a channel.
             if let currentChannelID, channels.contains(where: { $0.id == currentChannelID }) {
-                loadGuide(channelID: currentChannelID)
+                guideLoadTask?.cancel()
+                guideLoadTask = Task { @MainActor in
+                    await loadGuide(channelID: currentChannelID)
+                }
             }
         }
 
@@ -418,26 +403,31 @@
             guideLoadTask = Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 150_000_000)
                 guard !Task.isCancelled else { return }
-                loadGuide(channelID: channelID)
+                await loadGuide(channelID: channelID)
             }
         }
 
         /// Fetch the focused channel's guide. Catch-up channels reach back over
         /// their archive window so aired programmes are replayable; others show
         /// only what's on now and next.
-        private func loadGuide(channelID: String) {
+        private func loadGuide(channelID: String) async {
             guideChannelID = channelID
             guard let stream = channels.first(where: { $0.id == channelID }) else {
                 guideEntries = []
                 return
             }
-            let archiveDays = stream.tvArchive > 0 ? max(1, stream.tvArchiveDuration) : 0
-            let listings = TVPlayerContent.guideListings(
-                channelId: stream.epgChannelId, archiveDays: archiveDays, in: modelContext
-            )
-            guideEntries = listings.map {
-                GuideEntry(id: $0.id, title: $0.title, start: $0.start, end: $0.end)
-            }
+            let archiveDays = PlayableMedia.isCatchupCapable(stream: stream)
+                ? PlayableMedia.guideArchiveWindowDays(for: stream)
+                : 0
+            let channelId = stream.epgChannelId
+            let container = modelContext.container
+            let entries = await Task.detached(priority: .userInitiated) {
+                TVPlayerContent.guideListings(
+                    channelId: channelId, archiveDays: archiveDays, container: container
+                )
+            }.value
+            guard !Task.isCancelled else { return }
+            guideEntries = entries
         }
 
         // MARK: - Focus
@@ -502,6 +492,19 @@
     }
 
     // MARK: - Row style
+
+    /// Tints the archive glyphs a browser row carries. `TVBrowserRowStyle`'s
+    /// focused row is a solid-white fill with black content, which would
+    /// swallow blue-on-white — the same rule `EPGChannelCell.catchupColor`
+    /// applies in the guide.
+    private struct TVBrowserRowAccent<Content: View>: View {
+        @ViewBuilder var content: Content
+        @Environment(\.isFocused) private var isFocused
+
+        var body: some View {
+            content.foregroundStyle(isFocused ? .black : .blue)
+        }
+    }
 
     /// A full-width list row for the browser columns: white glass highlight
     /// under focus (black content), a faint persistent fill for the selected

--- a/Lume/Views/Player/TVPlayerContent.swift
+++ b/Lume/Views/Player/TVPlayerContent.swift
@@ -112,22 +112,53 @@
             return (try? context.fetch(descriptor)) ?? []
         }
 
+        /// A guide programme as plain values, so the fetch can hand its result
+        /// across actors and the overlay never holds managed `EPGListing`
+        /// objects across focus changes.
+        nonisolated struct GuideEntry: Identifiable, Equatable {
+            let id: String
+            let title: String
+            let start: Date
+            let end: Date
+
+            func isLive(at now: Date) -> Bool {
+                start <= now && now < end
+            }
+
+            func isPast(at now: Date) -> Bool {
+                end <= now
+            }
+        }
+
         /// EPG listings for the in-player guide, oldest first. With
         /// `archiveDays > 0` (a catch-up channel) it reaches back that many days
         /// so already-aired programmes are available to replay; otherwise it
         /// returns only what's airing now and later. The `channelId + end` index
         /// keeps this to a small slice of the guide table.
-        static func guideListings(channelId: String?, archiveDays: Int, in context: ModelContext) -> [EPGListing] {
+        ///
+        /// Runs on its own `ModelContext` off the caller's actor: a catch-up
+        /// channel's window is up to two weeks wide and this fires per debounced
+        /// focus move while video is playing.
+        nonisolated static func guideListings(
+            channelId: String?,
+            archiveDays: Int,
+            container: ModelContainer
+        ) -> [GuideEntry] {
             guard let channelId, !channelId.isEmpty else { return [] }
             let now = Date()
             let earliest = archiveDays > 0
                 ? Calendar.current.date(byAdding: .day, value: -archiveDays, to: now) ?? now
                 : now
-            let descriptor = FetchDescriptor<EPGListing>(
+            var descriptor = FetchDescriptor<EPGListing>(
                 predicate: #Predicate { $0.channelId == channelId && $0.end > earliest },
                 sortBy: [SortDescriptor(\.start)]
             )
-            return (try? context.fetch(descriptor)) ?? []
+            descriptor.propertiesToFetch = [\.id, \.title, \.start, \.end]
+            let context = ModelContext(container)
+            let listings = (try? context.fetch(descriptor)) ?? []
+            return listings.map {
+                GuideEntry(id: $0.id, title: $0.title, start: $0.start, end: $0.end)
+            }
         }
     }
 

--- a/LumePerformanceTests/ParsingBenchmarks.swift
+++ b/LumePerformanceTests/ParsingBenchmarks.swift
@@ -44,7 +44,12 @@ final class ParsingBenchmarks: XCTestCase {
     /// memory failure even if it parsed faster.
     func testM3UParse120kEntries() throws {
         let fixture = try PerfFixtures.writeM3U(entryCount: 120_000, to: scratch)
-        assertFixtureIsSubstantial(fixture, minimumBytes: 5_000_000)
+        // Floor raised 5 MB → 18 MB with the catch-up attributes (issue #203):
+        // the fixture is ~21.5 MB at 120k entries, so the old 5 MB floor would
+        // have waved through a generator that dropped a whole attribute block.
+        // Re-tune it alongside any change to `entryCount` or to the share of
+        // live entries `PerfFixtures.catchupAttributes(index:)` decorates.
+        assertFixtureIsSubstantial(fixture, minimumBytes: 18_000_000)
 
         measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
             var count = 0
@@ -67,9 +72,14 @@ final class ParsingBenchmarks: XCTestCase {
     /// `#EXTINF` attribute scanning in isolation. It runs once per playlist line,
     /// so a constant-factor regression here multiplies by hundreds of thousands.
     func testM3UExtInfAttributeScan() {
+        // Carries the catch-up attributes too — `parseExtInf` now does six more
+        // dictionary lookups per line, and `catchup-days` is deliberately
+        // unquoted because that is the form real playlists emit.
         let line = "#EXTINF:-1 tvg-id=\"ch4711\" tvg-name=\"Channel 4711\" "
             + "tvg-logo=\"https://example.invalid/logo/4711.png\" "
-            + "group-title=\"Sports, News & More\" type=\"video\",Channel 4711 HD, Extra"
+            + "group-title=\"Sports, News & More\" catchup=\"flussonic\" catchup-days=7 "
+            + "catchup-source=\"?utc={utc}&lutc={now}\" "
+            + "type=\"video\",Channel 4711 HD, Extra"
 
         // Assertion outside the loop: per-iteration XCTAsserts would dominate.
         measure(metrics: [XCTClockMetric()]) {
@@ -97,7 +107,10 @@ final class ParsingBenchmarks: XCTestCase {
                 tvgId: index.isMultiple(of: 2) ? "ch\(index)" : nil,
                 logo: nil,
                 group: "Group \(index % 100)",
-                type: nil
+                type: nil,
+                catchupTypeRaw: index.isMultiple(of: 2) ? "flussonic" : nil,
+                catchupDays: index.isMultiple(of: 2) ? 7 : nil,
+                catchupSource: nil
             )
         }
 

--- a/LumePerformanceTests/PerfSupport.swift
+++ b/LumePerformanceTests/PerfSupport.swift
@@ -92,6 +92,27 @@ enum PerfFixtures {
         return directory
     }
 
+    /// The catch-up attribute block for a live entry, keyed off `index` rather
+    /// than the generator so adding it left the existing bucket sequence — and
+    /// therefore the live/movie/series mix — byte-identical.
+    ///
+    /// Half the live entries carry one, spread across the spellings real
+    /// providers emit: the `fs` alias, both `catchup` and `catchup-type`, a
+    /// quoted and an unquoted day count, the bare `tvg-rec` enable flag, and
+    /// both template dialects. `parseExtInf` does a dictionary lookup per key
+    /// whether or not the key is present, so the empty half is measured too.
+    private static func catchupAttributes(index: Int) -> String {
+        switch index % 12 {
+        case 0: " catchup=\"fs\""
+        case 1: " catchup=\"flussonic\" catchup-days=\"7\""
+        case 2: " catchup-type=\"flussonic\" catchup-days=3"
+        case 3: " tvg-rec=\"1\""
+        case 4: " catchup=\"append\" catchup-source=\"?utc={utc}&lutc={now}\""
+        case 5: " catchup=\"default\" catchup-source=\"https://example.invalid/timeshift/user/pass/{utc}/{duration}/\(index).m3u8\""
+        default: ""
+        }
+    }
+
     /// Writes an extended-m3u playlist with `entryCount` entries, mixing live
     /// channels, movies and episode-shaped names in roughly the proportions a
     /// provider export has — so `M3UClassifier` does representative work.
@@ -100,15 +121,18 @@ enum PerfFixtures {
         var generator = SeededGenerator()
         let url = directory.appendingPathComponent("playlist.m3u")
         var text = "#EXTM3U url-tvg=\"https://example.invalid/guide.xml.gz\"\n"
-        text.reserveCapacity(entryCount * 180)
+        // ~180 B/entry measured after the catch-up attributes landed (~170
+        // before); the headroom keeps a 120k-entry generation realloc-free.
+        text.reserveCapacity(entryCount * 200)
 
         for index in 0 ..< entryCount {
             let bucket = Int.random(in: 0 ..< 100, using: &generator)
             let group = "Group \(index % 400)"
             if bucket < 45 {
                 text += "#EXTINF:-1 tvg-id=\"ch\(index)\" tvg-name=\"Channel \(index)\" "
-                text += "tvg-logo=\"https://example.invalid/logo/\(index).png\" group-title=\"\(group)\","
-                text += "Channel \(index) HD\n"
+                text += "tvg-logo=\"https://example.invalid/logo/\(index).png\" group-title=\"\(group)\""
+                text += catchupAttributes(index: index)
+                text += ",Channel \(index) HD\n"
                 text += "https://example.invalid/live/user/pass/\(index).ts\n"
             } else if bucket < 80 {
                 text += "#EXTINF:-1 tvg-id=\"\" tvg-logo=\"https://example.invalid/poster/\(index).jpg\" "

--- a/LumePerformanceTests/PersistenceBenchmarks.swift
+++ b/LumePerformanceTests/PersistenceBenchmarks.swift
@@ -414,6 +414,11 @@ final class PersistenceBenchmarks: XCTestCase {
         if stream.tvArchive != tvArchive { stream.tvArchive = tvArchive }
         let tvArchiveDuration = index % 4 == 0 ? 7 : 0
         if stream.tvArchiveDuration != tvArchiveDuration { stream.tvArchiveDuration = tvArchiveDuration }
+        // The catch-up columns are deliberately absent: only the m3u importer
+        // writes them (`ContentSyncManager.applyM3UCatchupFields`), and these
+        // benchmarks stand in for the Xtream path, whose `applyLiveStreamFields`
+        // never touches them. Writing them here would inflate the per-row cost
+        // against production.
         if stream.num != index { stream.num = index }
         let categoryId = "\(playlistId.uuidString)-live-\(index % 900)"
         if stream.categoryId != categoryId { stream.categoryId = categoryId }

--- a/LumePerformanceTests/README.md
+++ b/LumePerformanceTests/README.md
@@ -61,6 +61,85 @@ Sizes are a compromise between representativeness and a suite that finishes in a
 few minutes. When chasing a specific regression, raise `entryCount` locally —
 don't commit the raise, or every future baseline shifts.
 
+### The m3u fixture shape changed with the catch-up feature (issue #203)
+
+The catch-up branch moved the parser **and** the fixture in the same change, so
+`testM3UParse120kEntries` numbers do not compare across it without care.
+
+What changed in the fixture: `PerfFixtures.writeM3U` now appends
+`catchupAttributes(index:)` to every live entry — a `switch index % 12` whose
+cases 0–5 emit an attribute block and whose default emits nothing, so roughly
+half the live entries carry catch-up attributes and the other half exercise the
+lookup-misses. It is keyed off `index` rather than the LCG on purpose: the draw
+sequence, and therefore the live/movie/series mix, is byte-identical to before.
+`reserveCapacity` went `entryCount * 180` → `* 200` to keep generation
+realloc-free.
+
+Measured at 120k entries: **20,364,387 B (169 B/entry) before,
+21,557,041 B (179 B/entry) after** — 5.9% more input. `assertFixtureIsSubstantial`'s
+floor moved 5 MB → 18 MB in the same change; the point of the raise is that the
+old 5 MB floor was so far below the real size that a generator dropping an entire
+attribute block would still have passed it. Note the old-shape fixture is
+*20.4 MB*, i.e. still above the new 18 MB floor — the floor does not encode the
+new shape, it just stopped being useless.
+
+#### De-confounding the reported 25% regression
+
+The fresh-eyes review measured m3u parse of 120k entries going 0.851 s →
+1.067–1.421 s and attributed it to the extra per-`#EXTINF` dictionary lookups.
+Because code and input moved together, that attribution could not stand as
+measured. The experiment below moved them one at a time, in one process, in one
+run, under the Benchmark configuration on an iPhone 17 Pro simulator.
+
+Method: a throwaway `LegacyM3UParserExperiment.swift` in this target carried
+verbatim copies of the pre-branch parser (commit `76044b6`), of the branch's
+parser *as the review saw it* (before finding 7 added the display-name boundary
+to `parseAttributes`), and of the shipping parser, plus an old-shape
+`writeM3U`. Six cells, `XCTClockMetric`, five iterations each, five back-to-back
+runs on an otherwise idle machine; medians below.
+
+| Cell | Parser | Module | Fixture | Median |
+|---|---|---|---|---|
+| A | shipping | Lume | old shape | **0.954 s** |
+| B | pre-branch (76044b6) | test | old shape | **1.466 s** |
+| C | shipping | Lume | new shape | **0.883 s** |
+| D | as-reviewed | test | new shape | 1.434 s |
+| E | as-reviewed | test | old shape | 1.342 s |
+| F | shipping (verbatim copy) | test | old shape | 1.233 s |
+
+The *module* column is load-bearing and was the trap in the first pass. A
+verbatim copy of the shipping parser compiled into the test target (F) runs
+**29% slower than the identical source called across the module boundary into
+Lume (A)** — 1.233 s vs 0.954 s. Every legacy/as-reviewed cell pays that
+handicap and cells A and C do not, so a raw A-vs-B comparison overstates the
+shipping parser by roughly that much. F is the control that makes the
+same-module rows comparable to each other.
+
+What the cells say:
+
+- **Code, isolated (F vs B, same module, same input): the shipping parser is
+  15.9% *faster* than the pre-branch one.** Finding 7's fix stops attribute
+  scanning at the comma that starts the display name, so `parseAttributes` no
+  longer walks the name of every line — which more than pays for the six extra
+  dictionary lookups the feature added.
+- **Fixture shape, isolated (A vs C): no cost.** 0.954 s on the old shape vs
+  0.883 s on the new one; 5.9% more bytes did not make the parse slower, and
+  the direction is inside the run-to-run spread either way.
+- **Where the review's number came from (D and E):** only the as-reviewed
+  parser reproduces it. D is 1.434 s in the test module; divided by the 1.29
+  module handicap that is ~1.11 s in Lume-module terms, squarely inside the
+  review's 1.067–1.421 s band. Its old-shape twin E is 1.342 s, so the fixture
+  contributed ~7% of that and the attribute scan the rest.
+
+Caveat, so nobody over-reads the table: the pre-branch parser could only be
+measured as a test-module copy — swapping it into `Lume/` does not compile,
+because `ContentSyncManager+M3U` and `ParsingBenchmarks` read the new
+`M3UEntry` catch-up fields. Cross-module rows are therefore comparable to each
+other, not to A and C. B is also the noisiest cell in the set (1.30–1.62 s
+across runs); F and E are stable to a few percent.
+
+Verdict: the 25% is not a real regression in the shipping parser — it was the pre-finding-7 attribute scan, which no longer exists; on identical input in identical module placement the current parser is 15.9% faster than the pre-branch one (F 1.233 s vs B 1.466 s), the new fixture shape costs nothing measurable (A 0.954 s vs C 0.883 s), and there is nothing here to optimize.
+
 ## Stores are on disk, not in memory
 
 `PerfStore.makeOnDiskContainer()` creates a real store file per iteration. An

--- a/LumeTests/Models/EPGGridBuilderTests.swift
+++ b/LumeTests/Models/EPGGridBuilderTests.swift
@@ -134,6 +134,103 @@ struct EPGGridBuilderTests {
         #expect(cells[0].isGap)
     }
 
+    // MARK: - rows(streams:cellsByChannel:timeline:)
+
+    @MainActor
+    private static func row(for stream: LiveStream) -> EPGChannelRow? {
+        EPGGridBuilder.rows(streams: [stream], cellsByChannel: [:], timeline: timeline).first
+    }
+
+    /// The row snapshot and the player's own check must answer identically for
+    /// the same channel and instant — a divergence is a clock icon whose tap
+    /// does nothing.
+    @MainActor
+    private static func expectAgreement(
+        _ row: EPGChannelRow,
+        _ stream: LiveStream,
+        start: Date,
+        now: Date,
+        replayable: Bool,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        #expect(row.isReplayable(start: start, now: now) == replayable, sourceLocation: sourceLocation)
+        #expect(
+            row.isReplayable(start: start, now: now)
+                == PlayableMedia.isCatchupAvailable(stream: stream, start: start, now: now),
+            sourceLocation: sourceLocation
+        )
+    }
+
+    @MainActor
+    @Test func `an xtream archive channel is replayable inside its window`() throws {
+        let stream = LiveStream(id: "row-xtream", streamId: 1, name: "Archive",
+                                tvArchive: 1, tvArchiveDuration: 7)
+        let row = try #require(Self.row(for: stream))
+        let now = Self.windowStart
+
+        #expect(row.catchupCapable)
+        #expect(row.archiveDays == 7)
+        Self.expectAgreement(row, stream, start: now.addingTimeInterval(-3 * 86400), now: now, replayable: true)
+        Self.expectAgreement(row, stream, start: now.addingTimeInterval(-8 * 86400), now: now, replayable: false)
+    }
+
+    @MainActor
+    @Test func `an m3u channel with catchup attributes is replayable`() throws {
+        let stream = LiveStream(id: "row-m3u", streamId: 2, name: "Flussonic",
+                                tvArchive: 1, tvArchiveDuration: 3,
+                                catchupTypeRaw: "flussonic")
+        stream.directURL = "http://example.com/ch/video.m3u8"
+        let row = try #require(Self.row(for: stream))
+        let now = Self.windowStart
+
+        #expect(row.catchupCapable)
+        #expect(row.archiveDays == 3)
+        Self.expectAgreement(row, stream, start: now.addingTimeInterval(-86400), now: now, replayable: true)
+        Self.expectAgreement(row, stream, start: now.addingTimeInterval(-4 * 86400), now: now, replayable: false)
+    }
+
+    @MainActor
+    @Test func `a deep archive row uses the guide's clamped window`() throws {
+        let stream = LiveStream(id: "row-deep", streamId: 4, name: "Deep",
+                                tvArchive: 1, tvArchiveDuration: 30,
+                                catchupTypeRaw: "flussonic")
+        stream.directURL = "http://example.com/ch/video.m3u8"
+        let row = try #require(Self.row(for: stream))
+
+        #expect(row.catchupCapable)
+        #expect(row.archiveDays == PlayableMedia.guideArchiveWindowDays(for: stream))
+        #expect(row.archiveDays == PlayableMedia.maxGuideArchiveDays)
+    }
+
+    @MainActor
+    @Test func `an m3u channel without catchup attributes is not replayable`() throws {
+        let stream = LiveStream(id: "row-m3u-bare", streamId: 3, name: "Plain",
+                                tvArchive: 1, tvArchiveDuration: 7)
+        stream.directURL = "http://example.com/ch/video.m3u8"
+        let row = try #require(Self.row(for: stream))
+        let now = Self.windowStart
+
+        #expect(!row.catchupCapable)
+        Self.expectAgreement(row, stream, start: now.addingTimeInterval(-3600), now: now, replayable: false)
+    }
+
+    @MainActor
+    @Test func `a channel of unknown archive depth uses the guessed window`() throws {
+        let stream = LiveStream(id: "row-unknown", streamId: 4, name: "Depthless",
+                                tvArchive: 1, tvArchiveDuration: 0,
+                                catchupTypeRaw: "fs")
+        stream.directURL = "http://example.com/ch/video.m3u8"
+        let row = try #require(Self.row(for: stream))
+        let now = Self.windowStart
+        let unknown = TimeInterval(PlayableMedia.unknownArchiveDays) * 86400
+
+        #expect(row.catchupCapable)
+        #expect(row.archiveDays == PlayableMedia.unknownArchiveDays)
+        Self.expectAgreement(row, stream, start: now.addingTimeInterval(-2 * 86400), now: now, replayable: true)
+        Self.expectAgreement(row, stream, start: now.addingTimeInterval(-unknown + 3600), now: now, replayable: true)
+        Self.expectAgreement(row, stream, start: now.addingTimeInterval(-unknown - 3600), now: now, replayable: false)
+    }
+
     @Test func `cell ids stay unique so the grid can identify them`() {
         let cells = Self.cells([
             Self.listing("a", "First", startMinutes: 0, endMinutes: 30),

--- a/LumeTests/Models/ModelTests.swift
+++ b/LumeTests/Models/ModelTests.swift
@@ -358,6 +358,9 @@ struct ModelTests {
         #expect(stream.isFavorite == false)
         #expect(stream.tvArchive == 0)
         #expect(stream.tvArchiveDuration == 0)
+        #expect(stream.catchupTypeRaw == nil)
+        #expect(stream.catchupSource == nil)
+        #expect(stream.catchupType == nil)
     }
 
     @Test func `live stream full init`() {
@@ -373,7 +376,9 @@ struct ModelTests {
             tvArchiveDuration: 7,
             isAdult: 0,
             num: 1,
-            categoryId: "cat-1"
+            categoryId: "cat-1",
+            catchupTypeRaw: "flussonic",
+            catchupSource: "http://example.com/ch/archive-{utc}-{duration}.m3u8"
         )
         #expect(stream.streamIcon == "http://example.com/icon.png")
         #expect(stream.epgChannelId == "BBC1")
@@ -383,6 +388,48 @@ struct ModelTests {
         #expect(stream.tvArchiveDuration == 7)
         #expect(stream.categoryId == "cat-1")
         #expect(stream.customOrder == nil)
+        #expect(stream.catchupTypeRaw == "flussonic")
+        #expect(stream.catchupType == .flussonic)
+        #expect(stream.catchupSource == "http://example.com/ch/archive-{utc}-{duration}.m3u8")
+    }
+
+    @Test func `live stream catchup type accessor round-trips`() {
+        let stream = LiveStream(id: "l-catchup", streamId: 9, name: "Archive Channel")
+        stream.catchupType = .flussonic
+        #expect(stream.catchupTypeRaw == "flussonic")
+        #expect(stream.catchupType == .flussonic)
+        stream.catchupType = nil
+        #expect(stream.catchupTypeRaw == nil)
+        #expect(stream.catchupType == nil)
+    }
+
+    @Test func `catchup type parses canonical spellings`() {
+        #expect(CatchupType.parse("default") == .default)
+        #expect(CatchupType.parse("append") == .append)
+        #expect(CatchupType.parse("flussonic") == .flussonic)
+        #expect(CatchupType.parse("xc") == .xc)
+        #expect(CatchupType.parse("shift") == .shift)
+    }
+
+    @Test func `catchup type parses aliases and enable flags`() {
+        #expect(CatchupType.parse("fs") == .flussonic)
+        #expect(CatchupType.parse("FS") == .flussonic)
+        #expect(CatchupType.parse("flussonic_hls") == .flussonic)
+        #expect(CatchupType.parse("Flussonic-HLS") == .flussonic)
+        #expect(CatchupType.parse("xtream") == .xc)
+        #expect(CatchupType.parse("timeshift") == .shift)
+        #expect(CatchupType.parse("1") == .default)
+        #expect(CatchupType.parse("true") == .default)
+        #expect(CatchupType.parse(" append ") == .append)
+    }
+
+    @Test func `catchup type rejects unknown and empty values`() {
+        #expect(CatchupType.parse(nil) == nil)
+        #expect(CatchupType.parse("") == nil)
+        #expect(CatchupType.parse("   ") == nil)
+        #expect(CatchupType.parse("0") == nil)
+        #expect(CatchupType.parse("false") == nil)
+        #expect(CatchupType.parse("sometrandomscheme") == nil)
     }
 
     @Test func `live stream favorite`() {

--- a/LumeTests/Models/PlaylistStreamFormatTests.swift
+++ b/LumeTests/Models/PlaylistStreamFormatTests.swift
@@ -90,7 +90,7 @@ struct PlaylistStreamFormatTests {
             for: stream,
             playlist: makePlaylist(),
             start: Date(timeIntervalSince1970: 1_700_000_000),
-            durationMinutes: 90
+            end: Date(timeIntervalSince1970: 1_700_005_400)
         ))
         #expect(url.absoluteString.hasSuffix("/777.ts"))
     }
@@ -101,13 +101,13 @@ struct PlaylistStreamFormatTests {
             for: stream,
             playlist: makePlaylist(format: .mpegTS),
             start: Date(timeIntervalSince1970: 1_700_000_000),
-            durationMinutes: 90
+            end: Date(timeIntervalSince1970: 1_700_005_400)
         ))
         let hlsURL = try #require(makeClient().buildCatchupURL(
             for: stream,
             playlist: makePlaylist(format: .hls),
             start: Date(timeIntervalSince1970: 1_700_000_000),
-            durationMinutes: 90
+            end: Date(timeIntervalSince1970: 1_700_005_400)
         ))
         #expect(tsURL.absoluteString.hasSuffix("/777.ts"))
         #expect(hlsURL.absoluteString.hasSuffix("/777.m3u8"))

--- a/LumeTests/Services/M3UCatchupURLTests.swift
+++ b/LumeTests/Services/M3UCatchupURLTests.swift
@@ -1,0 +1,299 @@
+import Foundation
+@testable import Lume
+import Testing
+
+struct M3UCatchupURLTests {
+    /// Frozen so every expectation below can be an exact string.
+    private let start = Date(timeIntervalSince1970: 1_700_000_000)
+    private var end: Date {
+        start.addingTimeInterval(3600)
+    }
+
+    private var now: Date {
+        start.addingTimeInterval(7200)
+    }
+
+    private func build(
+        _ live: String,
+        _ type: CatchupType,
+        source: String? = nil
+    ) -> URL? {
+        guard let liveURL = URL(string: live) else { return nil }
+        return M3UCatchupURL.build(liveURL: liveURL, type: type, source: source, start: start, end: end, now: now)
+    }
+
+    // MARK: - Flussonic
+
+    @Test func `flussonic rewrites the video filename`() {
+        let url = build("http://example.com:8080/ch1/video.m3u8", .flussonic)
+        #expect(url?.absoluteString == "http://example.com:8080/ch1/video-1700000000-3600.m3u8")
+    }
+
+    @Test func `flussonic rewrites the index variant and keeps the query`() {
+        let url = build("http://example.com/ch1/index.m3u8?token=abc", .flussonic)
+        #expect(url?.absoluteString == "http://example.com/ch1/index-1700000000-3600.m3u8?token=abc")
+    }
+
+    /// Documented limitation: `…/mpegts` has no filename to rewrite and no
+    /// derivable archive path, so it stays unbuildable and gets no badge.
+    @Test func `flussonic rejects a URL with no filename extension`() throws {
+        #expect(build("http://example.com/ch1/mpegts", .flussonic) == nil)
+        let liveURL = try #require(URL(string: "http://example.com/ch1/mpegts"))
+        #expect(M3UCatchupURL.canBuild(type: .flussonic, source: nil, liveURL: liveURL) == false)
+    }
+
+    @Test func `flussonic prefers an explicit catch-up source over the filename rewrite`() {
+        let url = build(
+            "http://example.com/ch1/video.m3u8",
+            .flussonic,
+            source: "http://archive.example.com/ch1/{utc}-{duration}.m3u8"
+        )
+        #expect(url?.absoluteString == "http://archive.example.com/ch1/1700000000-3600.m3u8")
+    }
+
+    @Test func `flussonic resolves a relative catch-up source against the live URL`() {
+        let url = build(
+            "http://example.com:8080/ch1/index.m3u8?token=abc",
+            .flussonic,
+            source: "?utc={utc}&duration={duration}"
+        )
+        #expect(url?.absoluteString == "http://example.com:8080/ch1/index.m3u8?token=abc&utc=1700000000&duration=3600")
+    }
+
+    /// A source that cannot become a playable URL must not make a channel worse
+    /// off than one that shipped no source at all.
+    @Test func `flussonic falls back to the filename rewrite for an unusable source`() {
+        let url = build("http://example.com/ch1/video.m3u8", .flussonic, source: "plugin://foo/{utc}")
+        #expect(url?.absoluteString == "http://example.com/ch1/video-1700000000-3600.m3u8")
+        #expect(build("http://example.com/ch1/mpegts", .flussonic, source: "plugin://foo/{utc}") == nil)
+    }
+
+    @Test func `flussonic rescues an extension-less live URL when a source is given`() {
+        let url = build(
+            "http://example.com/ch1/mpegts",
+            .flussonic,
+            source: "/ch1/archive-{utc}-{duration}.m3u8"
+        )
+        #expect(url?.absoluteString == "http://example.com/ch1/archive-1700000000-3600.m3u8")
+    }
+
+    @Test func `canBuild agrees with build for flussonic sources`() throws {
+        let liveURL = try #require(URL(string: "http://example.com/ch1/video.m3u8"))
+        let extensionLess = try #require(URL(string: "http://example.com/ch1/mpegts"))
+        #expect(M3UCatchupURL.canBuild(
+            type: .flussonic, source: "http://archive.example.com/{utc}.m3u8", liveURL: liveURL
+        ))
+        #expect(M3UCatchupURL.canBuild(type: .flussonic, source: "?utc={utc}", liveURL: liveURL))
+        #expect(M3UCatchupURL.canBuild(type: .flussonic, source: "plugin://foo", liveURL: liveURL))
+        #expect(M3UCatchupURL.canBuild(type: .flussonic, source: "plugin://foo", liveURL: extensionLess) == false)
+        #expect(M3UCatchupURL.canBuild(type: .flussonic, source: "/dvr/{utc}.m3u8", liveURL: extensionLess))
+    }
+
+    // MARK: - Append
+
+    @Test func `append merges onto a URL that already has a query`() {
+        let url = build(
+            "http://example.com/live/ch1.m3u8?token=abc",
+            .append,
+            source: "?utc={utc}&lutc={now}"
+        )
+        #expect(url?.absoluteString == "http://example.com/live/ch1.m3u8?token=abc&utc=1700000000&lutc=1700007200")
+    }
+
+    @Test func `append starts a query on a URL that has none`() {
+        let url = build("http://example.com/live/ch1.m3u8", .append, source: "&utc={utc}")
+        #expect(url?.absoluteString == "http://example.com/live/ch1.m3u8?utc=1700000000")
+    }
+
+    @Test func `append without a source is not buildable`() {
+        #expect(build("http://example.com/live/ch1.m3u8", .append) == nil)
+    }
+
+    /// A whole URL under `catchup="append"` is a mis-tagged dialect: glued on it
+    /// would become `…ch1.tshttp://archive…`, which still passes the http/host
+    /// check and would badge a dead tap.
+    @Test func `append reads an absolute source as a replacement URL`() throws {
+        let url = build(
+            "http://live.example.com/ch1.ts",
+            .append,
+            source: "http://archive.example.com/x-{utc}.m3u8"
+        )
+        #expect(url?.absoluteString == "http://archive.example.com/x-1700000000.m3u8")
+
+        let liveURL = try #require(URL(string: "http://live.example.com/ch1.ts"))
+        #expect(M3UCatchupURL.canBuild(type: .append, source: "http://archive.example.com/x.m3u8", liveURL: liveURL))
+        #expect(M3UCatchupURL.canBuild(type: .append, source: "plugin://archive/{utc}", liveURL: liveURL) == false)
+    }
+
+    @Test func `append rejects a non-http absolute source`() {
+        #expect(build("http://live.example.com/ch1.ts", .append, source: "plugin://archive/{utc}") == nil)
+        #expect(build("http://live.example.com/ch1.ts", .append, source: "rtmp://archive/{utc}") == nil)
+    }
+
+    /// A network-path reference starts a new absolute URL too, it just borrows
+    /// the live URL's scheme — so `append` must resolve it rather than glue it
+    /// on, and must read it the same way `default` does.
+    @Test func `append resolves a protocol-relative source instead of gluing it on`() throws {
+        let url = build(
+            "http://live.example.com/ch1.ts",
+            .append,
+            source: "//archive.example.com/x-{utc}.m3u8"
+        )
+        #expect(url?.absoluteString == "http://archive.example.com/x-1700000000.m3u8")
+
+        let liveURL = try #require(URL(string: "http://live.example.com/ch1.ts"))
+        #expect(M3UCatchupURL.canBuild(
+            type: .append, source: "//archive.example.com/x.m3u8", liveURL: liveURL
+        ))
+        #expect(
+            build("http://live.example.com/ch1.ts", .default, source: "//archive.example.com/x-{utc}.m3u8")
+                == url
+        )
+    }
+
+    // MARK: - Template expansion
+
+    @Test func `default expands the full placeholder set`() {
+        let url = build(
+            "http://example.com/ch1/archive.m3u8",
+            .default,
+            source: "http://example.com/dvr?utc={utc}&u=${utc}&s={start}&e={end}&d={duration}&o={offset}&n={now}&l=${lutc}"
+        )
+        #expect(url?.absoluteString == """
+        http://example.com/dvr?utc=1700000000&u=1700000000&s=1700000000&e=1700003600\
+        &d=3600&o=7200&n=1700007200&l=1700007200
+        """)
+    }
+
+    @Test func `shift expands the same template`() {
+        let url = build(
+            "http://example.com/ch1/live.ts",
+            .shift,
+            source: "http://example.com/shift/{utc}/{duration}.ts"
+        )
+        #expect(url?.absoluteString == "http://example.com/shift/1700000000/3600.ts")
+    }
+
+    @Test func `unrecognised placeholders are left untouched`() throws {
+        let url = try #require(build(
+            "http://example.com/ch1/live.ts",
+            .default,
+            source: "http://example.com/dvr?u={utc}&x={bogus}"
+        ))
+        let string = url.absoluteString
+        #expect(string.contains("u=1700000000"))
+        // `URL(string:)` percent-encodes the braces it is handed; either
+        // spelling means the placeholder reached the provider unchanged.
+        #expect(string.contains("x=%7Bbogus%7D") || string.contains("x={bogus}"))
+    }
+
+    // MARK: - Relative catch-up sources
+
+    @Test func `default merges a bare-query source onto the live URL`() {
+        let url = build(
+            "http://example.com/live/ch1.m3u8?token=abc",
+            .default,
+            source: "?utc={utc}&lutc={now}"
+        )
+        #expect(url?.absoluteString == "http://example.com/live/ch1.m3u8?token=abc&utc=1700000000&lutc=1700007200")
+    }
+
+    @Test func `default resolves a leading-slash source against the live host`() {
+        let url = build(
+            "http://example.com:8080/live/ch1.m3u8",
+            .default,
+            source: "/dvr/ch1-{utc}-{duration}.m3u8"
+        )
+        #expect(url?.absoluteString == "http://example.com:8080/dvr/ch1-1700000000-3600.m3u8")
+    }
+
+    @Test func `default rejects a non-http source`() {
+        #expect(build("http://example.com/live/ch1.m3u8", .default, source: "plugin://foo/{utc}") == nil)
+        #expect(build("http://example.com/live/ch1.m3u8", .default, source: "rtmp://example.com/dvr") == nil)
+    }
+
+    /// Without a positive shape test these resolve against the live URL into
+    /// `http://example.com/garbage` — absolute, http, hosted, and so a badge on
+    /// a channel whose catch-up tap 404s.
+    @Test func `default rejects a scheme-less source that is not a relative path`() {
+        #expect(build("http://example.com/live/ch1.m3u8", .default, source: "garbage") == nil)
+        #expect(build("http://example.com/live/ch1.m3u8", .default, source: "not a url") == nil)
+        #expect(build("http://example.com/live/ch1.m3u8", .default, source: "://{utc}") == nil)
+    }
+
+    @Test func `default resolves dot-relative sources against the live URL`() {
+        let url = build("http://example.com/live/ch1.m3u8", .default, source: "./dvr-{utc}.m3u8")
+        #expect(url?.absoluteString == "http://example.com/live/dvr-1700000000.m3u8")
+        let parent = build("http://example.com/live/ch1.m3u8", .default, source: "../dvr/{utc}.m3u8")
+        #expect(parent?.absoluteString == "http://example.com/dvr/1700000000.m3u8")
+    }
+
+    @Test func `canBuild agrees with build for relative sources`() throws {
+        let liveURL = try #require(URL(string: "http://example.com/live/ch1.m3u8?token=abc"))
+        #expect(M3UCatchupURL.canBuild(type: .default, source: "?utc={utc}&lutc={now}", liveURL: liveURL))
+        #expect(M3UCatchupURL.canBuild(type: .default, source: "/dvr/{utc}.m3u8", liveURL: liveURL))
+        #expect(M3UCatchupURL.canBuild(type: .default, source: "./dvr/{utc}.m3u8", liveURL: liveURL))
+        #expect(M3UCatchupURL.canBuild(type: .default, source: "plugin://foo/{utc}", liveURL: liveURL) == false)
+        #expect(M3UCatchupURL.canBuild(type: .default, source: "garbage", liveURL: liveURL) == false)
+        #expect(M3UCatchupURL.canBuild(type: .default, source: "not a url", liveURL: liveURL) == false)
+        #expect(M3UCatchupURL.canBuild(type: .shift, source: "plugin://foo", liveURL: liveURL) == false)
+    }
+
+    // MARK: - XC
+
+    @Test func `xc recovers credentials from the channel path`() throws {
+        let url = try #require(build("http://example.com:8080/live/testuser/testpass/777.ts", .xc))
+        let string = url.absoluteString
+        #expect(string.hasPrefix("http://example.com:8080/timeshift/testuser/testpass/60/"))
+        #expect(string.hasSuffix("/777.ts"))
+        #expect(string.range(of: #"/\d{4}-\d{2}-\d{2}:\d{2}-\d{2}/777\.ts$"#, options: .regularExpression) != nil)
+    }
+
+    @Test func `xc accepts the live-less path shape and keeps the container`() throws {
+        let url = try #require(build("http://example.com/testuser/testpass/778.m3u8", .xc))
+        #expect(url.absoluteString.hasPrefix("http://example.com/timeshift/testuser/testpass/60/"))
+        #expect(url.absoluteString.hasSuffix("/778.m3u8"))
+    }
+
+    /// A token query on the live URL is what a protected panel authorises the
+    /// session with; losing it turns the rebuilt timeshift URL into a 403.
+    @Test func `xc keeps the live URL token query and drops the fragment`() throws {
+        let url = try #require(build("http://example.com:8080/live/testuser/testpass/777.ts?token=a%2Bb&sid=9#top", .xc))
+        #expect(url.absoluteString.hasPrefix("http://example.com:8080/timeshift/testuser/testpass/60/"))
+        #expect(url.absoluteString.hasSuffix("/777.ts?token=a%2Bb&sid=9"))
+        #expect(url.fragment == nil)
+    }
+
+    @Test func `xc returns nil for a path it cannot parse`() {
+        #expect(build("http://example.com/stream/777.ts", .xc) == nil)
+        #expect(build("http://example.com/live/testuser/testpass/movie.ts", .xc) == nil)
+    }
+
+    // MARK: - Guards
+
+    @Test func `non-positive duration is not buildable`() throws {
+        let liveURL = try #require(URL(string: "http://example.com/ch1/video.m3u8"))
+        #expect(M3UCatchupURL.build(
+            liveURL: liveURL, type: .flussonic, source: nil, start: start, end: start, now: now
+        ) == nil)
+    }
+
+    @Test func `a garbage dialect never reaches the builder`() {
+        #expect(CatchupType.parse("garbage") == nil)
+        #expect(CatchupType.parse("fs") == .flussonic)
+    }
+
+    // MARK: - canBuild
+
+    @Test func `canBuild agrees with build`() throws {
+        let flussonic = try #require(URL(string: "http://example.com/ch1/video.m3u8"))
+        #expect(M3UCatchupURL.canBuild(type: .flussonic, source: nil, liveURL: flussonic))
+        #expect(M3UCatchupURL.canBuild(type: .default, source: nil, liveURL: flussonic) == false)
+        #expect(M3UCatchupURL.canBuild(type: .default, source: "  ", liveURL: flussonic) == false)
+        #expect(M3UCatchupURL.canBuild(type: .append, source: "?utc={utc}", liveURL: flussonic))
+        #expect(M3UCatchupURL.canBuild(type: .xc, source: nil, liveURL: flussonic) == false)
+        #expect(try M3UCatchupURL.canBuild(
+            type: .xc, source: nil, liveURL: #require(URL(string: "http://example.com/live/u/p/9.ts"))
+        ))
+    }
+}

--- a/LumeTests/Services/M3UParserTests.swift
+++ b/LumeTests/Services/M3UParserTests.swift
@@ -112,6 +112,131 @@ struct M3UParserTests {
         #expect(entries.first?.name == "Named via tvg")
     }
 
+    @Test func `reads the catch-up spellings providers ship`() throws {
+        let playlist = """
+        #EXTM3U
+        #EXTINF:-1 tvg-id="a" catchup="fs",Chan A
+        http://example.com/a/video.m3u8
+        #EXTINF:-1 tvg-id="b" catchup="flussonic" catchup-days="7",Chan B
+        http://example.com/b/video.m3u8
+        #EXTINF:-1 tvg-id="c" catchup-type="flussonic" timeshift="3",Chan C
+        http://example.com/c/video.m3u8
+        #EXTINF:-1 tvg-id="d" tvg-rec="1" catchup-days="6" catchup-type="flussonic",Chan D
+        http://example.com/d/video.m3u8
+        #EXTINF:-1 tvg-id="e" tvg-rec="1",Chan E
+        http://example.com/e/video.m3u8
+        #EXTINF:-1 tvg-id="f",Chan F
+        http://example.com/f/video.m3u8
+        """
+        let entries = try parseAll(playlist).entries
+        #expect(entries.count == 6)
+
+        #expect(entries[0].catchupTypeRaw == "fs")
+        #expect(entries[0].catchupDays == nil)
+        #expect(CatchupType.parse(entries[0].catchupTypeRaw) == .flussonic)
+
+        #expect(entries[1].catchupTypeRaw == "flussonic")
+        #expect(entries[1].catchupDays == 7)
+
+        #expect(entries[2].catchupTypeRaw == "flussonic")
+        #expect(entries[2].catchupDays == 3)
+
+        #expect(entries[3].name == "Chan D")
+        #expect(entries[3].catchupTypeRaw == "flussonic")
+        #expect(entries[3].catchupDays == 6)
+
+        // A bare enable flag declares catch-up but no depth.
+        #expect(CatchupType.parse(entries[4].catchupTypeRaw) == .default)
+        #expect(entries[4].catchupDays == nil)
+
+        #expect(entries[5].catchupTypeRaw == nil)
+        #expect(entries[5].catchupDays == nil)
+        #expect(entries[5].catchupSource == nil)
+    }
+
+    @Test func `catch-up type prefers catchup-type over catchup`() throws {
+        let playlist = """
+        #EXTM3U
+        #EXTINF:-1 catchup="append" catchup-type="shift",Chan
+        http://example.com/x.ts
+        """
+        let entries = try parseAll(playlist).entries
+        #expect(entries.first?.catchupTypeRaw == "shift")
+    }
+
+    @Test func `unquoted attribute values are read`() throws {
+        let playlist = """
+        #EXTM3U
+        #EXTINF:-1 tvg-id="a" catchup=flussonic catchup-days=1,Chan A
+        http://example.com/a/video.m3u8
+        #EXTINF:-1 catchup=shift timeshift=2,Chan B
+        http://example.com/b/video.m3u8
+        """
+        let entries = try parseAll(playlist).entries
+        #expect(entries[0].catchupTypeRaw == "flussonic")
+        #expect(entries[0].catchupDays == 1)
+        #expect(entries[0].name == "Chan A")
+        #expect(entries[1].catchupTypeRaw == "shift")
+        #expect(entries[1].catchupDays == 2)
+        #expect(entries[1].name == "Chan B")
+    }
+
+    @Test func `an equals sign in the display name is not an attribute`() throws {
+        let playlist = """
+        #EXTM3U
+        #EXTINF:-1 tvg-id="a",Sky F1=HD
+        http://example.com/a.ts
+        #EXTINF:-1,Sky F1=HD
+        http://example.com/b.ts
+        """
+        let entries = try parseAll(playlist).entries
+        #expect(entries[0].name == "Sky F1=HD")
+        #expect(entries[0].tvgId == "a")
+        #expect(M3UParser.parseAttributes("-1 tvg-id=\"a\",Sky F1=HD")["F1"] == nil)
+        #expect(entries[1].name == "Sky F1=HD")
+        #expect(M3UParser.parseAttributes("-1,Sky F1=HD").isEmpty)
+    }
+
+    @Test func `real unquoted attributes survive an equals sign in the name`() throws {
+        let playlist = """
+        #EXTM3U
+        #EXTINF:-1 tvg-id="a" catchup=shift catchup-days=3,Sky F1=HD
+        http://example.com/a.ts
+        """
+        let entries = try parseAll(playlist).entries
+        let entry = try #require(entries.first)
+        #expect(entry.name == "Sky F1=HD")
+        #expect(entry.catchupTypeRaw == "shift")
+        #expect(entry.catchupDays == 3)
+    }
+
+    @Test func `catch-up source keeps its query template verbatim`() throws {
+        let source = "http://example.com/live/1.ts?utc={utc}&lutc={lutc}&d={duration},extra"
+        let playlist = """
+        #EXTM3U
+        #EXTINF:-1 tvg-id="a" catchup="default" catchup-source="\(source)" catchup-days="5",Chan A
+        http://example.com/live/1.ts
+        """
+        let entries = try parseAll(playlist).entries
+        let entry = try #require(entries.first)
+        #expect(entry.catchupSource == source)
+        #expect(entry.catchupTypeRaw == "default")
+        #expect(entry.catchupDays == 5)
+        #expect(entry.name == "Chan A")
+    }
+
+    @Test func `a space before the name comma still yields the display name`() throws {
+        let playlist = """
+        #EXTM3U
+        #EXTINF:-1 tvg-id="a" catchup-days="1" ,Chan A
+        http://example.com/a.ts
+        """
+        let entries = try parseAll(playlist).entries
+        let entry = try #require(entries.first)
+        #expect(entry.name == "Chan A")
+        #expect(entry.catchupDays == 1)
+    }
+
     /// Exercises the chunked reader's carry logic: the file is much larger
     /// than one 512 KB read, so lines straddle chunk boundaries.
     @Test func `parses a large playlist across chunk boundaries`() throws {

--- a/LumeTests/Services/M3USyncTests.swift
+++ b/LumeTests/Services/M3USyncTests.swift
@@ -23,9 +23,11 @@ struct M3USyncTests {
 
     private let mixedPlaylist = """
     #EXTM3U url-tvg="http://example.com/embedded-guide.xml"
-    #EXTINF:-1 tvg-id="news.1" tvg-logo="http://example.com/news1.png" group-title="News",News One
+    #EXTINF:-1 tvg-id="news.1" tvg-logo="http://example.com/news1.png" catchup="flussonic" \
+    catchup-days="7" catchup-source="http://example.com/live/news1.ts?utc={utc}&lutc={now}" \
+    group-title="News",News One
     http://example.com/live/news1.ts
-    #EXTINF:-1 tvg-id="sport.1" group-title="Sports",Sport One
+    #EXTINF:-1 tvg-id="sport.1" catchup="fs" group-title="Sports",Sport One
     http://example.com/live/sport1.m3u8
     #EXTINF:-1 group-title="General",Ungrouped Extras
     http://example.com/live/extra
@@ -71,8 +73,21 @@ struct M3USyncTests {
         #expect(newsOne.epgChannelId == "news.1")
         #expect(newsOne.streamIcon == "http://example.com/news1.png")
         #expect(newsOne.categoryId == "\(playlistId.uuidString)-live-News")
+        #expect(newsOne.tvArchive == 1)
+        #expect(newsOne.tvArchiveDuration == 7)
+        #expect(newsOne.catchupType == .flussonic)
+        // Stored verbatim: the placeholders are expanded at play time, so a
+        // template baked in here would carry a stale `now` forever.
+        #expect(newsOne.catchupSource == "http://example.com/live/news1.ts?utc={utc}&lutc={now}")
+        let sportOne = try #require(streams.first { $0.name == "Sport One" })
+        #expect(sportOne.tvArchive == 1)
+        #expect(sportOne.catchupType == .flussonic, "`fs` is the Flussonic alias")
+        #expect(sportOne.tvArchiveDuration == 0, "no declared depth stays 0 rather than an invented day count")
         let ungrouped = try #require(streams.first { $0.name == "Ungrouped Extras" })
         #expect(ungrouped.categoryId == "\(playlistId.uuidString)-live-General")
+        #expect(ungrouped.tvArchive == 0)
+        #expect(ungrouped.catchupTypeRaw == nil)
+        #expect(ungrouped.catchupSource == nil)
 
         let movies = try context.fetch(FetchDescriptor<Movie>())
         #expect(movies.count == 2)
@@ -131,8 +146,90 @@ struct M3USyncTests {
 
         let stream = try #require(try context.fetch(FetchDescriptor<LiveStream>()).first { $0.name == "News One" })
         #expect(stream.isFavorite, "Re-sync must not wipe favorites")
+        #expect(stream.tvArchive == 1)
+        #expect(stream.tvArchiveDuration == 7)
         let category = try #require(try context.fetch(FetchDescriptor<Lume.Category>()).first { $0.name == "News" })
         #expect(category.isHidden, "Re-sync must not wipe hidden state")
+    }
+
+    /// `mixedPlaylist`'s two archive channels with every catch-up attribute
+    /// stripped, on the same URLs — so a re-sync updates those rows instead of
+    /// pruning and re-inserting them.
+    private let archivelessPlaylist = """
+    #EXTM3U
+    #EXTINF:-1 tvg-id="news.1" group-title="News",News One
+    http://example.com/live/news1.ts
+    #EXTINF:-1 tvg-id="sport.1" group-title="Sports",Sport One
+    http://example.com/live/sport1.m3u8
+    """
+
+    @Test func `re-sync clears catch-up the provider stops advertising`() async throws {
+        let container = try makeTestContainer()
+        let fileURL = try writeTempFile(mixedPlaylist, ext: "m3u")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let playlist = try makePlaylist(container: container, fileURL: fileURL)
+
+        let manager = ContentSyncManager(modelContainer: container)
+        try await manager.syncPlaylist(playlist)
+
+        do {
+            let context = ModelContext(container)
+            let stream = try #require(try context.fetch(FetchDescriptor<LiveStream>()).first { $0.name == "News One" })
+            #expect(stream.tvArchive == 1)
+            stream.isFavorite = true
+            try context.save()
+        }
+
+        try archivelessPlaylist.write(to: fileURL, atomically: true, encoding: .utf8)
+        try await manager.syncPlaylist(playlist)
+
+        let context = ModelContext(container)
+        let stream = try #require(try context.fetch(FetchDescriptor<LiveStream>()).first { $0.name == "News One" })
+        #expect(stream.isFavorite, "The favorite proves this is the same row, not a re-insert")
+        #expect(stream.tvArchive == 0)
+        #expect(stream.tvArchiveDuration == 0)
+        #expect(stream.catchupTypeRaw == nil)
+        #expect(stream.catchupSource == nil)
+    }
+
+    /// Channels that declare an archive we cannot build a URL for, next to one
+    /// we can.
+    private let unbuildablePlaylist = """
+    #EXTM3U
+    #EXTINF:-1 catchup="quantum" catchup-days="5" group-title="News",Unknown Scheme
+    http://example.com/live/unknown.ts
+    #EXTINF:-1 catchup="default" catchup-days="5" group-title="News",No Source
+    http://example.com/live/nosource.ts
+    #EXTINF:-1 catchup="shift" catchup-source="http://example.com/live/shift.ts?utc={utc}&dur={duration}" group-title="News",Shift Source
+    http://example.com/live/shift.ts
+    """
+
+    @Test func `an archive we cannot build a URL for is never badged`() async throws {
+        let container = try makeTestContainer()
+        let fileURL = try writeTempFile(unbuildablePlaylist, ext: "m3u")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let playlist = try makePlaylist(container: container, fileURL: fileURL)
+
+        let manager = ContentSyncManager(modelContainer: container)
+        try await manager.syncPlaylist(playlist)
+
+        let context = ModelContext(container)
+        let streams = try context.fetch(FetchDescriptor<LiveStream>())
+
+        let unknown = try #require(streams.first { $0.name == "Unknown Scheme" })
+        #expect(unknown.tvArchive == 0, "An unrecognised dialect must not light up a dead affordance")
+        #expect(unknown.tvArchiveDuration == 0)
+        #expect(unknown.catchupTypeRaw == nil)
+
+        let noSource = try #require(streams.first { $0.name == "No Source" })
+        #expect(noSource.tvArchive == 0, "`default` without a catchup-source has nothing to expand")
+        #expect(noSource.tvArchiveDuration == 0, "The declared day count is dropped with the unbuildable scheme")
+        #expect(noSource.catchupTypeRaw == nil)
+
+        let shift = try #require(streams.first { $0.name == "Shift Source" })
+        #expect(shift.tvArchive == 1)
+        #expect(shift.catchupType == .shift)
+        #expect(shift.catchupSource == "http://example.com/live/shift.ts?utc={utc}&dur={duration}")
     }
 
     /// A reduced version of `mixedPlaylist`: Sport One (live), The Godfather

--- a/LumeTests/Services/PlayableMediaTests.swift
+++ b/LumeTests/Services/PlayableMediaTests.swift
@@ -7,6 +7,14 @@ struct PlayableMediaTests {
         Playlist(name: "Test", serverURL: "http://example.com:8080", username: "user", password: "pass")
     }
 
+    private func makeM3UPlaylist() -> Playlist {
+        Playlist(name: "M3U", m3uURL: "http://example.com/get.php?username=test&password=test")
+    }
+
+    private func makeStalkerPlaylist() -> Playlist {
+        Playlist(name: "Portal", portalURL: "http://example.com/c/", macAddress: "00:1A:79:00:00:01")
+    }
+
     // MARK: - from(movie:playlist:client:)
 
     @Test func `from movie creates media`() throws {
@@ -134,10 +142,59 @@ struct PlayableMediaTests {
         #expect(media == nil)
     }
 
-    @Test func `catchup returns nil for m3u direct stream`() {
-        let playlist = makePlaylist()
+    @Test func `catchup returns nil for m3u channel without catchup attributes`() {
+        let playlist = makeM3UPlaylist()
         let stream = LiveStream(id: "l-5", streamId: 302, name: "M3U", tvArchive: 1, tvArchiveDuration: 7)
         stream.directURL = "http://example.com/live/stream.m3u8"
+        let media = PlayableMedia.catchup(
+            stream: stream, playlist: playlist, programTitle: "x",
+            start: Date(), end: Date().addingTimeInterval(3600)
+        )
+        #expect(media == nil)
+    }
+
+    @Test func `catchup builds media for m3u flussonic channel`() throws {
+        let playlist = makeM3UPlaylist()
+        let stream = LiveStream(id: "l-5b", streamId: 303, name: "Flussonic",
+                                tvArchive: 1, tvArchiveDuration: 0,
+                                catchupTypeRaw: "fs")
+        stream.directURL = "http://example.com/ch/video.m3u8"
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let media = try #require(PlayableMedia.catchup(
+            stream: stream, playlist: playlist, programTitle: "Evening News",
+            start: start, end: start.addingTimeInterval(3600)
+        ))
+        #expect(media.url.absoluteString == "http://example.com/ch/video-1700000000-3600.m3u8")
+        #expect(media.id == "catchup-l-5b-1700000000")
+        #expect(media.kind == .vod)
+        #expect(media.startTime == 0)
+        #expect(media.contentRef == .live("l-5b"))
+        #expect(media.channelScope == nil)
+    }
+
+    @Test func `catchup ignores the playlist stream format rewrite`() throws {
+        let playlist = makeM3UPlaylist()
+        playlist.streamFormat = .mpegTS
+        let stream = LiveStream(id: "l-5c", streamId: 304, name: "Flussonic",
+                                tvArchive: 1, tvArchiveDuration: 3,
+                                catchupTypeRaw: "flussonic")
+        stream.directURL = "http://example.com/ch/index.m3u8"
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let media = try #require(PlayableMedia.catchup(
+            stream: stream, playlist: playlist, programTitle: "x",
+            start: start, end: start.addingTimeInterval(1800)
+        ))
+        #expect(media.url.absoluteString == "http://example.com/ch/index-1700000000-1800.m3u8")
+    }
+
+    @Test func `catchup returns nil for stalker channel`() {
+        let playlist = makeStalkerPlaylist()
+        let stream = LiveStream(id: "l-5d", streamId: 305, name: "Portal",
+                                tvArchive: 1, tvArchiveDuration: 7,
+                                catchupTypeRaw: "flussonic")
+        stream.directURL = "ffmpeg http://localhost/ch/video.m3u8"
         let media = PlayableMedia.catchup(
             stream: stream, playlist: playlist, programTitle: "x",
             start: Date(), end: Date().addingTimeInterval(3600)
@@ -163,12 +220,46 @@ struct PlayableMediaTests {
         #expect(!PlayableMedia.isCatchupAvailable(stream: stream, start: start, now: now))
     }
 
-    @Test func `catchup availability treats zero duration as one day`() {
+    @Test func `xtream zero duration keeps the one day window`() {
         let stream = LiveStream(id: "l-8", streamId: 305, name: "Archive",
                                 tvArchive: 1, tvArchiveDuration: 0)
         let now = Date(timeIntervalSince1970: 1_700_000_000)
+        #expect(PlayableMedia.archiveWindowDays(for: stream) == 1)
         #expect(PlayableMedia.isCatchupAvailable(stream: stream, start: now.addingTimeInterval(-3600), now: now))
         #expect(!PlayableMedia.isCatchupAvailable(stream: stream, start: now.addingTimeInterval(-2 * 86400), now: now))
+    }
+
+    @Test func `m3u zero duration opens the unknown depth window`() {
+        let stream = LiveStream(id: "l-8b", streamId: 310, name: "Archive",
+                                tvArchive: 1, tvArchiveDuration: 0,
+                                catchupTypeRaw: "flussonic")
+        stream.directURL = "http://example.com/ch/video.m3u8"
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let inside = -TimeInterval(PlayableMedia.unknownArchiveDays) * 86400 + 3600
+        let outside = -TimeInterval(PlayableMedia.unknownArchiveDays) * 86400 - 3600
+        #expect(PlayableMedia.archiveWindowDays(for: stream) == PlayableMedia.unknownArchiveDays)
+        #expect(PlayableMedia.isCatchupAvailable(stream: stream, start: now.addingTimeInterval(-2 * 86400), now: now))
+        #expect(PlayableMedia.isCatchupAvailable(stream: stream, start: now.addingTimeInterval(inside), now: now))
+        #expect(!PlayableMedia.isCatchupAvailable(stream: stream, start: now.addingTimeInterval(outside), now: now))
+    }
+
+    @Test func `xtream declared duration keeps its own window`() {
+        let stream = LiveStream(id: "l-8c", streamId: 311, name: "Archive",
+                                tvArchive: 1, tvArchiveDuration: 14)
+        #expect(PlayableMedia.archiveWindowDays(for: stream) == 14)
+    }
+
+    @Test func `a deep archive is clamped for the guide but not for playback`() {
+        let stream = LiveStream(id: "l-8d", streamId: 312, name: "Deep Archive",
+                                tvArchive: 1, tvArchiveDuration: 30)
+        #expect(PlayableMedia.archiveWindowDays(for: stream) == 30)
+        #expect(PlayableMedia.guideArchiveWindowDays(for: stream) == PlayableMedia.maxGuideArchiveDays)
+    }
+
+    @Test func `a fortnight archive survives the guide clamp unnarrowed`() {
+        let stream = LiveStream(id: "l-8e", streamId: 313, name: "Archive",
+                                tvArchive: 1, tvArchiveDuration: 14)
+        #expect(PlayableMedia.guideArchiveWindowDays(for: stream) == 14)
     }
 
     @Test func `catchup availability rejects channels without archive`() {
@@ -177,12 +268,40 @@ struct PlayableMediaTests {
         #expect(!PlayableMedia.isCatchupAvailable(stream: stream, start: now.addingTimeInterval(-3600), now: now))
     }
 
-    @Test func `catchup availability rejects m3u direct streams`() {
+    @Test func `catchup availability rejects m3u channels without catchup attributes`() {
         let stream = LiveStream(id: "l-10", streamId: 307, name: "M3U",
                                 tvArchive: 1, tvArchiveDuration: 7)
         stream.directURL = "http://example.com/live/stream.m3u8"
         let now = Date()
         #expect(!PlayableMedia.isCatchupAvailable(stream: stream, start: now.addingTimeInterval(-3600), now: now))
+    }
+
+    @Test func `catchup availability accepts m3u channels with catchup attributes`() {
+        let stream = LiveStream(id: "l-10b", streamId: 308, name: "M3U Archive",
+                                tvArchive: 1, tvArchiveDuration: 7,
+                                catchupTypeRaw: "flussonic")
+        stream.directURL = "http://example.com/ch/video.m3u8"
+        let now = Date()
+        #expect(PlayableMedia.isCatchupAvailable(stream: stream, start: now.addingTimeInterval(-3600), now: now))
+    }
+
+    @Test func `catchup capability rejects stalker channels`() {
+        // What the Stalker importer actually writes: no `tvArchive`, no
+        // `catchupTypeRaw`, and a `create_link` command in `directURL`.
+        let stream = LiveStream(id: "l-10d", streamId: 312, name: "Portal")
+        stream.directURL = "ffmpeg http://localhost/ch/video.m3u8"
+        #expect(!PlayableMedia.isCatchupCapable(stream: stream))
+    }
+
+    @Test func `catchup capability trusts the imported decision without rebuilding a url`() {
+        // `tvArchive == 1` is only ever written for a source the importer could
+        // build, so the render path must not re-derive it from the URL.
+        let stream = LiveStream(id: "l-10e", streamId: 313, name: "M3U Archive",
+                                tvArchive: 1, tvArchiveDuration: 7,
+                                catchupTypeRaw: "default",
+                                catchupSource: "plugin://foo/{utc}")
+        stream.directURL = "http://example.com/live/stream.m3u8"
+        #expect(PlayableMedia.isCatchupCapable(stream: stream))
     }
 
     // MARK: - Codable

--- a/LumeTests/Services/XtreamClientURLTests.swift
+++ b/LumeTests/Services/XtreamClientURLTests.swift
@@ -112,7 +112,9 @@ struct XtreamClientURLTests {
         let playlist = makePlaylist()
         let stream = LiveStream(id: "l-3", streamId: 777, name: "Catchup Channel")
         let start = Date(timeIntervalSince1970: 1_700_000_000)
-        let url = try #require(client.buildCatchupURL(for: stream, playlist: playlist, start: start, durationMinutes: 90))
+        let url = try #require(client.buildCatchupURL(
+            for: stream, playlist: playlist, start: start, end: start.addingTimeInterval(90 * 60)
+        ))
         let string = url.absoluteString
         #expect(string.hasPrefix("http://example.com:8080/timeshift/testuser/testpass/90/"))
         #expect(string.hasSuffix("/777.ts"))
@@ -130,21 +132,27 @@ struct XtreamClientURLTests {
         newYorkPlaylist.serverTimezone = "America/New_York"
 
         let utcURL = try #require(client.buildCatchupURL(
-            for: stream, playlist: utcPlaylist, start: start, durationMinutes: 60
+            for: stream, playlist: utcPlaylist, start: start, end: start.addingTimeInterval(3600)
         ))
         let newYorkURL = try #require(client.buildCatchupURL(
-            for: stream, playlist: newYorkPlaylist, start: start, durationMinutes: 60
+            for: stream, playlist: newYorkPlaylist, start: start, end: start.addingTimeInterval(3600)
         ))
 
         #expect(utcURL.absoluteString.contains("/2023-11-14:22-13/"))
         #expect(newYorkURL.absoluteString.contains("/2023-11-14:17-13/"))
     }
 
-    @Test func `build catchup URL rejects non-positive duration`() {
+    /// Panels answer 400 on a zero-minute request, so a sub-minute window is
+    /// rounded up to one minute by the builder rather than sent as written.
+    @Test func `build catchup URL rounds a sub-minute window up to one minute`() throws {
         let client = makeClient()
         let playlist = makePlaylist()
         let stream = LiveStream(id: "l-5", streamId: 779, name: "Catchup Channel")
-        #expect(client.buildCatchupURL(for: stream, playlist: playlist, start: Date(), durationMinutes: 0) == nil)
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        let url = try #require(client.buildCatchupURL(
+            for: stream, playlist: playlist, start: start, end: start.addingTimeInterval(20)
+        ))
+        #expect(url.absoluteString.hasPrefix("http://example.com:8080/timeshift/testuser/testpass/1/"))
     }
 
     // MARK: - Server URL trailing slash handling

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ adapted per size class
 - Browse channels by category with logos and **EPG** data (now & next)
 - Full **program guide** with a scrollable timeline
 - **Custom EPG sources**: add external XMLTV feeds, refresh the guide on its own schedule, and sync manually — managed separately from playlist content
-- Catchup / time-shift support
+- **Catchup / time-shift** on both **Xtream Codes** (`tv_archive`) and **M3U/M3U8** playlists — M3U channels are picked up from their `catchup` / `catchup-type` attributes, covering the `flussonic` (and `flussonic-hls` / `fs`), `append`, `default` / `shift` (`catchup-source` template expansion), and `xc` schemes
 - **Multi-View**: watch up to four channels at once in a 2 / 3 / 2×2 grid, with the audio on whichever tile you pick — channels can come from different playlists, so a provider limited to one concurrent connection is no obstacle
 - Channel zapping with recently-watched history
 - **In-player channel browser** on tvOS (left-press overlay with category/channel grid)


### PR DESCRIPTION
## Summary

Catch-up / archive playback only worked for Xtream Codes playlists. An M3U playlist that declares catch-up per channel never marked any channel as having an archive, so the Guide never offered a past programme — while other players play the same archive from the same playlist. This makes M3U channels behave like Xtream `tv_archive` channels: the clock affordance appears, the archive depth comes from `catchup-days`, and selecting a past programme builds a playable URL.

## Implementation

**Parsing.** `M3UParser` now reads the catchup attributes it already collected and discarded — `catchup` / `catchup-type`, `catchup-days` falling back to `timeshift` then `tvg-rec`, and `catchup-source` — and accepts unquoted values, which real playlists emit and the quoted-only scanner silently skipped. The attribute scan now stops at the display-name comma, so a channel named `Sky F1=HD` can no longer yield a bogus attribute. That fix also made the parser **15.9% faster than before this branch**: the old scan walked the entire line. `LumePerformanceTests/README.md` records the measurement, including the module-placement confound that makes the naive before/after comparison misleading.

**URL building.** New `M3UCatchupURL` covers all five dialects — `flussonic`/`flussonic-hls`/`fs` (filename rewrite, with an explicit `catchup-source` winning over the convention), `append`, `default`/`shift` template expansion, and `xc`, which recovers credentials from the channel URL path because an M3U `Playlist` carries none and `streamId` is an FNV hash. Timestamps are raw UTC epochs and `{duration}` is seconds; the Xtream builder's wall-clock-and-minutes convention exists to keep XC panels from answering 400 and is reached only through `xc`. URLs are built from the **raw** `directURL`, deliberately bypassing `PlaylistStreamFormat.applied(to:)`, which swaps `.m3u8` ⇄ `.ts` and would 404 a Flussonic archive for anyone who set the playlist to MPEG-TS. Every dialect's result is validated to an absolute http(s) URL with a host.

**Two decisions worth reviewing.** First, buildability is decided **once at import** and persisted as `tvArchive`, so a channel only badges when a URL can actually be produced, and no view re-derives it — `EPGChannelRow` is a value snapshot precisely because SwiftData reads fault to SQLite on the main thread during scroll. Second, the capability rule was previously spelled three different ways across nine sites; it is now one shared predicate, so a badge and its tap can no longer disagree. Getting that ordering wrong would have shipped dead buttons on all four platforms, so the gate was converged before the importer began setting `tvArchive`.

A stored `tvArchiveDuration` of 0 means "declared, depth unknown" and renders a day-less badge reusing the existing `Catch-up available` string. **No new localized strings** are added. Xtream behaviour is unchanged throughout — the unknown-depth window applies only to M3U channels.

## Testing

- [x] Acceptance criteria met
- [x] Tests pass (`xcodebuild test -scheme Lume -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`) — 1076/1076
- [x] SwiftLint clean (SwiftFormat 0/28, SwiftLint `--strict` silent)
- [x] Tests added — new `M3UCatchupURLTests` (per-dialect exact-URL assertions, relative/protocol-relative/garbage-source rejection, `canBuild`/`build` agreement), plus cases in `M3UParserTests`, `M3USyncTests`, `PlayableMediaTests`, `EPGGridBuilderTests` and `ModelTests`

Verified on a simulator against a playlist covering every dialect. All six catch-up cases badged with the right depth (`flussonic`+7d, `tvg-rec` flag+6d, `default`+source+3d, `append`+query+2d, unquoted days+4d), `catchup="fs"` with no day count rendered the glyph alone rather than "Catchup: 0d", and both controls — an unknown dialect and a channel with no attributes — correctly showed **no** affordance.

## Platforms

- [x] iOS / iPadOS
- [x] tvOS
- [x] macOS
- [ ] visionOS — **not verified**: the visionOS runtime is not installed on the build machine, so the gate could not run. No changed file contains a visionOS-specific branch, and the other three platforms build clean.

## Related

Closes #203
Field report: #213 (closed as duplicate) — its four real-world spellings are all covered.
Builds on #25 / #88 (original Xtream-only catch-up) and #114 / #115 (catch-up from the EPG).

**Known limitation, not addressed here:** `EPGGuideView` hard-codes a 12-hour reach-back, so a channel badged for several days is still only scrollable back 12 h in the Guide. That is a pre-existing window-size issue and is being tracked separately.