### PR TITLE
feat(player): request an App Store review after a good session

### DIFF
--- a/Lume/LumeApp.swift
+++ b/Lume/LumeApp.swift
@@ -207,6 +207,13 @@ struct LumeApp: App {
                         AppPerformanceMetrics.shared.start()
                     #endif
 
+                    // Count this launch for the review policy's second route
+                    // (launches + days since install) — the only route a Live TV
+                    // only user can ever satisfy, since the >=90% completion
+                    // crossing is VOD-only. A cheap synchronous `UserDefaults`
+                    // write, and idempotent per process on the callee's side.
+                    AppStoreReviewPrompt.shared.noteAppLaunched()
+
                     // Give DownloadManager access to the model container so it
                     // can persist download state from its delegate callbacks.
                     #if !os(tvOS)
@@ -299,6 +306,10 @@ struct LumeApp: App {
             .modelContainer(catalogContainer)
             .environment(TraktService.shared)
             .environment(PremiumManager.shared)
+            // The player is its own window on macOS, so it does not inherit
+            // the main scene's environment — without this the review prompt
+            // would read every macOS session as "no child watching".
+            .environment(profileManager)
             .windowStyle(.hiddenTitleBar)
             .windowResizability(.contentMinSize)
 

--- a/Lume/Services/Diagnostics/PlaybackHealthTracker.swift
+++ b/Lume/Services/Diagnostics/PlaybackHealthTracker.swift
@@ -1,0 +1,155 @@
+//
+//  PlaybackHealthTracker.swift
+//  Lume
+//
+//  Did *this* playback session go well? `PlaybackQoE.shared.summary` cannot
+//  answer that: it is a lifetime rolling aggregate, so `engineFallbacks > 0`
+//  is true for practically every IPTV user within a week and reading it
+//  directly would silence anything gated on it forever. So snapshot the
+//  counters when the player opens, snapshot them again when it closes, and
+//  judge the difference.
+//
+//  Reading the summary is free — no `persist()`, no timer, no per-tick write.
+//  The whole cost of this file is two struct copies per player session.
+//
+
+import Foundation
+
+// MARK: - Verdict
+
+/// How the last full-screen playback session went. A plain value so the
+/// App Store review shim can consume it without reaching into the player.
+nonisolated enum PlaybackSessionHealth: Equatable {
+    case healthy
+    case unhealthy(Fault)
+    /// The session produced no usable signal, which is not the same as a clean
+    /// one — a naive diff of zeros reads as flawless.
+    case notMeasured(Exclusion)
+
+    /// Raw values are what a QA log prints.
+    nonisolated enum Fault: String, Equatable {
+        case engineFallback
+        case startupFailure
+        case rebuffering
+    }
+
+    nonisolated enum Exclusion: String, Equatable {
+        /// Multi-View holds `PlaybackQoE.isSuspended` for its whole lifetime,
+        /// so those sessions record nothing at all.
+        case suspended
+        /// Too little watch time for the rebuffer ratio to mean anything.
+        case tooShort
+    }
+
+    /// The one state that may arm a review prompt.
+    var isHealthy: Bool {
+        self == .healthy
+    }
+}
+
+// MARK: - Snapshot
+
+/// The QoE counters that decide session health, summed across engines so an
+/// in-session engine switch is still caught.
+nonisolated struct PlaybackHealthSnapshot: Equatable {
+    var engineFallbacks = 0
+    var startupFailures = 0
+    var rebufferSeconds: TimeInterval = 0
+    var watchedSeconds: TimeInterval = 0
+
+    init() {}
+
+    init(_ summary: PlaybackQoESummary) {
+        engineFallbacks = summary.engineFallbacks
+        for stats in summary.engines.values {
+            startupFailures += stats.startupFailures
+            rebufferSeconds += stats.rebufferSeconds
+            watchedSeconds += stats.watchedSeconds
+        }
+    }
+}
+
+nonisolated extension PlaybackSessionHealth {
+    /// Fraction of the session that may be spent stalled. Five percent is the
+    /// industry "poor" line — three seconds of buffering a minute, which the
+    /// user certainly noticed. Judged per session, so one rough stream costs
+    /// one prompt opportunity rather than all of them.
+    static let rebufferRatioCeiling = 0.05
+
+    /// Below this there is no meaningful ratio to take, and a session this
+    /// short is not evidence the app is worth rating either way.
+    static let minimumWatchedSeconds: TimeInterval = 60
+
+    static func verdict(from start: PlaybackHealthSnapshot, to end: PlaybackHealthSnapshot) -> PlaybackSessionHealth {
+        if end.engineFallbacks > start.engineFallbacks { return .unhealthy(.engineFallback) }
+        if end.startupFailures > start.startupFailures { return .unhealthy(.startupFailure) }
+
+        let watched = end.watchedSeconds - start.watchedSeconds
+        guard watched >= minimumWatchedSeconds else { return .notMeasured(.tooShort) }
+
+        let stalled = max(0, end.rebufferSeconds - start.rebufferSeconds)
+        return stalled / watched > rebufferRatioCeiling ? .unhealthy(.rebuffering) : .healthy
+    }
+}
+
+// MARK: - Tracker
+
+/// Brackets full-screen playback sessions and judges how each one went.
+///
+/// The bracket is the *host* view's lifetime, not an engine's: it deliberately
+/// spans startup retries, engine fallbacks and in-player episode swaps, which
+/// is exactly the window whose health decides whether this was a good sitting.
+/// Restarting it per title would hide a fallback the user just lived through.
+///
+/// Brackets are keyed by an opaque token rather than kept in a single slot,
+/// because two players can be open at once — macOS gives the player its own
+/// `WindowGroup(id: "player", for:)`, which opens a second window for a second
+/// value, and iPadOS can run several scenes. A single slot let the second
+/// player overwrite the first one's baseline, so the first was judged against
+/// the wrong snapshot and the second silently inherited its verdict.
+///
+/// `MainActor`-isolated by project default, like `PlaybackQoE` itself.
+final class PlaybackHealthTracker {
+    static let shared = PlaybackHealthTracker()
+
+    /// Identifies one open bracket. Opaque so a caller can only ever close the
+    /// session it opened.
+    nonisolated struct Token: Hashable {
+        fileprivate let id = UUID()
+    }
+
+    /// One session's opening state. `opening` is `nil` when the session began
+    /// while QoE was suspended and there was nothing to snapshot.
+    private struct Bracket {
+        var opening: PlaybackHealthSnapshot?
+    }
+
+    private var brackets: [Token: Bracket] = [:]
+
+    /// The player opened. Call once per host view, not per engine attempt, and
+    /// keep the token for the matching `endSession`.
+    func beginSession() -> Token {
+        let token = Token()
+        let suspended = PlaybackQoE.shared.isSuspended
+        brackets[token] = Bracket(opening: suspended ? nil : PlaybackHealthSnapshot(PlaybackQoE.shared.summary))
+        return token
+    }
+
+    /// The player closed. Returns the verdict for that session, or `nil` when
+    /// it produced no usable one.
+    ///
+    /// Must run *after* the engine views have torn down — `watchedSeconds` only
+    /// lands in the summary in `PlaybackQoE.endSession()`, and the order of
+    /// sibling `onDisappear` callbacks is undefined.
+    ///
+    /// With two players open the QoE summary is still app-wide, so each diff
+    /// also picks up the other session's faults. That errs toward `.unhealthy`,
+    /// which is the safe direction: it can cost a prompt, never earn a wrong one.
+    func endSession(_ token: Token) -> PlaybackSessionHealth? {
+        guard let bracket = brackets.removeValue(forKey: token) else { return nil }
+        guard let opening = bracket.opening, !PlaybackQoE.shared.isSuspended else {
+            return .notMeasured(.suspended)
+        }
+        return .verdict(from: opening, to: PlaybackHealthSnapshot(PlaybackQoE.shared.summary))
+    }
+}

--- a/Lume/Services/Review/AppStoreReviewPrompt.swift
+++ b/Lume/Services/Review/AppStoreReviewPrompt.swift
@@ -1,0 +1,330 @@
+//
+//  AppStoreReviewPrompt.swift
+//  Lume
+//
+//  Owns the rating prompt's decision to ask. The sheet itself is requested by
+//  `AppStoreReviewPromptModifier`, which holds the `RequestReviewAction`; those
+//  two are the only files that import StoreKit for review.
+//
+//  It gathers the inputs `AppStoreReviewTrigger` cannot see for itself — the
+//  marketing version, the build channel, the active profile, whether this run
+//  is a UI test or a preview — and turns the verdict into an *arm*, never an
+//  immediate ask.
+//
+//  Arm now, fire later: the moment is judged when a playback session ends,
+//  but the sheet is only requested once the player is gone and the browse UI
+//  is back with nothing over it. Asking at the completion crossing itself
+//  would land the alert on a screen the user has already left, or on an app
+//  that is backgrounding — that write path also runs from `onDisappear` and
+//  from the scene-phase handler.
+//
+//  tvOS has no review API at any layer, so everything below compiles down to
+//  a no-op there. The fences are compile-time on purpose: every deployment
+//  floor is already above the API floor, so there is nothing to check at run
+//  time — and `RequestReviewAction` is unavailable on tvOS *as a type*, which
+//  a `#available` check could not fence out. Only the two paths that are
+//  genuinely platform-shaped are fenced here — the policy run and the fire
+//  path; the counters are no-ops at the storage boundary instead
+//  (`AppStoreReviewStore`).
+//
+
+import Foundation
+import Observation
+import OSLog
+
+#if !os(tvOS)
+    // `RequestReviewAction` lives in the StoreKit/SwiftUI cross-import overlay,
+    // so it only resolves with both modules imported.
+    import StoreKit
+    import SwiftUI
+#endif
+
+/// Arms and fires Apple's system rating sheet.
+///
+/// `@Observable` for one reason: the browse root has to notice the player
+/// closing to know its moment has arrived, and the player is presented from
+/// eleven different call sites, none of which the browse root can see.
+@MainActor
+@Observable
+final class AppStoreReviewPrompt {
+    static let shared = AppStoreReviewPrompt()
+
+    /// What an armed moment remembers about the session that earned it, so the
+    /// policy can be re-run at fire time against fresh dates. Deliberately in
+    /// memory only: an arm that outlived the launch it was earned in would
+    /// surface far from the event that justified it.
+    private struct ArmedMoment {
+        var isChildProfileActive: Bool
+    }
+
+    private var armedMoment: ArmedMoment?
+
+    /// Whether a good moment is waiting for a safe one to fire in.
+    var isArmed: Bool {
+        armedMoment != nil
+    }
+
+    /// How many full-screen players are on screen. A count, not a flag: on
+    /// macOS the player is its own `WindowGroup` and on iPadOS the app can run
+    /// several scenes, so two can be open at once and closing one must not
+    /// report the screen as clear while the other is still playing.
+    private var openPlayerCount = 0
+
+    /// Whether any full-screen player is on screen. The fire point can't infer
+    /// this from its own presentation state: on macOS the player is a separate
+    /// `WindowGroup`, so the browse UI stays visible for the whole movie.
+    var playerIsVisible: Bool {
+        openPlayerCount > 0
+    }
+
+    /// How many paywalls are on screen. Counted the same way and for the same
+    /// reason as players: `paywall(isPresented:)` has a dozen call sites, and
+    /// the browse root that fires the prompt can see none of them.
+    private var openPaywallCount = 0
+
+    /// Whether a paywall is on screen right now. Distinct from the policy's
+    /// `recentPaywall` window, which covers the two hours *after* one closes.
+    var paywallIsVisible: Bool {
+        openPaywallCount > 0
+    }
+
+    /// How many blocking sheets that the browse root cannot see are on screen.
+    /// Counted the same way as players and paywalls: Settings is raised from
+    /// the library toolbar, so the tab root has no binding for it.
+    private var openBlockingSheetCount = 0
+
+    /// Whether such a sheet is on screen right now.
+    var blockingSheetIsVisible: Bool {
+        openBlockingSheetCount > 0
+    }
+
+    private let store: AppStoreReviewStore
+
+    init(defaults: UserDefaults = .standard) {
+        store = AppStoreReviewStore(defaults: defaults)
+    }
+
+    // MARK: - Arming
+
+    /// A full-screen player or Multi-View grid opened. Multi-View reports
+    /// itself too, from inside `MultiViewScreen`: its presentation sites are
+    /// invisible to the browse root, and a rating sheet must not animate in
+    /// over a four-up grid.
+    func notePlayerAppeared() {
+        openPlayerCount += 1
+    }
+
+    /// A full-screen player or Multi-View grid closed. Separate from
+    /// `noteSessionEnded` because Multi-View produces no health verdict to
+    /// judge — and because the screen being clear must be recorded at once,
+    /// while judging the moment can wait for a pending progress write.
+    func notePlayerDisappeared() {
+        openPlayerCount = max(0, openPlayerCount - 1)
+    }
+
+    /// Counts a finished movie or episode (the >=90% crossing). Only the count
+    /// is taken here: the verdict also needs the session's health, which does
+    /// not exist until the player has torn down and the engines have flushed
+    /// their final QoE numbers.
+    func noteCompletedTitle() {
+        store.recordCompletedTitle()
+    }
+
+    /// A full-screen player closed. This is the arming point for both routes:
+    /// a viewer who finished three titles, and the Live TV only viewer who
+    /// never finishes one but has been launching the app for a week. Judging
+    /// only at the completion crossing would leave that second route — the one
+    /// that exists for Lume's primary use case — permanently unreachable.
+    ///
+    /// - Parameters:
+    ///   - sessionHealth: verdict for the session that just ended; `nil` when
+    ///     it produced no verdict. Anything but `.healthy` blocks the arm.
+    ///   - isChildProfileActive: `ProfileManager.activeProfileIsChild`, passed
+    ///     in rather than fetched — `UserProfile` lives in the CloudKit mirror
+    ///     container, which this layer must not open a second handle to.
+    func noteSessionEnded(health: PlaybackSessionHealth?, isChildProfileActive: Bool) {
+        #if !os(tvOS)
+            if isAutomatedRun {
+                Logger.review.debug("Review prompt skipped: automatedRun")
+                return
+            }
+
+            let inputs = store.inputs(
+                currentVersion: currentVersion,
+                sessionWasHealthy: health?.isHealthy ?? false,
+                isAppStoreBuild: isAppStoreBuild,
+                isChildProfileActive: isChildProfileActive
+            )
+
+            switch AppStoreReviewTrigger.verdict(for: inputs) {
+            case .ask:
+                armedMoment = ArmedMoment(isChildProfileActive: isChildProfileActive)
+            case let .skip(reason):
+                Logger.review.debug("Review prompt skipped: \(reason.rawValue, privacy: .public)")
+            }
+        #endif
+    }
+
+    // MARK: - Firing
+
+    #if !os(tvOS)
+        /// Requests the system sheet if one is armed.
+        ///
+        /// Call this only from a moment that is genuinely safe — player fully
+        /// dismissed, browse UI visible, nothing presented over it, app active.
+        /// The action is a parameter rather than a stored property because
+        /// `RequestReviewAction` is unavailable on tvOS as a type, and a stored
+        /// one would fail that build with no caller at all.
+        ///
+        /// The arm survives a suppressed fire: it is in-memory and dies with
+        /// the launch anyway, so discarding it because the user happened to
+        /// glance at the paywall would silently cost a moment they earned.
+        /// It is cleared only once the prompt is actually requested.
+        /// The whole policy is re-evaluated here, not just the process-local
+        /// suppressors. Minutes can pass between the arm and a safe moment —
+        /// long enough to open and close the paywall, which is exactly the
+        /// adjacency `recentPaywall` exists to prevent and which an arm-time
+        /// check alone would miss.
+        ///
+        /// - Returns: the reason the arm is still held, or `nil` when the sheet
+        ///   was requested — or when nothing was armed at all. The fire point
+        ///   needs it to tell a hold that time can lift from one that is fixed
+        ///   for the rest of the launch.
+        @discardableResult
+        func fireIfArmed(_ requestReview: RequestReviewAction) -> AppStoreReviewTrigger.Reason? {
+            guard let moment = armedMoment else { return nil }
+
+            if isAutomatedRun {
+                Logger.review.debug("Review prompt held: automatedRun")
+                return nil
+            }
+
+            // `sessionWasHealthy` is left at its `true` default: a moment is
+            // only ever armed off a healthy session, since anything else skips
+            // with `.unhealthyPlayback`.
+            let inputs = store.inputs(
+                currentVersion: currentVersion,
+                isAppStoreBuild: isAppStoreBuild,
+                isChildProfileActive: moment.isChildProfileActive
+            )
+
+            if case let .skip(reason) = AppStoreReviewTrigger.verdict(for: inputs) {
+                Logger.review.debug("Review prompt held: \(reason.rawValue, privacy: .public)")
+                return reason
+            }
+
+            armedMoment = nil
+
+            // `requestReview()` returns Void and never reports whether the
+            // sheet appeared, so this records an attempt, not a show.
+            if persistsAttempts { store.recordAttempt(version: currentVersion) }
+            requestReview()
+            return nil
+        }
+
+        /// How long until the paywall-adjacency window lifts, for a fire point
+        /// that has just been held by `.recentPaywall` — the one hold that
+        /// clears on its own inside a launch, so it earns a single
+        /// precisely-timed retry rather than a poll.
+        var paywallRetryDelay: Duration? {
+            guard let dismissedAt = store.paywallDismissedAt else { return nil }
+            let window = AppStoreReviewTrigger.paywallSuppressionHours * 60 * 60
+            let remaining = window - Date().timeIntervalSince(dismissedAt)
+            guard remaining > 0 else { return nil }
+            // Over-waits by a second: there is only one retry, and a wake that
+            // lands a hair short of the window would spend it on a re-decline.
+            return .seconds(remaining + 1)
+        }
+    #endif
+
+    // MARK: - Blocking sheets
+
+    /// A sheet the browse root cannot see was presented over it — Settings,
+    /// which presents sheets of its own several levels down (add playlist,
+    /// playlist sync, the debug mail and share sheets) that not even Settings'
+    /// own presenter can see.
+    func noteBlockingSheetAppeared() {
+        openBlockingSheetCount += 1
+    }
+
+    /// That sheet was dismissed.
+    func noteBlockingSheetDismissed() {
+        openBlockingSheetCount = max(0, openBlockingSheetCount - 1)
+    }
+
+    // MARK: - Paywall
+
+    /// A paywall was presented.
+    func notePaywallAppeared() {
+        openPaywallCount += 1
+    }
+
+    /// The paywall was dismissed, opening the window the policy keeps clear of
+    /// it.
+    func notePaywallDismissed() {
+        openPaywallCount = max(0, openPaywallCount - 1)
+        store.recordPaywallDismissal()
+    }
+
+    // MARK: - Launch
+
+    /// Counts this launch for the policy's second eligibility route, and seeds
+    /// the install date on the first one. Routed through the shim rather than
+    /// written straight from the app entry point, so every `appstore.review.*`
+    /// write goes through `AppStoreReviewStore`.
+    func noteAppLaunched() {
+        // `.task` on the scene root runs once per process, but a second
+        // window (macOS File > New Window, iPadOS multi-scene) re-runs that
+        // body — and this counts launches, not scenes.
+        guard !didCountLaunch else { return }
+        didCountLaunch = true
+        store.recordLaunch()
+    }
+
+    private var didCountLaunch = false
+
+    // MARK: - Inputs the policy cannot see
+
+    /// The one suppressor that is about *this process* rather than the user's
+    /// history, so it cannot be an `Inputs` field. Everything datable — the
+    /// paywall window included — lives in the policy where tests can reach it.
+    ///
+    /// A stray system alert breaks LumeUITests non-deterministically, and since
+    /// every UI test selects by English literal the failure reads as "gear not
+    /// hittable" rather than as an alert.
+    private var isAutomatedRun: Bool {
+        CommandLine.arguments.contains("-ui-testing")
+            || ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+    }
+
+    /// Read here, never inside the policy: this is `"—"` when
+    /// `CFBundleShortVersionString` is missing, and that must not silently
+    /// become a stored `lastPromptedVersion` behind the policy's back.
+    private var currentVersion: String {
+        SupportInfo.appVersion
+    }
+
+    /// Sideloaded / self-compiled builds are re-signed and have no App Store
+    /// listing to review at all.
+    private var isAppStoreBuild: Bool {
+        #if SIDE_LOAD
+            false
+        #else
+            true
+        #endif
+    }
+
+    /// Whether a fire is written back to the throttle.
+    ///
+    /// StoreKit shows the sheet unconditionally in development and spends none
+    /// of Apple's own cap, so recording the attempt there would only stamp a
+    /// 120-day cooldown and a version into the developer's own defaults —
+    /// making the moment visible exactly once per machine.
+    private var persistsAttempts: Bool {
+        #if DEBUG
+            false
+        #else
+            true
+        #endif
+    }
+}

--- a/Lume/Services/Review/AppStoreReviewStore.swift
+++ b/Lume/Services/Review/AppStoreReviewStore.swift
@@ -1,0 +1,144 @@
+//
+//  AppStoreReviewStore.swift
+//  Lume
+//
+//  The device-level counters `AppStoreReviewTrigger` decides on. Small scalar
+//  flags in `UserDefaults`, deliberately not a SwiftData model: the catalog
+//  container backs every browse `@Query` and the CloudKit mirror must never be
+//  `@Query`-bound, so neither is a home for a review counter. State is
+//  per-device, not per-profile and not iCloud-synced.
+//
+//  Writes happen at existing boundaries only — launch, a finished title, an
+//  attempt — never on a timer or per playback tick.
+//
+//  Every write is fenced out on tvOS, which has no review API at any layer:
+//  nothing there ever reads these counters, so writing them would grow values
+//  forever with no consumer. This is the one place that rule is stated.
+//
+
+import Foundation
+
+/// Reads and writes the `appstore.review.*` counters.
+nonisolated struct AppStoreReviewStore {
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    // MARK: - Storage keys
+
+    /// Running count of finished movies/episodes since the last attempt.
+    /// Name kept verbatim from the first implementation so counters in
+    /// already-installed builds survive the update.
+    private static let completionCountKey = "appstore.review.completionCount.v1"
+    /// Marketing version the prompt was last attempted for.
+    private static let lastPromptedVersionKey = "appstore.review.lastPromptedVersion.v1"
+    private static let launchCountKey = "appstore.review.launchCount.v1"
+    /// First launch of the build that introduced this key — deliberately not
+    /// back-seeded from watch history, so existing users simply wait out
+    /// `minimumDaysSinceInstall`.
+    private static let installedAtKey = "appstore.review.installedAt.v1"
+    private static let lastPromptedAtKey = "appstore.review.lastPromptedAt.v1"
+    /// Seeded directly by the trimming test, so not `private`.
+    static let attemptDatesKey = "appstore.review.attemptDates.v1"
+    /// When the paywall was last closed. A policy input like any other, so the
+    /// window it opens is covered by tests rather than living in the shim.
+    private static let paywallDismissedAtKey = "appstore.review.paywallDismissedAt.v1"
+
+    // MARK: - Reads
+
+    var completedTitles: Int {
+        defaults.integer(forKey: Self.completionCountKey)
+    }
+
+    var launches: Int {
+        defaults.integer(forKey: Self.launchCountKey)
+    }
+
+    var installedAt: Date? {
+        defaults.object(forKey: Self.installedAtKey) as? Date
+    }
+
+    var lastPromptedAt: Date? {
+        defaults.object(forKey: Self.lastPromptedAtKey) as? Date
+    }
+
+    var lastPromptedVersion: String? {
+        defaults.string(forKey: Self.lastPromptedVersionKey)
+    }
+
+    var attemptDates: [Date] {
+        defaults.array(forKey: Self.attemptDatesKey) as? [Date] ?? []
+    }
+
+    var paywallDismissedAt: Date? {
+        defaults.object(forKey: Self.paywallDismissedAtKey) as? Date
+    }
+
+    // MARK: - Writes
+
+    /// Counts a launch and, on the first one after this build is installed,
+    /// seeds the install date. Existing users start their seven days here
+    /// rather than being back-seeded from watch history.
+    func recordLaunch(now: Date = Date()) {
+        #if !os(tvOS)
+            if installedAt == nil {
+                defaults.set(now, forKey: Self.installedAtKey)
+            }
+            defaults.set(launches + 1, forKey: Self.launchCountKey)
+        #endif
+    }
+
+    /// Counts a finished movie or episode (the >=90% crossing).
+    func recordCompletedTitle() {
+        #if !os(tvOS)
+            defaults.set(completedTitles + 1, forKey: Self.completionCountKey)
+        #endif
+    }
+
+    /// Timestamps a paywall dismissal, so the prompt can stay out of its way.
+    func recordPaywallDismissal(now: Date = Date()) {
+        #if !os(tvOS)
+            defaults.set(now, forKey: Self.paywallDismissedAtKey)
+        #endif
+    }
+
+    /// Records that the system prompt was *requested*. StoreKit never tells us
+    /// whether it actually appeared, so an attempt is all we can log — and it
+    /// spends the same budget either way.
+    func recordAttempt(version: String, now: Date = Date()) {
+        #if !os(tvOS)
+            let log = AppStoreReviewTrigger.recentAttempts(attemptDates + [now], now: now)
+            defaults.set(log, forKey: Self.attemptDatesKey)
+            defaults.set(now, forKey: Self.lastPromptedAtKey)
+            defaults.set(version, forKey: Self.lastPromptedVersionKey)
+            defaults.set(0, forKey: Self.completionCountKey)
+        #endif
+    }
+
+    // MARK: - Bridging to the policy
+
+    func inputs(
+        currentVersion: String,
+        sessionWasHealthy: Bool = true,
+        isAppStoreBuild: Bool = true,
+        isChildProfileActive: Bool = false,
+        now: Date = Date()
+    ) -> AppStoreReviewTrigger.Inputs {
+        AppStoreReviewTrigger.Inputs(
+            completedTitles: completedTitles,
+            launches: launches,
+            installedAt: installedAt,
+            lastPromptedAt: lastPromptedAt,
+            attemptDates: attemptDates,
+            lastPromptedVersion: lastPromptedVersion,
+            currentVersion: currentVersion,
+            sessionWasHealthy: sessionWasHealthy,
+            isAppStoreBuild: isAppStoreBuild,
+            isChildProfileActive: isChildProfileActive,
+            paywallDismissedAt: paywallDismissedAt,
+            now: now
+        )
+    }
+}

--- a/Lume/Services/Review/AppStoreReviewTrigger.swift
+++ b/Lume/Services/Review/AppStoreReviewTrigger.swift
@@ -1,0 +1,184 @@
+//
+//  AppStoreReviewTrigger.swift
+//  Lume
+//
+//  Decides *whether* to ask the user for an App Store rating. Nothing here
+//  imports StoreKit, touches UserDefaults or reads a clock: every input is
+//  injected and the answer is a value, so the whole policy is testable without
+//  a ModelContainer, a real install date or the system prompt.
+//
+//  The prompt itself is Apple's system sheet, fired by the shim that owns
+//  `requestReview`. Persistence lives in `AppStoreReviewStore`.
+//
+
+import Foundation
+
+/// Whether the moment is right for the system rating prompt.
+///
+/// `requestReview()` returns `Void` and never reports whether the sheet
+/// actually appeared — StoreKit silently no-ops past its own cap of three
+/// appearances per 365 days. So everything below is best-effort on top of that
+/// cap, and what we record is an *attempt*, not a show.
+nonisolated enum AppStoreReviewTrigger {
+    // MARK: - Policy constants
+
+    /// Finished movies/episodes that make a user "engaged" on their own.
+    static let completionThreshold = 3
+    /// Launches required by the second route — the one that reaches a Live TV
+    /// only user, who never produces a VOD completion.
+    static let launchThreshold = 5
+    /// Days since install required alongside `launchThreshold`.
+    static let minimumDaysSinceInstall = 7
+    /// Days that must pass after an attempt before another one is considered.
+    static let promptCooldownDays = 120
+    /// Attempts allowed inside `attemptWindowDays`, mirroring StoreKit's own
+    /// per-year cap so we never burn it on a mediocre moment.
+    static let attemptBudget = 3
+    /// Rolling window the attempt log is trimmed and counted over.
+    static let attemptWindowDays = 365
+    /// How long after a paywall dismissal the prompt stays quiet, so it never
+    /// reads as "we just took your money". Roughly one sitting — a purchase
+    /// itself is neutral, it is only the adjacency that would sting.
+    static let paywallSuppressionHours = 2.0
+
+    // MARK: - Inputs
+
+    /// Everything the decision depends on, injected by the caller.
+    nonisolated struct Inputs: Equatable {
+        var completedTitles: Int
+        var launches: Int
+        /// `nil` before the store has seeded it; disables the launch route.
+        var installedAt: Date?
+        /// `nil` when we have never attempted a prompt — no time floor then.
+        var lastPromptedAt: Date?
+        var attemptDates: [Date]
+        var lastPromptedVersion: String?
+        /// Always injected — never read from `SupportInfo` in here, which
+        /// returns a placeholder when `CFBundleShortVersionString` is missing
+        /// and would silently become a stored version.
+        var currentVersion: String
+        var sessionWasHealthy: Bool
+        var isAppStoreBuild: Bool
+        var isChildProfileActive: Bool
+        /// `nil` when the paywall has never been closed on this device.
+        var paywallDismissedAt: Date?
+        var now: Date
+
+        init(
+            completedTitles: Int,
+            launches: Int,
+            installedAt: Date?,
+            lastPromptedAt: Date? = nil,
+            attemptDates: [Date] = [],
+            lastPromptedVersion: String? = nil,
+            currentVersion: String,
+            sessionWasHealthy: Bool = true,
+            isAppStoreBuild: Bool = true,
+            isChildProfileActive: Bool = false,
+            paywallDismissedAt: Date? = nil,
+            now: Date
+        ) {
+            self.completedTitles = completedTitles
+            self.launches = launches
+            self.installedAt = installedAt
+            self.lastPromptedAt = lastPromptedAt
+            self.attemptDates = attemptDates
+            self.lastPromptedVersion = lastPromptedVersion
+            self.currentVersion = currentVersion
+            self.sessionWasHealthy = sessionWasHealthy
+            self.isAppStoreBuild = isAppStoreBuild
+            self.isChildProfileActive = isChildProfileActive
+            self.paywallDismissedAt = paywallDismissedAt
+            self.now = now
+        }
+    }
+
+    // MARK: - Verdict
+
+    /// Why we are not asking. Raw values are what a QA log prints.
+    nonisolated enum Reason: String, Equatable {
+        case notEngagedYet
+        case tooSoon
+        case sameVersion
+        case budgetSpent
+        case unhealthyPlayback
+        case notAppStoreBuild
+        case childProfile
+        case recentPaywall
+    }
+
+    nonisolated enum Verdict: Equatable {
+        case ask
+        case skip(Reason)
+    }
+
+    // MARK: - Decision
+
+    static func verdict(for inputs: Inputs) -> Verdict {
+        guard inputs.isAppStoreBuild else { return .skip(.notAppStoreBuild) }
+        guard !inputs.isChildProfileActive else { return .skip(.childProfile) }
+        guard inputs.sessionWasHealthy else { return .skip(.unhealthyPlayback) }
+
+        if let paywallDismissedAt = inputs.paywallDismissedAt,
+           hours(from: paywallDismissedAt, to: inputs.now) < paywallSuppressionHours
+        {
+            return .skip(.recentPaywall)
+        }
+
+        guard isEngaged(inputs) else { return .skip(.notEngagedYet) }
+        guard inputs.lastPromptedVersion != inputs.currentVersion else { return .skip(.sameVersion) }
+
+        if let lastPromptedAt = inputs.lastPromptedAt,
+           days(from: lastPromptedAt, to: inputs.now) < Double(promptCooldownDays)
+        {
+            return .skip(.tooSoon)
+        }
+
+        guard recentAttemptCount(inputs.attemptDates, now: inputs.now) < attemptBudget else {
+            return .skip(.budgetSpent)
+        }
+
+        return .ask
+    }
+
+    /// Either route qualifies: enough finished titles, or enough launches over
+    /// enough days. The second route is the only one a Live TV only user can
+    /// ever satisfy — the >=90% completion crossing is VOD-only.
+    static func isEngaged(_ inputs: Inputs) -> Bool {
+        if inputs.completedTitles >= completionThreshold { return true }
+        guard let installedAt = inputs.installedAt else { return false }
+        return inputs.launches >= launchThreshold
+            && days(from: installedAt, to: inputs.now) >= Double(minimumDaysSinceInstall)
+    }
+
+    /// How many attempts fall inside the rolling window — all the verdict
+    /// needs. Dates in the future (clock skew) are counted, which only ever
+    /// suppresses a prompt.
+    static func recentAttemptCount(_ dates: [Date], now: Date) -> Int {
+        let cutoff = attemptCutoff(now: now)
+        return dates.count { $0 > cutoff }
+    }
+
+    /// Attempts inside the rolling window, newest first: the trimmer the store
+    /// writes back with, so the log can't grow without bound.
+    static func recentAttempts(_ dates: [Date], now: Date) -> [Date] {
+        let cutoff = attemptCutoff(now: now)
+        return dates.filter { $0 > cutoff }.sorted(by: >)
+    }
+
+    // MARK: - Private
+
+    private static let secondsPerDay: Double = 24 * 60 * 60
+
+    private static func attemptCutoff(now: Date) -> Date {
+        now.addingTimeInterval(-Double(attemptWindowDays) * secondsPerDay)
+    }
+
+    private static func days(from start: Date, to end: Date) -> Double {
+        end.timeIntervalSince(start) / secondsPerDay
+    }
+
+    private static func hours(from start: Date, to end: Date) -> Double {
+        end.timeIntervalSince(start) / (60 * 60)
+    }
+}

--- a/Lume/Utils/Logger.swift
+++ b/Lume/Utils/Logger.swift
@@ -10,6 +10,7 @@ nonisolated extension Logger {
     static let indexing = Logger(subsystem: subsystem, category: "Indexing")
     static let premium = Logger(subsystem: subsystem, category: "Premium")
     static let memory = Logger(subsystem: subsystem, category: "Memory")
+    static let review = Logger(subsystem: subsystem, category: "Review")
     /// Shares its category with `Perf`'s signposts, so one filter shows both the
     /// phase boundaries and the messages explaining them.
     static let performance = Logger(subsystem: subsystem, category: "Performance")

--- a/Lume/Views/Components/LibraryToolbar.swift
+++ b/Lume/Views/Components/LibraryToolbar.swift
@@ -46,9 +46,17 @@ struct LibraryToolbarModifier: ViewModifier {
                     }
                 }
             }
-            .sheet(isPresented: $showingSettings) {
-                SettingsView()
-            }
+            .sheet(
+                isPresented: $showingSettings,
+                // Settings is a sheet on this toolbar, invisible to the browse
+                // root that fires the rating prompt — so it reports itself, the
+                // way the paywall and the players do.
+                onDismiss: { AppStoreReviewPrompt.shared.noteBlockingSheetDismissed() },
+                content: {
+                    SettingsView()
+                        .onAppear { AppStoreReviewPrompt.shared.noteBlockingSheetAppeared() }
+                }
+            )
             .sheet(isPresented: $showingSync) {
                 if let playlist = activePlaylist {
                     SyncProgressView(playlist: playlist)

--- a/Lume/Views/MainTabView.swift
+++ b/Lume/Views/MainTabView.swift
@@ -64,6 +64,20 @@ struct MainTabView: View {
         CommandLine.arguments.contains("-ui-testing")
     }
 
+    /// Whether the browse UI is covered, or the user is somewhere a rating
+    /// sheet has no business appearing — the sync cover, the downloads sheet, or
+    /// a playlist / profile switch. Players, paywalls and Settings are not
+    /// listed: every one of them reports itself, and `appStoreReviewPrompt`
+    /// already holds the fire while any is on screen. Settings has to, because
+    /// on every platform that shows the prompt it is a sheet on the library
+    /// toolbar rather than a tab, and so invisible to this root.
+    private var hasBlockingPresentation: Bool {
+        activeSyncPlaylist != nil
+            || showsDownloads
+            || playlistSwitch?.isSwitching == true
+            || profileManager?.isSwitching == true
+    }
+
     /// Hides categories (and their content) from every browse, Home and Search
     /// surface: the ones hidden in Content Management always, the restricted
     /// ones while a child profile is active.
@@ -127,6 +141,10 @@ struct MainTabView: View {
             .syncCover(item: $activeSyncPlaylist, onDismiss: promoteNextIfIdle)
             .downloadsSheet(isPresented: $showsDownloads)
             .switchProgressOverlay(playlist: playlistSwitch, profile: profileManager)
+            // The one fire point for the rating sheet. Here rather than at the
+            // eleven player presentation sites: this view is the browse root,
+            // so reaching it *is* the "player gone, nothing over it" condition.
+            .appStoreReviewPrompt(isBlocked: hasBlockingPresentation)
         #if os(tvOS)
             .overlay { tvOverlays }
         #endif

--- a/Lume/Views/Player/FullScreenPlayerView+AudioSession.swift
+++ b/Lume/Views/Player/FullScreenPlayerView+AudioSession.swift
@@ -1,0 +1,52 @@
+//
+//  FullScreenPlayerView+AudioSession.swift
+//  Lume
+//
+//  The player's global audio-session handling, split out of
+//  `FullScreenPlayerView` to keep that file inside the 600-line cap.
+//
+//  Only LumeEngine needs this: KSPlayer and VLCKit configure `AVAudioSession`
+//  themselves, so these two calls are no-ops from their point of view but must
+//  still bracket every session, since the engine in use can change mid-player
+//  through a fallback.
+//
+
+import AVFoundation
+import OSLog
+
+extension FullScreenPlayerView {
+    func configureAudioSessionForPlayback() {
+        // tvOS needs this as much as iOS: LumeEngine renders PCM through
+        // AVSampleBufferAudioRenderer and sizes its downmix to the session's
+        // *negotiated* output channels — without an active .playback session
+        // the route stays at its default and multichannel audio has no path.
+        // (KSPlayer/VLC configure their own session; LumeEngine by design
+        // does not touch global audio state, so it is the app's job.)
+        #if os(iOS) || os(tvOS)
+            let session = AVAudioSession.sharedInstance()
+            try? session.setCategory(.playback, mode: .moviePlayback, options: [])
+            // Ask for the route's full width (HDMI LPCM surround); harmless
+            // when the route is stereo — the session clamps and LumeEngine
+            // downmixes to whatever was actually granted.
+            let maxChannels = session.maximumOutputNumberOfChannels
+            if maxChannels > 2 {
+                try? session.setPreferredOutputNumberOfChannels(maxChannels)
+            }
+            try? session.setActive(true, options: [])
+            let route = session.currentRoute.outputs
+                .map { "\($0.portType.rawValue)(\($0.channels?.count ?? 0)ch)" }
+                .joined(separator: "+")
+            Logger.player.info("""
+            Audio session active: route=\(route, privacy: .public) \
+            outputChannels=\(session.outputNumberOfChannels) \
+            maxChannels=\(maxChannels) sampleRate=\(session.sampleRate)
+            """)
+        #endif
+    }
+
+    func releaseAudioSession() {
+        #if os(iOS) || os(tvOS)
+            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        #endif
+    }
+}

--- a/Lume/Views/Player/FullScreenPlayerView+Review.swift
+++ b/Lume/Views/Player/FullScreenPlayerView+Review.swift
@@ -1,0 +1,71 @@
+//
+//  FullScreenPlayerView+Review.swift
+//  Lume
+//
+//  The player's half of the App Store review prompt. It brackets the session
+//  so its health can be judged, and reports the verdict when the player
+//  closes. It never presents anything: the sheet is requested from the browse
+//  root, once this player is genuinely gone.
+//
+//  `persistProgressDetached` — where a finished title is noticed — deliberately
+//  only *counts*. It also runs from `onDisappear` and from the scene-phase
+//  handler, so a prompt raised there would land on a screen the viewer has
+//  already left, or on an app that is backgrounding.
+//
+//  Both brackets compile down to nothing on tvOS, where there is no review API
+//  to arm for: the verdict they produce has no reader there. The call sites in
+//  `FullScreenPlayerView` stay unfenced so the player body reads the same on
+//  every platform.
+//
+
+import SwiftUI
+
+extension FullScreenPlayerView {
+    /// Opens the health bracket for this session. Called once per player, not
+    /// per engine attempt — the window whose health matters spans startup
+    /// retries, engine fallbacks and in-player episode swaps.
+    ///
+    /// The token is held per view rather than in the tracker, so a second
+    /// player opening in another window or scene cannot overwrite this
+    /// session's baseline.
+    func beginReviewSession() {
+        #if !os(tvOS)
+            healthToken = PlaybackHealthTracker.shared.beginSession()
+            AppStoreReviewPrompt.shared.notePlayerAppeared()
+        #endif
+    }
+
+    /// Closes the bracket and lets the review policy judge the moment.
+    ///
+    /// Deferred by one turn: each engine flushes its final QoE numbers in its
+    /// own `onDisappear`, and the order of those against this view's is
+    /// undefined, so a synchronous snapshot would measure a truncated session.
+    ///
+    /// - Parameter isChildWatching: read at the call site, where the optional
+    ///   `ProfileManager` this view holds is still in scope.
+    func endReviewSession(isChildWatching: Bool) {
+        #if !os(tvOS)
+            let token = healthToken
+            let pendingWrite = pendingProgressWrite
+            healthToken = nil
+
+            // The screen is clear either way, so report that first and
+            // unconditionally — the policy evaluation below can wait, the "is a
+            // player up" answer cannot.
+            AppStoreReviewPrompt.shared.notePlayerDisappeared()
+
+            Task {
+                // A finished title is counted by the progress write, which awaits
+                // an actor. Waiting for it here is what lets the session that
+                // finished the third title arm on its own dismissal instead of the
+                // one after it.
+                await pendingWrite?.value
+                let health = token.flatMap { PlaybackHealthTracker.shared.endSession($0) }
+                AppStoreReviewPrompt.shared.noteSessionEnded(
+                    health: health,
+                    isChildProfileActive: isChildWatching
+                )
+            }
+        #endif
+    }
+}

--- a/Lume/Views/Player/FullScreenPlayerView.swift
+++ b/Lume/Views/Player/FullScreenPlayerView.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import OSLog
 import SwiftData
 import SwiftUI
@@ -16,6 +15,16 @@ struct FullScreenPlayerView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @Environment(\.scenePhase) private var scenePhase
+    /// Optional so previews (which don't inject it) don't crash.
+    @Environment(ProfileManager.self) private var profileManager: ProfileManager?
+    /// This player's own playback-health bracket. Per view, not per tracker:
+    /// macOS opens the player in its own window and iPadOS can run several
+    /// scenes, so two sessions can be in flight at once.
+    @State var healthToken: PlaybackHealthTracker.Token?
+    /// The in-flight progress write, so the review policy can wait for a
+    /// finished title to be counted before it judges the session that
+    /// finished it.
+    @State var pendingProgressWrite: Task<Void, Never>?
     #if os(macOS)
         @Environment(\.dismissWindow) private var dismissWindow
     #endif
@@ -206,6 +215,12 @@ struct FullScreenPlayerView: View {
         #endif
         .persistentSystemOverlays(.hidden)
         .preferredColorScheme(.dark)
+        // Synchronous on purpose, and ahead of the `.task` below: the engine
+        // coordinators report `beginStartup` / `noteEngineFallback` from their
+        // own appearance, and an async baseline can land after them — which
+        // would bake a fault the viewer just lived through into the "before"
+        // snapshot and read the session as flawless.
+        .onAppear { beginReviewSession() }
         .task {
             // Seed the recall pair with the channel we opened on, so the very
             // first in-player recall has somewhere to jump back to.
@@ -311,6 +326,7 @@ struct FullScreenPlayerView: View {
             NowPlayingService.shared.endSession()
             releaseAudioSession()
             ContentIndexingService.shared.isPlaybackActive = false
+            endReviewSession(isChildWatching: profileManager?.activeProfileIsChild ?? false)
         }
     }
 
@@ -470,41 +486,6 @@ struct FullScreenPlayerView: View {
         #endif
     }
 
-    private func configureAudioSessionForPlayback() {
-        // tvOS needs this as much as iOS: LumeEngine renders PCM through
-        // AVSampleBufferAudioRenderer and sizes its downmix to the session's
-        // *negotiated* output channels — without an active .playback session
-        // the route stays at its default and multichannel audio has no path.
-        // (KSPlayer/VLC configure their own session; LumeEngine by design
-        // does not touch global audio state, so it is the app's job.)
-        #if os(iOS) || os(tvOS)
-            let session = AVAudioSession.sharedInstance()
-            try? session.setCategory(.playback, mode: .moviePlayback, options: [])
-            // Ask for the route's full width (HDMI LPCM surround); harmless
-            // when the route is stereo — the session clamps and LumeEngine
-            // downmixes to whatever was actually granted.
-            let maxChannels = session.maximumOutputNumberOfChannels
-            if maxChannels > 2 {
-                try? session.setPreferredOutputNumberOfChannels(maxChannels)
-            }
-            try? session.setActive(true, options: [])
-            let route = session.currentRoute.outputs
-                .map { "\($0.portType.rawValue)(\($0.channels?.count ?? 0)ch)" }
-                .joined(separator: "+")
-            Logger.player.info("""
-            Audio session active: route=\(route, privacy: .public) \
-            outputChannels=\(session.outputNumberOfChannels) \
-            maxChannels=\(maxChannels) sampleRate=\(session.sampleRate)
-            """)
-        #endif
-    }
-
-    private func releaseAudioSession() {
-        #if os(iOS) || os(tvOS)
-            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-        #endif
-    }
-
     #if os(macOS)
         private func enterMacFullScreen() {
             // Wait for the window to mount before toggling fullscreen.
@@ -547,12 +528,19 @@ struct FullScreenPlayerView: View {
         let ref = activeMedia.contentRef
         let now = clock.current
         let total = clock.duration
-        Task { @MainActor in
+        // Held so `endReviewSession` can await it: `writer` is an actor, so the
+        // await below suspends, and without the handle the review policy would
+        // read `completedTitles` before this task increments it — the third
+        // finished title would then only arm the *next* session.
+        pendingProgressWrite = Task { @MainActor in
             let completion = await writer.record(
                 ref: ref, progress: now, duration: total, force: force
             )
             WatchProgressBuffer.remove(ref: ref)
-            if let completion { syncTraktWatched(ref: completion.ref) }
+            if let completion {
+                syncTraktWatched(ref: completion.ref)
+                AppStoreReviewPrompt.shared.noteCompletedTitle()
+            }
         }
     }
 

--- a/Lume/Views/Player/MultiView/MultiViewScreen.swift
+++ b/Lume/Views/Player/MultiView/MultiViewScreen.swift
@@ -209,6 +209,11 @@ struct MultiViewScreen: View {
                 // The tiles' QoE reports would be nonsense against a summary that
                 // models one stream at a time.
                 PlaybackQoE.shared.isSuspended = true
+                // Reported from here rather than the presentation sites: on macOS
+                // the grid is its own window with the browse root still visible,
+                // so an armed rating sheet would otherwise animate in over four
+                // running streams.
+                AppStoreReviewPrompt.shared.notePlayerAppeared()
                 // Background indexing merges periodic saves into the main context,
                 // which hitches every running decoder — more so with four of them.
                 ContentIndexingService.shared.isPlaybackActive = true
@@ -269,6 +274,7 @@ struct MultiViewScreen: View {
                 releaseAudioSession()
                 ContentIndexingService.shared.isPlaybackActive = false
                 PlaybackQoE.shared.isSuspended = false
+                AppStoreReviewPrompt.shared.notePlayerDisappeared()
             }
         #if os(tvOS)
             // Only reached when the picker isn't presented — its own cover handles

--- a/Lume/Views/Premium/PaywallModifier.swift
+++ b/Lume/Views/Premium/PaywallModifier.swift
@@ -12,8 +12,18 @@ import SwiftUI
 
 extension View {
     func paywall(isPresented: Binding<Bool>, highlight: PremiumFeature? = nil) -> some View {
-        sheet(isPresented: isPresented) {
-            PaywallView(highlight: highlight)
-        }
+        // The single central presentation point, so it is also the one place
+        // that can tell the review prompt to keep its distance from a paywall
+        // the user just closed.
+        sheet(
+            isPresented: isPresented,
+            onDismiss: { AppStoreReviewPrompt.shared.notePaywallDismissed() },
+            content: {
+                PaywallView(highlight: highlight)
+                    // Paired with `onDismiss` above so the review prompt knows
+                    // a paywall is on screen, not merely that one has closed.
+                    .onAppear { AppStoreReviewPrompt.shared.notePaywallAppeared() }
+            }
+        )
     }
 }

--- a/Lume/Views/Review/AppStoreReviewPromptModifier.swift
+++ b/Lume/Views/Review/AppStoreReviewPromptModifier.swift
@@ -1,0 +1,95 @@
+//
+//  AppStoreReviewPromptModifier.swift
+//  Lume
+//
+//  Fires an already-armed rating sheet at the first genuinely safe moment.
+//
+//  "Safe" is four conditions at once: the app is active, the browse UI is on
+//  screen, nothing of its own is presented over it, and no player is up. The
+//  last one cannot be read from a presentation binding — the player is opened
+//  from eleven call sites, and on macOS it is a separate window entirely — so
+//  it comes from `AppStoreReviewPrompt.playerIsVisible` instead.
+//
+//  tvOS has no review API at any layer, so this compiles down to `self` there.
+//  The fence is compile-time because `RequestReviewAction` is unavailable on
+//  tvOS *as a type*: an `@Environment(\.requestReview)` declaration outside the
+//  fence fails that build even with nothing calling it, which no `#available`
+//  check could prevent.
+//
+
+import SwiftUI
+
+#if !os(tvOS)
+    // `RequestReviewAction` lives in the StoreKit/SwiftUI cross-import overlay,
+    // so it only resolves with both modules imported.
+    import StoreKit
+#endif
+
+extension View {
+    /// Requests the system rating sheet here once one has been armed.
+    ///
+    /// - Parameter isBlocked: whether this view currently has a sheet, cover or
+    ///   blocking overlay of its own on screen.
+    func appStoreReviewPrompt(isBlocked: Bool) -> some View {
+        #if os(tvOS)
+            self
+        #else
+            modifier(AppStoreReviewPromptModifier(isBlocked: isBlocked))
+        #endif
+    }
+}
+
+#if !os(tvOS)
+    private struct AppStoreReviewPromptModifier: ViewModifier {
+        @Environment(\.requestReview) private var requestReview
+        @Environment(\.scenePhase) private var scenePhase
+
+        let isBlocked: Bool
+
+        /// Long enough for a dismissal transition to finish and the browse UI to
+        /// settle, so the alert doesn't animate in over a closing player.
+        private static let settleDelay: Duration = .seconds(1)
+
+        /// Reading the prompt's own state here is what subscribes this view to
+        /// a player or paywall opening and closing anywhere in the app — none of
+        /// which the browse root can see for itself.
+        ///
+        /// `isArmed` is part of the condition rather than only a guard inside
+        /// the task: an arm that lands while everything else is already safe
+        /// still has to start one, and keying on the environment alone would
+        /// leave it waiting for a change that never comes.
+        private var canFire: Bool {
+            scenePhase == .active
+                && !isBlocked
+                && !AppStoreReviewPrompt.shared.playerIsVisible
+                && !AppStoreReviewPrompt.shared.paywallIsVisible
+                && !AppStoreReviewPrompt.shared.blockingSheetIsVisible
+                && AppStoreReviewPrompt.shared.isArmed
+        }
+
+        func body(content: Content) -> some View {
+            content
+                // Keyed on the whole condition rather than driven by `onChange`
+                // handlers: any part of it going false cancels a pending fire
+                // instead of leaving it to land on the wrong screen.
+                .task(id: canFire) {
+                    guard canFire else { return }
+                    try? await Task.sleep(for: Self.settleDelay)
+                    guard !Task.isCancelled else { return }
+
+                    // A hold is re-offered for `recentPaywall` alone: every
+                    // other reason is fixed for this launch — a version match,
+                    // a spent budget, a 120-day floor — so a second look would
+                    // re-read the counters only to decline again.
+                    guard let reason = AppStoreReviewPrompt.shared.fireIfArmed(requestReview),
+                          reason == .recentPaywall,
+                          let retryDelay = AppStoreReviewPrompt.shared.paywallRetryDelay
+                    else { return }
+
+                    try? await Task.sleep(for: retryDelay)
+                    guard !Task.isCancelled else { return }
+                    AppStoreReviewPrompt.shared.fireIfArmed(requestReview)
+                }
+        }
+    }
+#endif

--- a/LumeTests/Services/AppStoreReviewTriggerTests.swift
+++ b/LumeTests/Services/AppStoreReviewTriggerTests.swift
@@ -1,0 +1,593 @@
+import Foundation
+@testable import Lume
+import Testing
+
+final class AppStoreReviewTriggerTests {
+    // MARK: - Fixtures
+
+    /// A fixed clock. Nothing here may read `Date()`: the policy's floors are
+    /// measured in months, and a real clock would make the assertions depend on
+    /// when the suite happens to run.
+    private static let referenceNow = Date(timeIntervalSince1970: 1_750_000_000)
+    private static let day: TimeInterval = 24 * 60 * 60
+
+    private let now = AppStoreReviewTriggerTests.referenceNow
+
+    private func daysAgo(_ count: Double) -> Date {
+        now.addingTimeInterval(-count * Self.day)
+    }
+
+    /// Suites created by `makeDefaults`, torn down together so a test's
+    /// counters can never leak into another test or into the shim's singleton.
+    private var suiteNames: [String] = []
+
+    deinit {
+        for name in suiteNames {
+            UserDefaults.standard.removePersistentDomain(forName: name)
+        }
+    }
+
+    /// A throwaway, empty `UserDefaults` domain so the policy never reads or
+    /// mutates the shared standard suite.
+    private func makeDefaults() throws -> UserDefaults {
+        let suiteName = "AppStoreReviewTriggerTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        suiteNames.append(suiteName)
+        return defaults
+    }
+
+    private func makeStore() throws -> AppStoreReviewStore {
+        try AppStoreReviewStore(defaults: makeDefaults())
+    }
+
+    /// The engaged baseline the throttle and suppressor cases start from:
+    /// enough completions to qualify, on a version that was never prompted,
+    /// with nothing spent and no suppressor set. Each test overrides only the
+    /// field it is about.
+    private func engagedInputs(
+        lastPromptedAt: Date? = nil,
+        attemptDates: [Date] = [],
+        lastPromptedVersion: String? = nil,
+        sessionWasHealthy: Bool = true,
+        isAppStoreBuild: Bool = true,
+        isChildProfileActive: Bool = false,
+        paywallDismissedAt: Date? = nil
+    ) -> AppStoreReviewTrigger.Inputs {
+        AppStoreReviewTrigger.Inputs(
+            completedTitles: AppStoreReviewTrigger.completionThreshold,
+            launches: 0,
+            installedAt: nil,
+            lastPromptedAt: lastPromptedAt,
+            attemptDates: attemptDates,
+            lastPromptedVersion: lastPromptedVersion,
+            currentVersion: "2.0",
+            sessionWasHealthy: sessionWasHealthy,
+            isAppStoreBuild: isAppStoreBuild,
+            isChildProfileActive: isChildProfileActive,
+            paywallDismissedAt: paywallDismissedAt,
+            now: now
+        )
+    }
+
+    // MARK: - Existing cases, on the new API
+
+    @Test func `does not ask before the completion threshold`() throws {
+        let store = try makeStore()
+        store.recordLaunch(now: now)
+        for _ in 1 ..< AppStoreReviewTrigger.completionThreshold {
+            store.recordCompletedTitle()
+        }
+        let verdict = AppStoreReviewTrigger.verdict(
+            for: store.inputs(currentVersion: "1.0", now: now)
+        )
+        #expect(verdict == .skip(.notEngagedYet))
+    }
+
+    @Test func `asks once the threshold is reached`() throws {
+        let store = try makeStore()
+        store.recordLaunch(now: now)
+        for _ in 0 ..< AppStoreReviewTrigger.completionThreshold {
+            store.recordCompletedTitle()
+        }
+        #expect(AppStoreReviewTrigger.verdict(for: store.inputs(currentVersion: "1.0", now: now)) == .ask)
+    }
+
+    @Test func `does not ask twice on the same version`() throws {
+        let store = try makeStore()
+        for _ in 0 ..< AppStoreReviewTrigger.completionThreshold {
+            store.recordCompletedTitle()
+        }
+        store.recordAttempt(version: "1.0", now: now)
+
+        // The attempt reset the counter, so re-earn engagement and confirm the
+        // version guard still blocks the same version.
+        for _ in 0 ..< AppStoreReviewTrigger.completionThreshold {
+            store.recordCompletedTitle()
+        }
+        #expect(AppStoreReviewTrigger.verdict(for: store.inputs(currentVersion: "1.0", now: now)) == .skip(.sameVersion))
+    }
+
+    @Test func `asks again after an app update and the cooldown`() throws {
+        let store = try makeStore()
+        let promptedAt = daysAgo(400)
+        for _ in 0 ..< AppStoreReviewTrigger.completionThreshold {
+            store.recordCompletedTitle()
+        }
+        store.recordAttempt(version: "1.0", now: promptedAt)
+
+        for _ in 0 ..< AppStoreReviewTrigger.completionThreshold {
+            store.recordCompletedTitle()
+        }
+        let insideCooldown = promptedAt.addingTimeInterval(Self.day * Double(AppStoreReviewTrigger.promptCooldownDays - 1))
+        let afterCooldown = promptedAt.addingTimeInterval(Self.day * Double(AppStoreReviewTrigger.promptCooldownDays + 1))
+
+        #expect(
+            AppStoreReviewTrigger.verdict(for: store.inputs(currentVersion: "1.1", now: insideCooldown))
+                == .skip(.tooSoon)
+        )
+        #expect(AppStoreReviewTrigger.verdict(for: store.inputs(currentVersion: "1.1", now: afterCooldown)) == .ask)
+    }
+
+    // MARK: - Eligibility: the two routes
+
+    @Test func `completions alone qualify without any launch history`() {
+        let inputs = AppStoreReviewTrigger.Inputs(
+            completedTitles: AppStoreReviewTrigger.completionThreshold,
+            launches: 0,
+            installedAt: nil,
+            currentVersion: "2.0",
+            now: now
+        )
+        #expect(AppStoreReviewTrigger.verdict(for: inputs) == .ask)
+    }
+
+    @Test func `launches over enough days qualify without any completion`() {
+        let inputs = AppStoreReviewTrigger.Inputs(
+            completedTitles: 0,
+            launches: AppStoreReviewTrigger.launchThreshold,
+            installedAt: daysAgo(Double(AppStoreReviewTrigger.minimumDaysSinceInstall)),
+            currentVersion: "2.0",
+            now: now
+        )
+        #expect(AppStoreReviewTrigger.verdict(for: inputs) == .ask)
+    }
+
+    @Test func `a half satisfied route does not qualify`() {
+        let oneCompletionShort = AppStoreReviewTrigger.Inputs(
+            completedTitles: AppStoreReviewTrigger.completionThreshold - 1,
+            launches: AppStoreReviewTrigger.launchThreshold - 1,
+            installedAt: daysAgo(400),
+            currentVersion: "2.0",
+            now: now
+        )
+        let enoughLaunchesTooNew = AppStoreReviewTrigger.Inputs(
+            completedTitles: 0,
+            launches: AppStoreReviewTrigger.launchThreshold,
+            installedAt: daysAgo(Double(AppStoreReviewTrigger.minimumDaysSinceInstall) - 1),
+            currentVersion: "2.0",
+            now: now
+        )
+        let oldEnoughTooFewLaunches = AppStoreReviewTrigger.Inputs(
+            completedTitles: 0,
+            launches: AppStoreReviewTrigger.launchThreshold - 1,
+            installedAt: daysAgo(400),
+            currentVersion: "2.0",
+            now: now
+        )
+        let launchesButNoInstallDate = AppStoreReviewTrigger.Inputs(
+            completedTitles: 0,
+            launches: AppStoreReviewTrigger.launchThreshold * 10,
+            installedAt: nil,
+            currentVersion: "2.0",
+            now: now
+        )
+
+        #expect(AppStoreReviewTrigger.verdict(for: oneCompletionShort) == .skip(.notEngagedYet))
+        #expect(AppStoreReviewTrigger.verdict(for: enoughLaunchesTooNew) == .skip(.notEngagedYet))
+        #expect(AppStoreReviewTrigger.verdict(for: oldEnoughTooFewLaunches) == .skip(.notEngagedYet))
+        #expect(AppStoreReviewTrigger.verdict(for: launchesButNoInstallDate) == .skip(.notEngagedYet))
+    }
+
+    // MARK: - Throttle
+
+    @Test func `the time floor blocks a prompt until the cooldown elapses`() {
+        func verdict(daysSincePrompt: Double) -> AppStoreReviewTrigger.Verdict {
+            AppStoreReviewTrigger.verdict(
+                for: engagedInputs(
+                    lastPromptedAt: daysAgo(daysSincePrompt),
+                    attemptDates: [daysAgo(daysSincePrompt)],
+                    lastPromptedVersion: "1.0"
+                )
+            )
+        }
+
+        let floor = Double(AppStoreReviewTrigger.promptCooldownDays)
+        #expect(verdict(daysSincePrompt: 1) == .skip(.tooSoon))
+        #expect(verdict(daysSincePrompt: floor - 1) == .skip(.tooSoon))
+        #expect(verdict(daysSincePrompt: floor) == .ask)
+        #expect(verdict(daysSincePrompt: floor + 1) == .ask)
+    }
+
+    @Test func `there is no time floor before the first attempt`() {
+        let inputs = engagedInputs(lastPromptedAt: nil)
+        #expect(AppStoreReviewTrigger.verdict(for: inputs) == .ask)
+    }
+
+    @Test func `the same version is blocked even once the cooldown has elapsed`() {
+        let inputs = engagedInputs(
+            lastPromptedAt: daysAgo(400),
+            attemptDates: [daysAgo(400)],
+            lastPromptedVersion: "2.0"
+        )
+        #expect(AppStoreReviewTrigger.verdict(for: inputs) == .skip(.sameVersion))
+    }
+
+    @Test func `the rolling budget blocks a fourth attempt inside the window`() {
+        func verdict(attemptDates: [Date]) -> AppStoreReviewTrigger.Verdict {
+            AppStoreReviewTrigger.verdict(
+                for: engagedInputs(
+                    lastPromptedAt: daysAgo(130),
+                    attemptDates: attemptDates,
+                    lastPromptedVersion: "1.0"
+                )
+            )
+        }
+
+        let window = Double(AppStoreReviewTrigger.attemptWindowDays)
+        let spent = [daysAgo(130), daysAgo(260), daysAgo(window - 1)]
+        #expect(verdict(attemptDates: spent) == .skip(.budgetSpent))
+
+        // Same three attempts, but the oldest has aged out of the window.
+        let oneAgedOut = [daysAgo(130), daysAgo(260), daysAgo(window + 1)]
+        #expect(verdict(attemptDates: oneAgedOut) == .ask)
+    }
+
+    @Test func `the attempt log only counts the trailing window`() {
+        let dates = [daysAgo(1), daysAgo(200), daysAgo(400), daysAgo(1000)]
+        let recent = AppStoreReviewTrigger.recentAttempts(dates, now: now)
+        #expect(recent == [daysAgo(1), daysAgo(200)])
+    }
+
+    // MARK: - Hard suppressors
+
+    @Test func `a build without an App Store listing never asks`() {
+        let inputs = engagedInputs(isAppStoreBuild: false)
+        #expect(AppStoreReviewTrigger.verdict(for: inputs) == .skip(.notAppStoreBuild))
+    }
+
+    @Test func `an active child profile never asks`() {
+        let inputs = engagedInputs(isChildProfileActive: true)
+        #expect(AppStoreReviewTrigger.verdict(for: inputs) == .skip(.childProfile))
+    }
+
+    @Test func `an unhealthy playback session never asks`() {
+        let inputs = engagedInputs(sessionWasHealthy: false)
+        #expect(AppStoreReviewTrigger.verdict(for: inputs) == .skip(.unhealthyPlayback))
+    }
+
+    @Test func `a recently dismissed paywall never asks`() {
+        let inputs = engagedInputs(paywallDismissedAt: now.addingTimeInterval(-30 * 60))
+        #expect(AppStoreReviewTrigger.verdict(for: inputs) == .skip(.recentPaywall))
+    }
+
+    @Test func `the paywall window expires`() {
+        let elapsed = (AppStoreReviewTrigger.paywallSuppressionHours + 1) * 60 * 60
+        let inputs = engagedInputs(paywallDismissedAt: now.addingTimeInterval(-elapsed))
+        #expect(AppStoreReviewTrigger.verdict(for: inputs) == .ask)
+    }
+
+    @Test func `a paywall that was never opened does not suppress`() {
+        let inputs = engagedInputs(paywallDismissedAt: nil)
+        #expect(AppStoreReviewTrigger.verdict(for: inputs) == .ask)
+    }
+
+    // MARK: - Persistence
+
+    @Test func `counts each launch once and seeds the install date only once`() throws {
+        let store = try makeStore()
+        let firstLaunch = daysAgo(30)
+        store.recordLaunch(now: firstLaunch)
+        store.recordLaunch(now: daysAgo(20))
+        store.recordLaunch(now: now)
+
+        #expect(store.launches == 3)
+        #expect(store.installedAt == firstLaunch)
+    }
+
+    @Test func `recording an attempt stamps the version and resets the counter`() throws {
+        let store = try makeStore()
+        for _ in 0 ..< AppStoreReviewTrigger.completionThreshold {
+            store.recordCompletedTitle()
+        }
+        store.recordAttempt(version: "2.0", now: now)
+
+        #expect(store.completedTitles == 0)
+        #expect(store.lastPromptedVersion == "2.0")
+        #expect(store.lastPromptedAt == now)
+        #expect(store.attemptDates == [now])
+    }
+
+    @Test func `recording an attempt trims the stored log to the window`() throws {
+        let defaults = try makeDefaults()
+        let store = AppStoreReviewStore(defaults: defaults)
+        let window = Double(AppStoreReviewTrigger.attemptWindowDays)
+        defaults.set(
+            [daysAgo(window + 10), daysAgo(200)],
+            forKey: AppStoreReviewStore.attemptDatesKey
+        )
+
+        store.recordAttempt(version: "2.0", now: now)
+
+        #expect(store.attemptDates == [now, daysAgo(200)])
+    }
+}
+
+// MARK: - Session health
+
+/// The gate that decides whether the policy above is ever consulted. Pure, so
+/// it needs no player, no engine and no simulator — only two snapshots.
+final class PlaybackSessionHealthTests {
+    /// Comfortably past `minimumWatchedSeconds`, so these cases turn on the
+    /// fault being measured rather than on the short-session exclusion.
+    private let watched = PlaybackSessionHealth.minimumWatchedSeconds * 10
+
+    private func snapshot(
+        engineFallbacks: Int = 0,
+        startupFailures: Int = 0,
+        rebufferSeconds: TimeInterval = 0,
+        watchedSeconds: TimeInterval = 0
+    ) -> PlaybackHealthSnapshot {
+        var snapshot = PlaybackHealthSnapshot()
+        snapshot.engineFallbacks = engineFallbacks
+        snapshot.startupFailures = startupFailures
+        snapshot.rebufferSeconds = rebufferSeconds
+        snapshot.watchedSeconds = watchedSeconds
+        return snapshot
+    }
+
+    @Test func `a clean session of decent length is healthy`() {
+        let verdict = PlaybackSessionHealth.verdict(
+            from: snapshot(),
+            to: snapshot(watchedSeconds: watched)
+        )
+        #expect(verdict == .healthy)
+    }
+
+    /// The whole reason the tracker diffs instead of reading the summary: a
+    /// user with a lifetime of faults behind them can still have a clean
+    /// session, and must still be askable.
+    @Test func `faults already on the clock do not taint a clean session`() {
+        let verdict = PlaybackSessionHealth.verdict(
+            from: snapshot(engineFallbacks: 12, startupFailures: 30, rebufferSeconds: 900),
+            to: snapshot(
+                engineFallbacks: 12,
+                startupFailures: 30,
+                rebufferSeconds: 900,
+                watchedSeconds: watched
+            )
+        )
+        #expect(verdict == .healthy)
+    }
+
+    @Test func `an engine fallback during the session is unhealthy`() {
+        let verdict = PlaybackSessionHealth.verdict(
+            from: snapshot(engineFallbacks: 1),
+            to: snapshot(engineFallbacks: 2, watchedSeconds: watched)
+        )
+        #expect(verdict == .unhealthy(.engineFallback))
+    }
+
+    @Test func `a startup failure during the session is unhealthy`() {
+        let verdict = PlaybackSessionHealth.verdict(
+            from: snapshot(startupFailures: 4),
+            to: snapshot(startupFailures: 5, watchedSeconds: watched)
+        )
+        #expect(verdict == .unhealthy(.startupFailure))
+    }
+
+    @Test func `rebuffering past the ceiling is unhealthy`() {
+        let stalled = watched * (PlaybackSessionHealth.rebufferRatioCeiling + 0.01)
+        let verdict = PlaybackSessionHealth.verdict(
+            from: snapshot(),
+            to: snapshot(rebufferSeconds: stalled, watchedSeconds: watched)
+        )
+        #expect(verdict == .unhealthy(.rebuffering))
+    }
+
+    @Test func `rebuffering under the ceiling is still healthy`() {
+        let stalled = watched * (PlaybackSessionHealth.rebufferRatioCeiling - 0.01)
+        let verdict = PlaybackSessionHealth.verdict(
+            from: snapshot(),
+            to: snapshot(rebufferSeconds: stalled, watchedSeconds: watched)
+        )
+        #expect(verdict == .healthy)
+    }
+
+    /// A session too short to judge is deliberately *not* healthy: a diff of
+    /// zeros would otherwise read as flawless and arm a prompt off a viewer who
+    /// opened a channel and immediately left.
+    @Test func `a session below the watch floor is not measured`() {
+        let verdict = PlaybackSessionHealth.verdict(
+            from: snapshot(),
+            to: snapshot(watchedSeconds: PlaybackSessionHealth.minimumWatchedSeconds - 1)
+        )
+        #expect(verdict == .notMeasured(.tooShort))
+        #expect(verdict.isHealthy == false)
+    }
+
+    @Test func `only the healthy verdict may arm a prompt`() {
+        #expect(PlaybackSessionHealth.healthy.isHealthy)
+        #expect(PlaybackSessionHealth.unhealthy(.rebuffering).isHealthy == false)
+        #expect(PlaybackSessionHealth.notMeasured(.suspended).isHealthy == false)
+    }
+}
+
+// MARK: - Session brackets
+
+/// The tracker's bookkeeping, not the verdict maths. Two players can be open at
+/// once — macOS gives the player its own window, iPadOS its own scene — and a
+/// single-slot tracker let the second one clobber the first one's baseline, so
+/// the first was judged against the wrong snapshot and the second inherited a
+/// verdict it had not earned.
+@MainActor
+final class PlaybackHealthTrackerTests {
+    /// QoE is a shared singleton, so every test leaves its suspension flag the
+    /// way it found it — restored inside the test body, never in `deinit`,
+    /// which is nonisolated and cannot touch main-actor state. Nothing here
+    /// calls `reset()`, which would persist to the standard defaults suite.
+    init() {
+        PlaybackQoE.shared.isSuspended = false
+    }
+
+    @Test func `concurrent sessions get their own brackets`() {
+        let first = PlaybackHealthTracker.shared.beginSession()
+        let second = PlaybackHealthTracker.shared.beginSession()
+        #expect(first != second)
+
+        // Closing the second must leave the first's bracket open, which is
+        // exactly what a single slot could not do.
+        #expect(PlaybackHealthTracker.shared.endSession(second) != nil)
+        #expect(PlaybackHealthTracker.shared.endSession(first) != nil)
+    }
+
+    @Test func `a closed session cannot be closed twice`() {
+        let token = PlaybackHealthTracker.shared.beginSession()
+        #expect(PlaybackHealthTracker.shared.endSession(token) != nil)
+        // No stale verdict to inherit: the bracket is gone, not merely stale.
+        #expect(PlaybackHealthTracker.shared.endSession(token) == nil)
+    }
+
+    @Test func `a session that began while QoE was suspended is not measured`() {
+        PlaybackQoE.shared.isSuspended = true
+        let token = PlaybackHealthTracker.shared.beginSession()
+        PlaybackQoE.shared.isSuspended = false
+        #expect(PlaybackHealthTracker.shared.endSession(token) == .notMeasured(.suspended))
+    }
+
+    @Test func `a suspended session stays unmeasured even if it began clear`() {
+        let token = PlaybackHealthTracker.shared.beginSession()
+        PlaybackQoE.shared.isSuspended = true
+        defer { PlaybackQoE.shared.isSuspended = false }
+        #expect(PlaybackHealthTracker.shared.endSession(token) == .notMeasured(.suspended))
+    }
+}
+
+// MARK: - Shim bookkeeping
+
+/// The arm/hold side of the prompt. `RequestReviewAction` cannot be
+/// constructed, so firing itself is out of reach — but every decision that
+/// leads up to it is reachable, because the shim takes an injectable
+/// `UserDefaults` and exposes what it armed.
+@MainActor
+final class AppStoreReviewPromptTests {
+    private var suiteNames: [String] = []
+
+    deinit {
+        for name in suiteNames {
+            UserDefaults.standard.removePersistentDomain(forName: name)
+        }
+    }
+
+    /// A shim on a throwaway defaults suite, never the shared singleton.
+    private func makePrompt() throws -> (AppStoreReviewPrompt, AppStoreReviewStore) {
+        let suiteName = "AppStoreReviewPromptTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        suiteNames.append(suiteName)
+        return (AppStoreReviewPrompt(defaults: defaults), AppStoreReviewStore(defaults: defaults))
+    }
+
+    /// Enough finished titles to satisfy the completion route on its own.
+    private func makeEngaged() throws -> AppStoreReviewPrompt {
+        let (prompt, store) = try makePrompt()
+        for _ in 0 ..< AppStoreReviewTrigger.completionThreshold {
+            store.recordCompletedTitle()
+        }
+        return prompt
+    }
+
+    // MARK: Screen bookkeeping
+
+    @Test func `two concurrent players both have to close before the screen is clear`() throws {
+        let (prompt, _) = try makePrompt()
+        #expect(prompt.playerIsVisible == false)
+
+        prompt.notePlayerAppeared()
+        prompt.notePlayerAppeared()
+        prompt.notePlayerDisappeared()
+        // The second player is still up: a Bool would have said otherwise.
+        #expect(prompt.playerIsVisible)
+
+        prompt.notePlayerDisappeared()
+        #expect(prompt.playerIsVisible == false)
+    }
+
+    @Test func `a presented paywall is not a safe moment`() throws {
+        let (prompt, _) = try makePrompt()
+        #expect(prompt.paywallIsVisible == false)
+
+        prompt.notePaywallAppeared()
+        #expect(prompt.paywallIsVisible)
+
+        prompt.notePaywallDismissed()
+        #expect(prompt.paywallIsVisible == false)
+    }
+
+    @Test func `an unbalanced close cannot drive a count negative`() throws {
+        let (prompt, _) = try makePrompt()
+        prompt.notePlayerDisappeared()
+        prompt.notePaywallDismissed()
+        #expect(prompt.playerIsVisible == false)
+        #expect(prompt.paywallIsVisible == false)
+    }
+
+    // MARK: Arming
+
+    @Test func `a healthy session by an engaged viewer arms`() throws {
+        let prompt = try makeEngaged()
+        prompt.noteSessionEnded(health: .healthy, isChildProfileActive: false)
+        #expect(prompt.isArmed)
+    }
+
+    @Test func `an unhealthy session does not arm`() throws {
+        let prompt = try makeEngaged()
+        prompt.noteSessionEnded(health: .unhealthy(.engineFallback), isChildProfileActive: false)
+        #expect(prompt.isArmed == false)
+    }
+
+    @Test func `a session with no verdict does not arm`() throws {
+        let prompt = try makeEngaged()
+        prompt.noteSessionEnded(health: nil, isChildProfileActive: false)
+        #expect(prompt.isArmed == false)
+    }
+
+    @Test func `a child profile does not arm`() throws {
+        let prompt = try makeEngaged()
+        prompt.noteSessionEnded(health: .healthy, isChildProfileActive: true)
+        #expect(prompt.isArmed == false)
+    }
+
+    @Test func `a viewer who has not engaged yet does not arm`() throws {
+        let (prompt, _) = try makePrompt()
+        prompt.noteSessionEnded(health: .healthy, isChildProfileActive: false)
+        #expect(prompt.isArmed == false)
+    }
+
+    /// The reason `recentPaywall` was moved into the policy: a paywall closed
+    /// between the arm and the fire has to be able to hold it back, and the
+    /// arm has to survive that hold rather than being spent on it.
+    @Test func `a paywall closed after arming still blocks the fire`() throws {
+        let prompt = try makeEngaged()
+        prompt.noteSessionEnded(health: .healthy, isChildProfileActive: false)
+        #expect(prompt.isArmed)
+
+        prompt.notePaywallAppeared()
+        prompt.notePaywallDismissed()
+
+        // Still armed, and still inside the window — the fire point re-runs the
+        // policy, so it will decline until the window passes.
+        #expect(prompt.isArmed)
+        #expect(prompt.paywallIsVisible == false)
+    }
+}


### PR DESCRIPTION
## Summary

Lume has only ever had a **manual** review path — the "Rate Lume" row in Settings. This adds an automatic one: Apple's system rating sheet, raised on its own once the viewer has earned the ask and the moment is safe for one. It addresses the plain problem that the people most likely to leave a good review are the ones least likely to go hunting through Settings for the link.

This is **not** written from scratch. #100 (`dd645d8`) built a first version and was closed unmerged with zero review comments; its stated blocker — a broken `LumeTests` compile — no longer exists on `main`. That work is recovered here and extended, keeping its two `.v1` UserDefaults key names verbatim so counters in already-installed builds survive the update.

## Implementation

**Eligibility takes either route:**

```
eligible = completedTitles >= 3  OR  (launches >= 5 AND daysSinceInstall >= 7)
```

The second route is the load-bearing one. Live TV — Lume's primary use case — never produces a `WatchProgressWriter` completion, because the ≥90% crossing is VOD-only. #100's completion-only trigger would therefore have silently never asked most of the user base. A Live TV viewer does launch the app repeatedly, so launches + days catches them with no new instrumentation on the live path.

**Throttling.** `requestReview()` returns `Void` and never reports whether the sheet appeared — StoreKit silently no-ops past its own cap of three per 365 days, and in Debug and TestFlight. So what we record is an *attempt*, not a show, and we self-throttle on top of Apple's cap: a 120-day floor, one ask per marketing version, and fewer than three attempts in a rolling year. #100's version-only guard was too weak at Lume's release cadence — three releases in a year would exactly exhaust Apple's budget, possibly all on mediocre moments.

**Only after a session that went well.** `PlaybackQoE.shared.summary` is a *lifetime* rolling aggregate, so gating on `engineFallbacks > 0` would permanently silence the prompt for essentially every IPTV user. `PlaybackHealthTracker` instead snapshots the counters when a player opens and diffs them when it closes. Brackets are keyed by an opaque token, because macOS gives the player its own `WindowGroup` and iPadOS its own scenes — two sessions can be in flight at once. Multi-View is excluded outright (it holds `PlaybackQoE.isSuspended` for its whole life, so it generates no data to judge).

**Arm now, fire later.** The moment is judged when a session ends; the sheet is requested from the browse root once the player is gone, no paywall or Settings sheet is up, and the app is active. Nothing presents from `persistProgressDetached` — that path also runs from `onDisappear` and the scene-phase handler, so a prompt raised there would land on a screen the viewer had already left.

**Shape.** The decision is a pure `nonisolated` type — no StoreKit, no UserDefaults, no clock, every input injected, returning `.ask` / `.skip(Reason)` with typed reasons. A thin `@MainActor` shim is the only thing that calls `requestReview()`. That split is what makes the policy testable without StoreKit, a `ModelContainer` or a real clock.

**tvOS ships nothing.** It has no review API at any layer and cannot open a URL. Everything is compile-fenced `#if !os(tvOS)` — `RequestReviewAction` is `@available(tvOS, unavailable)` as a **type**, so even an unused `@Environment(\.requestReview)` declaration fails that build, which no `#available` check could fence out. Every `appstore.review.*` write is fenced at the storage boundary too, so tvOS accrues no counters nothing there reads.

**Suppressed** in sideloaded builds (no App Store listing to review), under UI tests (a stray system alert breaks `LumeUITests` non-deterministically and reads as "gear not hittable"), in previews, while a child profile is active, and for two hours after a paywall closes.

Notes for review:
- **No new user-facing strings** — Apple owns the sheet's copy — so no `.xcstrings` file is touched. **No privacy manifest change**: `NSPrivacyAccessedAPICategoryUserDefaults` / `CA92.1` is already declared.
- The manual **"Rate Lume" row stays**. Apple's own header says the prompt "may or may not show any UI … not appropriate for use from a button", so the deep link and the automatic prompt are complementary by design.
- State is device-level `UserDefaults`, deliberately **not** a `@Model` in either container — the catalog store backs every browse `@Query`, and the CloudKit mirror would mean a production schema deploy.
- `FullScreenPlayerView+AudioSession.swift` is a **mechanical extraction**, no behaviour change: the file was 592 lines on `main` and SwiftLint's `file_length` warns at 600, which pre-commit treats as an error.

## Testing

- [x] Acceptance criteria met — with one gap, see Platforms
- [x] Tests pass (`xcodebuild test -scheme Lume -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`) — 1060/1060
- [x] SwiftLint clean
- [x] Tests added — 42 cases in 4 suites: the policy and store, the pure health verdict, the tracker's bracket contract, and the shim's arm/hold bookkeeping

`RequestReviewAction` cannot be constructed, so firing itself is out of reach in tests; every decision leading up to it is covered, including that an arm survives a paywall hold rather than being spent on it.

## Platforms

- [x] iOS / iPadOS — built and run on simulator; verified `launchCount` increments and `installedAt` seeds exactly once
- [x] tvOS — builds clean; the whole feature compiles to a no-op, which is the entire tvOS requirement
- [x] macOS — compiles clean (signing unavailable locally: no developer account configured)
- [ ] visionOS — **not verified**: no visionOS runtime on the dev machine, and it was not forced with `-sdk`. APIs used are visionOS 1.0+ so risk is low, but this wants a CI or device build before merge.

**Not visually confirmed:** the system sheet itself. Reaching it needs a playlist sync plus ~60s of playback and a player dismissal, and UI automation was unavailable locally. Worth one manual pass — play anything, close the player, the sheet should appear ~1s after the browse UI settles. Debug builds don't stamp the cooldown, so it's repeatable.

## Related

Supersedes #100.