### PR TITLE
feat(settings): show when a playlist last synced — and when it didn't

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -16371,6 +16371,58 @@
         }
       }
     },
+    "Last sync failed" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte Synchronisierung fehlgeschlagen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error en la última sincronización"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de la dernière synchronisation"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima sincronizzazione non riuscita"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前回の同期に失敗しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마지막 동기화 실패"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falha na última sincronização"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次同步失败"
+          }
+        }
+      }
+    },
     "Last Synced" : {
       "localizations" : {
         "de" : {
@@ -20819,6 +20871,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "网络超时"
+          }
+        }
+      }
+    },
+    "Never synced" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch nie synchronisiert"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nunca sincronizado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jamais synchronisé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mai sincronizzato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未同期"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "동기화한 적 없음"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nunca sincronizado"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从未同步"
           }
         }
       }
@@ -33493,6 +33597,58 @@
         }
       }
     },
+    "Sync due" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronisierung fällig"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronización pendiente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronisation due"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzazione in scadenza"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同期予定"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "동기화 예정"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronização pendente"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "待同步"
+          }
+        }
+      }
+    },
     "Sync Enabled" : {
       "localizations" : {
         "de" : {
@@ -33697,6 +33853,58 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "立即同步"
+          }
+        }
+      }
+    },
+    "Sync off" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronisierung aus"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronización desactivada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronisation désactivée"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzazione disattivata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同期オフ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "동기화 꺼짐"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronização desativada"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步已关闭"
           }
         }
       }

--- a/Lume/Services/Sync/PlaylistSyncState.swift
+++ b/Lume/Services/Sync/PlaylistSyncState.swift
@@ -1,0 +1,137 @@
+//
+//  PlaylistSyncState.swift
+//  Lume
+//
+//  What a playlist's sync looks like *right now*, as one value the settings
+//  surfaces can render. Derived from state the playlist already carries —
+//  `syncStatus`, `lastSyncDate`, `syncEnabled` — plus the global frequency;
+//  nothing new is persisted.
+//
+//  Three places show this (the iOS list row, the tvOS row, and both detail
+//  panes), and before this type each decided for itself what was worth
+//  mentioning: the list rows said nothing at all, and the detail panes rendered
+//  `Last Synced` only when there was a date, so a playlist that had never
+//  finished a sync looked exactly like a healthy one. Resolving it once, here,
+//  is what keeps those surfaces telling the same story — and keeps the decision
+//  unit-testable, like `AutoSync.shouldSync` next door.
+//
+
+import Foundation
+import SwiftUI
+
+/// A playlist's sync condition, in the order the surfaces care about it: the
+/// states that need the viewer's attention come first, and the healthy steady
+/// state comes last and stays quiet.
+enum PlaylistSyncState: Equatable {
+    /// A sync is running for this playlist right now.
+    case syncing
+    /// The last attempt ended in an error. Note there is no reason to show
+    /// with it: `Playlist` stores only `idle` / `syncing` / `error`, so
+    /// "it failed" is the whole of what is actually known.
+    case failed
+    /// Never finished a sync. Distinct from `failed` because it is also the
+    /// ordinary state of a playlist added a moment ago.
+    case never
+    /// Synced before, but longer ago than the frequency allows — so it is due
+    /// and will start on the next launch, playlist switch or foreground.
+    case overdue(lastSyncDate: Date)
+    /// Synced within the interval. Nothing to say.
+    case synced(lastSyncDate: Date)
+    /// The playlist opted out of automatic syncing, so staleness is expected
+    /// and reporting it would be noise.
+    case disabled(lastSyncDate: Date?)
+
+    /// Resolve the state from a playlist's own fields. Takes them loose rather
+    /// than taking `Playlist` so it stays testable without a `ModelContext`,
+    /// and `now` is injectable for the same reason.
+    static func resolve(
+        syncEnabled: Bool,
+        status: SyncStatus,
+        lastSyncDate: Date?,
+        frequency: SyncFrequency,
+        now: Date = Date()
+    ) -> PlaylistSyncState {
+        // Checked ahead of `syncEnabled`: a sync kicked off by hand (Sync Now)
+        // runs regardless of the opt-out, and while it runs that is the most
+        // useful thing to say.
+        if status == .syncing { return .syncing }
+        guard syncEnabled else { return .disabled(lastSyncDate: lastSyncDate) }
+        if status == .error { return .failed }
+        guard let lastSyncDate else { return .never }
+        if frequency.isDue(lastSyncDate: lastSyncDate, now: now) {
+            return .overdue(lastSyncDate: lastSyncDate)
+        }
+        return .synced(lastSyncDate: lastSyncDate)
+    }
+
+    /// The date to show as "Last Synced", when there is one.
+    var lastSyncDate: Date? {
+        switch self {
+        case let .overdue(date), let .synced(date): date
+        case let .disabled(date): date
+        case .syncing, .failed, .never: nil
+        }
+    }
+
+    /// Whether a list row should draw an accessory for this state at all.
+    ///
+    /// Only the states a viewer would act on earn one. Badging every row —
+    /// including the healthy majority — trains the eye to skip the badge, which
+    /// costs exactly the signal this was added for.
+    var deservesRowAccessory: Bool {
+        switch self {
+        case .syncing, .failed, .never: true
+        case .overdue, .synced, .disabled: false
+        }
+    }
+
+    /// SF Symbol for the row accessory. `nil` where `deservesRowAccessory` is
+    /// false, and for `.syncing`, which draws a spinner instead of a glyph.
+    var symbolName: String? {
+        switch self {
+        case .failed: "exclamationmark.triangle.fill"
+        case .never: "clock.badge.questionmark"
+        case .syncing, .overdue, .synced, .disabled: nil
+        }
+    }
+
+    /// Tint for the accessory and the detail status row.
+    ///
+    /// Deliberately never `.accentColor`: that resolves to white on tvOS, where
+    /// it would read as ordinary text rather than as a warning.
+    var tint: Color {
+        switch self {
+        case .failed: .orange
+        case .syncing, .never, .overdue, .synced, .disabled: .secondary
+        }
+    }
+
+    /// The detail pane's Status line. Always says something, including for the
+    /// two states the panes used to render as an absent row.
+    var statusLabel: LocalizedStringResource {
+        switch self {
+        case .syncing: "Syncing"
+        case .failed: "Last sync failed"
+        case .never: "Never synced"
+        case .overdue: "Sync due"
+        case .synced: "Up to date"
+        case .disabled: "Sync off"
+        }
+    }
+}
+
+extension Playlist {
+    /// This playlist's sync state under the stored global frequency. The
+    /// convenience the views actually call; `PlaylistSyncState.resolve` stays
+    /// the testable seam beneath it.
+    var syncState: PlaylistSyncState {
+        PlaylistSyncState.resolve(
+            syncEnabled: syncEnabled,
+            status: syncStatus,
+            lastSyncDate: lastSyncDate,
+            frequency: SyncFrequency.resolve(
+                UserDefaults.standard.string(forKey: SyncFrequency.storageKey) ?? ""
+            )
+        )
+    }
+}

--- a/Lume/Views/Settings/PlaylistDetailView+TV.swift
+++ b/Lume/Views/Settings/PlaylistDetailView+TV.swift
@@ -156,16 +156,19 @@ import SwiftUI
                     }
                     .buttonStyle(TVSettingsRowButtonStyle())
 
-                    if playlist.syncStatus == .syncing {
-                        TVSettingsValueRow("Status") {
-                            HStack(spacing: 8) {
+                    // Unconditional — see the iOS pane: the states worth
+                    // reading were the ones that used to render as no row.
+                    TVSettingsValueRow("Status") {
+                        HStack(spacing: 8) {
+                            if syncState == .syncing {
                                 ProgressView()
-                                Text("Syncing")
                             }
+                            Text(syncState.statusLabel)
+                                .foregroundStyle(syncState.tint)
                         }
                     }
 
-                    if let lastSync = playlist.lastSyncDate {
+                    if let lastSync = syncState.lastSyncDate {
                         TVSettingsValueRow("Last Synced") {
                             Text(lastSync, style: .relative)
                         }

--- a/Lume/Views/Settings/PlaylistDetailView.swift
+++ b/Lume/Views/Settings/PlaylistDetailView.swift
@@ -6,6 +6,24 @@ struct PlaylistDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(CloudSyncCoordinator.self) private var cloudSync: CloudSyncCoordinator?
     @Bindable var playlist: Playlist
+    /// Held here rather than read inside `playlist.syncState` so changing the
+    /// frequency in Settings re-renders the Status row (it decides `.overdue`).
+    @AppStorage(SyncFrequency.storageKey)
+    private var syncFrequencyRaw: String = SyncFrequency.defaultValue.rawValue
+
+    /// This playlist's sync condition, shared by the Status row and the
+    /// `Last Synced` line below it so the two can never disagree.
+    ///
+    /// Not `private`: the tvOS pane in PlaylistDetailView+TV (separate file)
+    /// renders the same two rows from it.
+    var syncState: PlaylistSyncState {
+        PlaylistSyncState.resolve(
+            syncEnabled: playlist.syncEnabled,
+            status: playlist.syncStatus,
+            lastSyncDate: playlist.lastSyncDate,
+            frequency: SyncFrequency.resolve(syncFrequencyRaw)
+        )
+    }
 
     /// tvOS: called to leave this detail when it is shown inline in the Settings
     /// detail pane (e.g. after deleting the playlist, whose object then becomes
@@ -234,20 +252,21 @@ struct PlaylistDetailView: View {
             Section {
                 Toggle("Sync Enabled", isOn: $playlist.syncEnabled)
 
-                if playlist.syncStatus == .syncing {
-                    HStack {
-                        Text("Status")
-                        Spacer()
-                        HStack(spacing: 6) {
+                // Unconditional: "never synced" and "last sync failed" are the
+                // two states most worth reading here, and both used to render
+                // as no row at all.
+                LabeledContent("Status") {
+                    HStack(spacing: 6) {
+                        if syncState == .syncing {
                             ProgressView()
                                 .controlSize(.small)
-                            Text("Syncing")
-                                .foregroundStyle(.secondary)
                         }
+                        Text(syncState.statusLabel)
+                            .foregroundStyle(syncState.tint)
                     }
                 }
 
-                if let lastSync = playlist.lastSyncDate {
+                if let lastSync = syncState.lastSyncDate {
                     LabeledContent("Last Synced") {
                         Text(lastSync, style: .relative)
                             .foregroundStyle(.secondary)

--- a/Lume/Views/Settings/PlaylistSyncAccessory.swift
+++ b/Lume/Views/Settings/PlaylistSyncAccessory.swift
@@ -1,0 +1,41 @@
+//
+//  PlaylistSyncAccessory.swift
+//  Lume
+//
+//  The small trailing indicator a playlist row draws when its sync needs
+//  attention — and draws nothing at all when it doesn't. Shared by the iOS /
+//  macOS settings list and the tvOS playlist row so the two can't drift.
+//
+
+import SwiftUI
+
+/// Trailing accessory for a playlist row: a spinner while syncing, a glyph for
+/// the states worth surfacing, and nothing for a playlist that is fine.
+///
+/// The empty case is the important one. A row that badges every state teaches
+/// the eye to skip the badge, so the healthy majority stays silent and the
+/// accessory only ever means "look at this one".
+struct PlaylistSyncAccessory: View {
+    let state: PlaylistSyncState
+    /// Point size of the glyph. tvOS rows are far larger than an iOS list cell,
+    /// so the caller sets this rather than the view guessing from the platform.
+    var size: CGFloat = 15
+
+    var body: some View {
+        switch state {
+        case .syncing:
+            ProgressView()
+                .controlSize(.small)
+                .accessibilityLabel(Text(state.statusLabel))
+        case .failed, .never:
+            if let symbolName = state.symbolName {
+                Image(systemName: symbolName)
+                    .font(.system(size: size))
+                    .foregroundStyle(state.tint)
+                    .accessibilityLabel(Text(state.statusLabel))
+            }
+        case .overdue, .synced, .disabled:
+            EmptyView()
+        }
+    }
+}

--- a/Lume/Views/Settings/SettingsView.swift
+++ b/Lume/Views/Settings/SettingsView.swift
@@ -201,6 +201,9 @@ struct SettingsView: View {
                                         .lineLimit(1)
                                         .truncationMode(.middle)
                                 }
+
+                                Spacer(minLength: 0)
+                                PlaylistSyncAccessory(state: playlist.syncState)
                             }
                             .padding(.vertical, 1)
                         }

--- a/Lume/Views/TV/TVSwitchRows.swift
+++ b/Lume/Views/TV/TVSwitchRows.swift
@@ -32,6 +32,7 @@
                             .truncationMode(.middle)
                     }
                     Spacer(minLength: 0)
+                    PlaylistSyncAccessory(state: playlist.syncState, size: 26)
                     if isActive {
                         TVSwitchRowCheckmark()
                     }

--- a/LumeTests/Services/PlaylistSyncStateTests.swift
+++ b/LumeTests/Services/PlaylistSyncStateTests.swift
@@ -1,0 +1,92 @@
+//
+//  PlaylistSyncStateTests.swift
+//  LumeTests
+//
+//  Covers how a playlist's stored fields resolve into the state the settings
+//  surfaces render (`PlaylistSyncState.resolve`), including the two cases the
+//  detail panes used to show as no row at all: never synced, and failed.
+//
+
+import Foundation
+@testable import Lume
+import Testing
+
+struct PlaylistSyncStateTests {
+    private let frequency = SyncFrequency.everyThreeDays
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func resolve(
+        syncEnabled: Bool = true,
+        status: SyncStatus = .idle,
+        lastSyncDate: Date?
+    ) -> PlaylistSyncState {
+        PlaylistSyncState.resolve(
+            syncEnabled: syncEnabled,
+            status: status,
+            lastSyncDate: lastSyncDate,
+            frequency: frequency,
+            now: now
+        )
+    }
+
+    // MARK: - Resolution
+
+    @Test func `a playlist that has never synced reads as never, not as up to date`() {
+        #expect(resolve(lastSyncDate: nil) == .never)
+    }
+
+    @Test func `an errored playlist reads as failed even though it synced before`() {
+        let yesterday = now.addingTimeInterval(-24 * 60 * 60)
+        #expect(resolve(status: .error, lastSyncDate: yesterday) == .failed)
+    }
+
+    @Test func `a running sync outranks everything else`() {
+        #expect(resolve(status: .syncing, lastSyncDate: nil) == .syncing)
+    }
+
+    @Test func `a manual sync shows as syncing even with automatic sync off`() {
+        #expect(resolve(syncEnabled: false, status: .syncing, lastSyncDate: nil) == .syncing)
+    }
+
+    @Test func `an opted-out playlist reads as disabled rather than stale`() {
+        let longAgo = now.addingTimeInterval(-30 * 24 * 60 * 60)
+        #expect(resolve(syncEnabled: false, lastSyncDate: longAgo) == .disabled(lastSyncDate: longAgo))
+    }
+
+    // MARK: - The interval boundary
+
+    @Test func `synced inside the interval is up to date`() {
+        let recent = now.addingTimeInterval(-frequency.interval + 60)
+        #expect(resolve(lastSyncDate: recent) == .synced(lastSyncDate: recent))
+    }
+
+    @Test func `synced exactly at the interval is already overdue`() {
+        let boundary = now.addingTimeInterval(-frequency.interval)
+        #expect(resolve(lastSyncDate: boundary) == .overdue(lastSyncDate: boundary))
+    }
+
+    // MARK: - Presentation
+
+    @Test func `only the states worth acting on draw a row accessory`() {
+        let date = now.addingTimeInterval(-60)
+        #expect(PlaylistSyncState.syncing.deservesRowAccessory)
+        #expect(PlaylistSyncState.failed.deservesRowAccessory)
+        #expect(PlaylistSyncState.never.deservesRowAccessory)
+        #expect(!PlaylistSyncState.synced(lastSyncDate: date).deservesRowAccessory)
+        #expect(!PlaylistSyncState.overdue(lastSyncDate: date).deservesRowAccessory)
+        #expect(!PlaylistSyncState.disabled(lastSyncDate: date).deservesRowAccessory)
+    }
+
+    @Test func `states without a successful sync carry no date to show`() {
+        #expect(PlaylistSyncState.never.lastSyncDate == nil)
+        #expect(PlaylistSyncState.failed.lastSyncDate == nil)
+        #expect(PlaylistSyncState.syncing.lastSyncDate == nil)
+    }
+
+    @Test func `states with a successful sync carry the date through`() {
+        let date = now.addingTimeInterval(-60)
+        #expect(PlaylistSyncState.synced(lastSyncDate: date).lastSyncDate == date)
+        #expect(PlaylistSyncState.overdue(lastSyncDate: date).lastSyncDate == date)
+        #expect(PlaylistSyncState.disabled(lastSyncDate: date).lastSyncDate == date)
+    }
+}


### PR DESCRIPTION
Right now the playlists list tells you a name and a server URL. Whether a playlist synced an hour ago, failed every attempt since you added it, or has never synced at all, it looks the same.

The detail panes are only slightly better: `Last Synced` sits inside `if let lastSyncDate`, so the one state you'd most want flagged — never successfully synced — renders as no row. And `.error` isn't drawn anywhere in the app, despite `syncStatus` having carried the case from the start.

**What you see now**

| State | List row | Detail Status row |
|---|---|---|
| Syncing | spinner | Syncing |
| Last attempt failed | orange ⚠︎ | Last sync failed |
| Never synced | clock glyph | Never synced |
| Due for a sync | — | Sync due |
| Up to date | — | Up to date |
| Sync switched off | — | Sync off |

The blanks are deliberate. A badge on every row, healthy ones included, is one people learn to skip — which costs exactly the signal this is for. Only the three states you'd act on draw anything.

**How it's built:** one derived value, `PlaylistSyncState`, from fields the playlist already carries plus the global frequency. Nothing new is persisted, no schema change, no migration. It's resolved in one place so the iOS row, tvOS row and both detail panes can't tell different stories — which is how they drifted apart to begin with.

**Deliberately not included:** no error *reason*. `Playlist` stores `idle`/`syncing`/`error` and nothing more, so "Last sync failed" is the whole of what's known — storing the message is a model change worth its own discussion. This also doesn't change any sync scheduling behavior; it only reports it.

**Tests:** 10 cases over `PlaylistSyncState.resolve` — each state, the manual-sync-while-disabled precedence, the exact interval boundary between up-to-date and due, and which states earn a row accessory. Strings added for all nine languages.
