### PR TITLE
feat(player): state the negotiated audio output width to LumeEngine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,9 +159,22 @@ Two separate `ModelContainer`s:
 - App-side wiring only lives here (`Lume/Views/Player/LumeEngine*.swift`); demux/decode/render/sync bugs are engine-side. Decide which side a bug belongs to *before* editing.
 - Declared last in `PlayerEngineKind` so it appends to the end of existing priority lists — opt-in, never silently promoted while KSPlayer is the default.
 - The engine never retries on its own schedule: reconnect/backoff, engine fallback, and overlays stay Lume's job. If a fix would add retry policy to the engine, it belongs here instead.
+- The engine's audio output width is **host-stated**: `PlayerConfiguration.maxOutputChannels` must carry the *negotiated* width (`AVAudioSession.outputNumberOfChannels` after activation), never `maximumOutputNumberOfChannels` — over-shooting fails `AVSampleBufferAudioRenderer` outright (silence, wedged pipeline), which is worse than a downmix. macOS has no `AVAudioSession` and the engine falls back to a flat 2 there, so `PlaybackAudioRoute` queries CoreAudio for the default output device's own channel count instead. It owns the session and the arithmetic, and `LumeEngineCoordinator.makeConfiguration` resolves the value itself precisely so no SwiftUI `.task` / `.onAppear` ordering can race it: a session opens exactly one URL with no rebuild-in-place, so a width resolved too early is the width for the whole stream.
 
 ### Localization
 String Catalogs (9 languages: en, de, es, fr, it, ja, ko, pt, zh-Hans; the App Store listing mirrors them — see `ship-release`'s `references/store-metadata.json`). Run `xcstringstool sync` and include the tvOS stringsdata. Normalize `.xcstrings` with `Scripts/normalize-xcstrings.swift` (pre-commit hook) to avoid format churn.
+
+### Dolby branding — technical labels only
+Never put the Dolby word marks ("Dolby Vision", "Dolby Atmos", "Dolby Digital")
+in user-facing UI, String Catalogs or App Store copy. Use technical labels
+instead — `HDR10`, `HLG`, `DV P8.1`, `E-AC-3 JOC`, `TrueHD`, `5.1`, `7.1`.
+Dolby licenses its marks, and Lume has no agreement; the marks are also the
+most visible exposure because store metadata is public. Internal API names
+(`TrackInfo.DolbyVision`) and diagnostic log tokens (`dv=P8.1/L6`,
+`objectAudio=yes`) are fine — the rule is about what a user or reviewer sees.
+Decided 2026-09-05 while scoping issue #207; see that issue for the wider
+licensing picture (bundled FFmpeg decodes E-AC-3/TrueHD ourselves rather than
+through Apple's licensed frameworks, which is a separate, pre-existing matter).
 
 ### Pre-commit hooks (lefthook)
 SwiftFormat + SwiftLint run as errors. Notable: `String(decoding:)` is banned; `redundantStaticSelf` crashes on `for x in (try? …) ?? []` — avoid that pattern.

--- a/Lume/Services/Debug/DebugLogExporter.swift
+++ b/Lume/Services/Debug/DebugLogExporter.swift
@@ -80,11 +80,8 @@ nonisolated struct DebugLogExporter {
         }
         let start = startDate(now: now)
         let position = store.position(date: start)
-        let predicate = Bundle.main.bundleIdentifier.map {
-            NSPredicate(format: "subsystem == %@", $0)
-        }
 
-        let entries = try store.getEntries(at: position, matching: predicate)
+        let entries = try store.getEntries(at: position, matching: Self.entryPredicate())
         return entries.compactMap { entry -> String? in
             switch entry {
             case let log as OSLogEntryLog:
@@ -93,19 +90,60 @@ nonisolated struct DebugLogExporter {
                 // interpolates a URL with `privacy: .public`, it must not reach
                 // a shared report — stream URLs carry playlist credentials.
                 let message = LogRedaction.scrubURLs(in: log.composedMessage)
-                return "\(time)  [\(log.category)] \(Self.label(for: log.level))  \(message)"
+                let label = Self.categoryLabel(subsystem: log.subsystem, category: log.category)
+                return "\(time)  [\(label)] \(Self.label(for: log.level))  \(message)"
             case let signpost as OSLogEntrySignpost:
                 // MetricKit is compiled out on tvOS, so on Apple TV the `Perf`
                 // intervals are the only phase timing a field report can carry.
                 let time = Self.entryStamp.string(from: signpost.date)
                 let message = LogRedaction.scrubURLs(in: signpost.composedMessage)
-                let head = "\(time)  [\(signpost.category)] \(Self.signpostLabel(for: signpost.signpostType))  \(signpost.signpostName) #\(signpost.signpostIdentifier)"
+                let label = Self.categoryLabel(subsystem: signpost.subsystem, category: signpost.category)
+                let head = "\(time)  [\(label)] \(Self.signpostLabel(for: signpost.signpostType))  \(signpost.signpostName) #\(signpost.signpostIdentifier)"
                 return message.isEmpty ? head : "\(head)  \(message)"
             default:
                 return nil
             }
         }
     }
+
+    /// The app's own subsystem plus LumeEngine's once-per-stream readouts.
+    ///
+    /// LumeEngine logs into its own subsystem, so without this the `stream-open`,
+    /// `video-color` and `audio-width` lines — the only record of what colour
+    /// signalling and audio width a session actually resolved — are filtered out
+    /// of a report the user sends.
+    ///
+    /// `engine.lume/ffmpeg` is deliberately excluded: it is the raw FFmpeg log
+    /// bridge at `AV_LOG_WARNING`, which some streams hit per frame, so a 24 h
+    /// lookback would bury the report in decoder chatter. Everything the engine
+    /// states once per stream is on `diagnostics`.
+    static func entryPredicate() -> NSPredicate {
+        let engine = NSPredicate(
+            format: "subsystem == %@ AND category == %@",
+            Self.engineSubsystem,
+            Self.engineDiagnosticsCategory
+        )
+        guard let app = Bundle.main.bundleIdentifier else { return engine }
+        return NSCompoundPredicate(orPredicateWithSubpredicates: [
+            NSPredicate(format: "subsystem == %@", app),
+            engine
+        ])
+    }
+
+    /// Bracketed label for an entry. Foreign subsystems are qualified so an
+    /// engine line can't be misread as an app category of the same name.
+    static func categoryLabel(
+        subsystem: String,
+        category: String,
+        appSubsystem: String? = Bundle.main.bundleIdentifier
+    ) -> String {
+        let name = category.isEmpty ? "—" : category
+        guard !subsystem.isEmpty, subsystem != appSubsystem else { return name }
+        return "\(subsystem)/\(name)"
+    }
+
+    static let engineSubsystem = "engine.lume"
+    static let engineDiagnosticsCategory = "diagnostics"
 
     /// The debugging session start, floored to `maxLookback` so an ancient
     /// session (logging left on for days) doesn't drag in an unbounded history.

--- a/Lume/Services/Player/PlaybackAudioRoute.swift
+++ b/Lume/Services/Player/PlaybackAudioRoute.swift
@@ -1,0 +1,165 @@
+import Foundation
+import OSLog
+
+#if os(iOS) || os(tvOS)
+    import AVFoundation
+#elseif os(macOS)
+    import CoreAudio
+#endif
+
+/// The app-owned playback audio session, and the output width it negotiated.
+///
+/// KSPlayer and VLCKit configure their own session; LumeEngine by design never
+/// touches global audio state, so widening the route — and telling the engine
+/// how wide it ended up — is the app's job.
+@MainActor
+enum PlaybackAudioRoute {
+    private enum Activation {
+        case stereo
+        case widened
+    }
+
+    private static var activation: Activation?
+    private static var grantedChannels: Int?
+
+    /// Activates `.playback` / `.moviePlayback`, asks the route for its full
+    /// channel width and returns what was actually granted; on macOS, where
+    /// there is no audio session, it reports the default output device's own
+    /// width instead. `nil` means stereo — nothing worth stating.
+    ///
+    /// Idempotent: repeat calls return the width resolved by the first one, so
+    /// the player view and `LumeEngineCoordinator.makeConfiguration` may both
+    /// call it in either order.
+    @discardableResult
+    static func activateForPlayback() -> Int? {
+        #if os(iOS) || os(tvOS)
+            if activation == .widened {
+                return grantedChannels
+            }
+            let session = AVAudioSession.sharedInstance()
+            try? session.setCategory(.playback, mode: .moviePlayback, options: [])
+            // Activate BEFORE asking how wide the route is.
+            // `maximumOutputNumberOfChannels` describes the *current* route,
+            // and an inactive session reports the pre-activation default of 2
+            // even when the HDMI sink takes 5.1/7.1. Reading it first made the
+            // `> 2` guard fail on an Apple TV wired to a surround receiver, so
+            // the session was never widened, LumeEngine correctly sized its
+            // downmix to the 2 channels on offer, and a 5.1 E-AC-3 JOC track
+            // reached the receiver as stereo LPCM. See issue #207.
+            try? session.setActive(true, options: [])
+            let maxChannels = session.maximumOutputNumberOfChannels
+            if maxChannels > 2 {
+                try? session.setPreferredOutputNumberOfChannels(maxChannels)
+            }
+            let granted = negotiatedWidth(granted: session.outputNumberOfChannels, maximum: maxChannels)
+            activation = .widened
+            grantedChannels = granted
+            let route = session.currentRoute.outputs
+                .map { "\($0.portType.rawValue)(\($0.channels?.count ?? 0)ch)" }
+                .joined(separator: "+")
+            let negotiated = granted.map(String.init) ?? "stereo"
+            Logger.player.info("""
+            Audio session active: route=\(route, privacy: .public) \
+            outputChannels=\(session.outputNumberOfChannels) \
+            maxChannels=\(maxChannels) sampleRate=\(session.sampleRate) \
+            negotiatedWidth=\(negotiated, privacy: .public)
+            """)
+            return granted
+        #elseif os(macOS)
+            if activation == .widened {
+                return grantedChannels
+            }
+            let width = defaultOutputDeviceWidth()
+            activation = .widened
+            grantedChannels = width
+            let negotiated = width.map(String.init) ?? "stereo"
+            Logger.player.info("Audio output device: negotiatedWidth=\(negotiated, privacy: .public)")
+            return width
+        #else
+            return nil
+        #endif
+    }
+
+    /// Activates the same category without requesting the route's full width.
+    static func activateStereo() {
+        #if os(iOS) || os(tvOS)
+            guard activation == nil else { return }
+            let session = AVAudioSession.sharedInstance()
+            try? session.setCategory(.playback, mode: .moviePlayback, options: [])
+            try? session.setActive(true, options: [])
+            activation = .stereo
+        #endif
+    }
+
+    static func release() {
+        activation = nil
+        grantedChannels = nil
+        #if os(iOS) || os(tvOS)
+            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        #endif
+    }
+
+    /// The width to state to LumeEngine: what the session actually outputs,
+    /// never what the hardware could carry. Over-shooting the renderer fails it
+    /// outright (silence, wedged pipeline), which is worse than a downmix, so
+    /// `granted` is the ceiling and anything stereo or narrower resolves to
+    /// `nil` — nothing worth stating, the engine's own default stands.
+    static func negotiatedWidth(granted: Int, maximum: Int) -> Int? {
+        let width = min(granted, maximum)
+        return width > 2 ? width : nil
+    }
+
+    /// Sum of an output device's per-stream channel counts.
+    static func totalChannels(inBufferCounts counts: [UInt32]) -> Int {
+        counts.reduce(0) { $0 + Int($1) }
+    }
+
+    /// The macOS counterpart of `negotiatedWidth`: CoreAudio reports the device
+    /// width outright, so there is nothing to negotiate — the same stereo floor
+    /// applies, and the sum is never rounded up towards a nominal capability.
+    static func deviceWidth(inBufferCounts counts: [UInt32]) -> Int? {
+        let width = totalChannels(inBufferCounts: counts)
+        return negotiatedWidth(granted: width, maximum: width)
+    }
+
+    #if os(macOS)
+        /// macOS has no `AVAudioSession`, so LumeEngine falls back to a flat 2
+        /// and querying CoreAudio is the host's job.
+        ///
+        /// No route-change observer is wired: a session opens exactly one URL
+        /// with no rebuild-in-place, so a device swapped mid-playback is picked
+        /// up on the next open (or `reload()`). Deliberate for this round.
+        private static func defaultOutputDeviceWidth() -> Int? {
+            var deviceAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            var device = AudioDeviceID(0)
+            var deviceSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+            let deviceStatus = AudioObjectGetPropertyData(
+                AudioObjectID(kAudioObjectSystemObject), &deviceAddress, 0, nil, &deviceSize, &device
+            )
+            guard deviceStatus == noErr, device != kAudioObjectUnknown else { return nil }
+
+            var streamAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioDevicePropertyStreamConfiguration,
+                mScope: kAudioObjectPropertyScopeOutput,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            var size = UInt32(0)
+            guard AudioObjectGetPropertyDataSize(device, &streamAddress, 0, nil, &size) == noErr, size > 0 else {
+                return nil
+            }
+            let storage = UnsafeMutableRawPointer.allocate(
+                byteCount: Int(size), alignment: MemoryLayout<AudioBufferList>.alignment
+            )
+            defer { storage.deallocate() }
+            guard AudioObjectGetPropertyData(device, &streamAddress, 0, nil, &size, storage) == noErr else {
+                return nil
+            }
+            let buffers = UnsafeMutableAudioBufferListPointer(storage.assumingMemoryBound(to: AudioBufferList.self))
+            return deviceWidth(inBufferCounts: buffers.map(\.mNumberChannels))
+        }
+    #endif
+}

--- a/Lume/Views/Player/FullScreenPlayerView.swift
+++ b/Lume/Views/Player/FullScreenPlayerView.swift
@@ -477,32 +477,11 @@ struct FullScreenPlayerView: View {
         // the route stays at its default and multichannel audio has no path.
         // (KSPlayer/VLC configure their own session; LumeEngine by design
         // does not touch global audio state, so it is the app's job.)
-        #if os(iOS) || os(tvOS)
-            let session = AVAudioSession.sharedInstance()
-            try? session.setCategory(.playback, mode: .moviePlayback, options: [])
-            // Ask for the route's full width (HDMI LPCM surround); harmless
-            // when the route is stereo — the session clamps and LumeEngine
-            // downmixes to whatever was actually granted.
-            let maxChannels = session.maximumOutputNumberOfChannels
-            if maxChannels > 2 {
-                try? session.setPreferredOutputNumberOfChannels(maxChannels)
-            }
-            try? session.setActive(true, options: [])
-            let route = session.currentRoute.outputs
-                .map { "\($0.portType.rawValue)(\($0.channels?.count ?? 0)ch)" }
-                .joined(separator: "+")
-            Logger.player.info("""
-            Audio session active: route=\(route, privacy: .public) \
-            outputChannels=\(session.outputNumberOfChannels) \
-            maxChannels=\(maxChannels) sampleRate=\(session.sampleRate)
-            """)
-        #endif
+        PlaybackAudioRoute.activateForPlayback()
     }
 
     private func releaseAudioSession() {
-        #if os(iOS) || os(tvOS)
-            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-        #endif
+        PlaybackAudioRoute.release()
     }
 
     #if os(macOS)

--- a/Lume/Views/Player/LumeEngineCoordinator.swift
+++ b/Lume/Views/Player/LumeEngineCoordinator.swift
@@ -161,6 +161,15 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
                 self.selectedSubtitleID = await session.selectedSubtitleTrackIndex.map { String($0) }
                 self.publishTracks(info: info)
                 self.publishVideoInfo(info: info)
+                // Dolby/format readout at stream open. The pipeline-health
+                // heartbeat below carries the same tokens, but its first tick
+                // lands ~30 s in — and never at all on a short clip or a
+                // stream that fails early — which is too late to triage a
+                // "Lume downmixed my Atmos" report. Reads the engine's own
+                // diagnostics so selected-track resolution is not duplicated
+                // here. See issue #207.
+                let openDiagnostics = await session.diagnostics
+                Logger.player.info("LumeEngine stream open \(openDiagnostics.description, privacy: .public)")
                 if !self.isEmbedded {
                     self.pipBridge = PictureInPictureBridge(session: session, mediaInfo: info)
                 }
@@ -340,6 +349,13 @@ final class LumeEngineCoordinator: NSObject, ObservableObject {
             // on AVFoundation.
             configuration.autoEnableForcedSubtitlesForForeignAudio = true
         }
+        // Resolved here, not in a SwiftUI `.task`: the engine picks its audio
+        // output width when it builds the lane, and a session opens exactly one
+        // URL with no rebuild-in-place, so a width read before the app widened
+        // the route is the width for the whole stream. `activateForPlayback()`
+        // is idempotent, so this and the player view's own call cannot race —
+        // whichever runs first negotiates, the other reuses the result.
+        configuration.maxOutputChannels = PlaybackAudioRoute.activateForPlayback()
         configuration.demuxer.enableReconnect = options.httpReconnect
         configuration.demuxer.ioTimeout = options.ioTimeout
         // The open timeout stays tied to the engine-fallback budget rather than

--- a/Lume/Views/Player/MultiView/MultiViewScreen.swift
+++ b/Lume/Views/Player/MultiView/MultiViewScreen.swift
@@ -502,16 +502,10 @@ struct MultiViewScreen: View {
     /// asking for an HDMI surround layout for a muted 2×2 grid would negotiate a
     /// wider route than anything here can fill.
     private func configureAudioSession() {
-        #if os(iOS) || os(tvOS)
-            let session = AVAudioSession.sharedInstance()
-            try? session.setCategory(.playback, mode: .moviePlayback, options: [])
-            try? session.setActive(true, options: [])
-        #endif
+        PlaybackAudioRoute.activateStereo()
     }
 
     private func releaseAudioSession() {
-        #if os(iOS) || os(tvOS)
-            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-        #endif
+        PlaybackAudioRoute.release()
     }
 }

--- a/LumeTests/Services/DebugLogExporterTests.swift
+++ b/LumeTests/Services/DebugLogExporterTests.swift
@@ -42,6 +42,41 @@ struct DebugLogExporterTests {
         #expect(DebugLogExporter.signpostLabel(for: .undefined) == "signpost")
     }
 
+    @Test func `app subsystem entries keep the bare category`() {
+        let label = DebugLogExporter.categoryLabel(
+            subsystem: "com.bilipp.lume",
+            category: "player",
+            appSubsystem: "com.bilipp.lume"
+        )
+        #expect(label == "player")
+    }
+
+    @Test func `engine entries are qualified by their subsystem`() {
+        let label = DebugLogExporter.categoryLabel(
+            subsystem: DebugLogExporter.engineSubsystem,
+            category: DebugLogExporter.engineDiagnosticsCategory,
+            appSubsystem: "com.bilipp.lume"
+        )
+        #expect(label == "engine.lume/diagnostics")
+    }
+
+    @Test func `category labels are never empty`() {
+        #expect(!DebugLogExporter.categoryLabel(subsystem: "", category: "", appSubsystem: "com.bilipp.lume").isEmpty)
+        #expect(!DebugLogExporter.categoryLabel(subsystem: "engine.lume", category: "", appSubsystem: "com.bilipp.lume").isEmpty)
+        #expect(!DebugLogExporter.categoryLabel(subsystem: "com.bilipp.lume", category: "sync", appSubsystem: nil).isEmpty)
+    }
+
+    @Test func `the entry predicate matches the app and the engine diagnostics channel`() {
+        let format = DebugLogExporter.entryPredicate().predicateFormat
+        #expect(format.contains("engine.lume"))
+        #expect(format.contains("diagnostics"))
+        // The raw FFmpeg bridge is per-frame on some streams; it stays out.
+        #expect(!format.contains("ffmpeg"))
+        if let app = Bundle.main.bundleIdentifier {
+            #expect(format.contains(app))
+        }
+    }
+
     @Test func `device model is never empty`() {
         #expect(!DebugLogExporter.deviceModel.isEmpty)
     }

--- a/LumeTests/Services/PlaybackAudioRouteTests.swift
+++ b/LumeTests/Services/PlaybackAudioRouteTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+@testable import Lume
+import Testing
+
+@MainActor
+struct PlaybackAudioRouteTests {
+    @Test func `a stereo route states nothing and lets the engine default stand`() {
+        #expect(PlaybackAudioRoute.negotiatedWidth(granted: 2, maximum: 2) == nil)
+    }
+
+    @Test func `a granted 5 point 1 route states six, never the hardware maximum`() {
+        #expect(PlaybackAudioRoute.negotiatedWidth(granted: 6, maximum: 8) == 6)
+    }
+
+    @Test func `an ungranted widening request stays stereo rather than over-shooting`() {
+        #expect(PlaybackAudioRoute.negotiatedWidth(granted: 2, maximum: 8) == nil)
+    }
+
+    @Test func `the granted width is the ceiling`() {
+        #expect(PlaybackAudioRoute.negotiatedWidth(granted: 8, maximum: 8) == 8)
+        #expect(PlaybackAudioRoute.negotiatedWidth(granted: 64, maximum: 8) == 8)
+    }
+
+    @Test func `absurd inputs resolve to nothing stated`() {
+        #expect(PlaybackAudioRoute.negotiatedWidth(granted: 0, maximum: 0) == nil)
+        #expect(PlaybackAudioRoute.negotiatedWidth(granted: -3, maximum: 8) == nil)
+        #expect(PlaybackAudioRoute.negotiatedWidth(granted: 6, maximum: 0) == nil)
+        #expect(PlaybackAudioRoute.negotiatedWidth(granted: 3, maximum: 8) == 3)
+    }
+
+    @Test func `an output device with no streams states nothing`() {
+        #expect(PlaybackAudioRoute.totalChannels(inBufferCounts: []) == 0)
+        #expect(PlaybackAudioRoute.deviceWidth(inBufferCounts: []) == nil)
+    }
+
+    @Test func `a stereo output device states nothing`() {
+        #expect(PlaybackAudioRoute.deviceWidth(inBufferCounts: [2]) == nil)
+    }
+
+    @Test func `channels sum across every output stream of the device`() {
+        #expect(PlaybackAudioRoute.totalChannels(inBufferCounts: [2, 2, 2]) == 6)
+        #expect(PlaybackAudioRoute.deviceWidth(inBufferCounts: [2, 2, 2]) == 6)
+    }
+
+    @Test func `a single wide stream states its full width`() {
+        #expect(PlaybackAudioRoute.deviceWidth(inBufferCounts: [8]) == 8)
+    }
+}


### PR DESCRIPTION
## Summary

Round 2a of #207. LumeEngine decodes audio to PCM and downmixes to a single output width. With nothing stated by the host it read `AVAudioSession.outputNumberOfChannels` at audio-lane-build time, which lost an ordering race: `LumeEngineEngineView` starts the session from `.onAppear`, while `FullScreenPlayerView` only activated and widened the route from its own later `.task`. A session opens exactly one URL with no rebuild-in-place, so a width resolved too early is the width for the whole stream — a 5.1 track could reach a surround receiver as stereo.

- **New `PlaybackAudioRoute`** owns playback audio-session setup. `activateForPlayback()` is idempotent and is called from `LumeEngineCoordinator.makeConfiguration`, so whichever of the two callers runs first negotiates and the other reuses the result. Ordering can no longer produce a stereo-clamped lane.
- **It activates the session *before* reading channel counts.** An inactive session reports the pre-activation default of 2 even on a route that can carry more, so the previous order asked for a widening that never happened.
- **`negotiatedWidth` is `min(granted, maximum)`, `nil` at or below stereo.** It never passes `maximumOutputNumberOfChannels` through — that is capability, not granted width, and over-shooting fails the renderer outright (silence, wedged pipeline) rather than merely downmixing.
- **macOS** gets a CoreAudio output-device width query, replacing the engine's flat 2-channel fallback.
- **`MultiViewScreen` keeps its deliberately non-widening session** via `activateStereo()` — only one tile is audible, so negotiating a surround layout for a muted grid would be wrong.
- **The exported diagnostic report now includes `engine.lume/diagnostics`**, so the once-per-stream colour and audio-width readouts survive into a report a user sends. The raw `engine.lume/ffmpeg` bridge stays excluded: it logs at `AV_LOG_WARNING` and some streams hit it per frame.
- **`AGENTS.md`** records that Dolby word marks must never appear in user-facing UI or store copy — technical labels only.

Pairs with **bilipp/LumeEngine#33**. Refs #207 — does **not** close it; the technical-label UI badges (Round 2b) are still to come and will stack on #210.

### What the hardware measurement actually showed

The issue's premise was partly wrong, and measuring first caught it. On an Apple TV 4K with a DV P8.1 title:

- **Video already worked.** `path=videoToolbox` produced a buffer with all three colour keys present and correct (`ITU_R_2020` / `SMPTE_ST_2084_PQ` / `ITU_R_2020`), DV P8.1 detected, picture confirmed clean. No fix was needed on the path that matters — the engine-side change targets the narrower CPU-decoded case.
- **The audio downmix is real but this change is not yet validated on hardware.** The measurement ran with `route=AirPlay(2ch)`, which is genuinely a stereo path, so `sessionMax=2` was correct there. An HDMI run is still needed to confirm; look for `widthSource=configured` and `route=HDMIOutput(…)`.

## Type of change

- [x] `feat` — new feature

## Platforms verified

- [x] iOS / iPadOS
- [x] macOS
- [x] tvOS
- [ ] visionOS

visionOS is **not** verified: no visionOS simulator runtime is installed here, and `main` does not build for it independently of this PR — `PictureInPictureBridge` is gated `#if os(iOS) || os(macOS) || os(tvOS)` in LumeEngine while `LumeEngineCoordinator` references it ungated at `:94` and `:165`. Pre-existing, tracked separately.

## Screenshots / recordings

None — no UI changes in this PR.

## Checklist

- [x] I opened an issue first (for features / non-trivial changes) and linked it above.
- [x] My commits follow the Conventional Commits format.
- [x] Pre-commit hooks pass (SwiftFormat, SwiftLint `--strict`, String Catalog normalization).
- [x] The test suite passes — `LumeTests` green (`** TEST SUCCEEDED **`, iPhone 17 Pro / iOS 26.4, `-parallel-testing-enabled NO`). `LumeUITests` was **not** run.
- [x] New/changed user-facing text is localized — **n/a**, this PR adds no user-facing text.
- [x] I added or updated tests covering my change where it makes sense (`PlaybackAudioRouteTests`, 9 cases: stereo route ⇒ nil, granted 6 / maximum 8 ⇒ 6 never 8, ungranted preference ⇒ nil never an over-shoot, clamping).
- [x] My change contains no credentials, stream URLs, or other content.
