### PR TITLE
feat(settings): add an Xtream provider link straight as an Xtream login

### DIFF
--- a/Lume/Localizable.xcstrings
+++ b/Lume/Localizable.xcstrings
@@ -2437,6 +2437,59 @@
         }
       }
     },
+    "Add as Xtream Login" : {
+      "comment" : "A button that adds the provider behind an Xtream get.php m3u link as an Xtream playlist.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Als Xtream-Login hinzufügen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir como inicio de sesión Xtream"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter comme connexion Xtream"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi come accesso Xtream"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xtream ログインとして追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xtream 로그인으로 추가"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar como login Xtream"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加为 Xtream 登录"
+          }
+        }
+      }
+    },
     "Add Channel" : {
       "localizations" : {
         "de" : {

--- a/Lume/Services/Network/M3UClient.swift
+++ b/Lume/Services/Network/M3UClient.swift
@@ -22,7 +22,9 @@ import OSLog
 /// Favourites, watch positions, the CloudKit `UserContentState` records keyed by
 /// those ids, and all TMDB enrichment would be orphaned, and the next sweep
 /// would delete the rows they pointed at. A user who wants Xtream adds a second
-/// playlist and removes the m3u one.
+/// playlist and removes the m3u one — which is all the add sheet's "Add as
+/// Xtream Login" button does: it creates a fresh Xtream playlist from these
+/// credentials, it does not rewrite one.
 nonisolated struct XtreamCredentialsHint {
     /// Scheme, host and (when non-default) port only — the form an Xtream login
     /// expects. No path, no query: the query is what carries the credentials.

--- a/Lume/Views/LoginView.swift
+++ b/Lume/Views/LoginView.swift
@@ -57,26 +57,14 @@ struct LoginView: View {
         }
     }
 
-    /// True when the entered m3u URL is really an Xtream `get.php` endpoint.
-    /// The hint it drives is advisory only: nothing switches the source type or
-    /// rewrites the URL, because the two pipelines disagree on content identity
-    /// (see `XtreamCredentialsHint`).
-    private var showsXtreamHint: Bool {
-        sourceType == .m3u
-            && M3UClient.xtreamCredentials(in: m3uURL.trimmingCharacters(in: .whitespacesAndNewlines)) != nil
-    }
-
-    private static let xtreamHintMessage: LocalizedStringKey =
-        "This is an Xtream provider link. It works as an m3u playlist, or add the provider as an Xtream login instead — Xtream syncs far less data for the same catalog."
-
-    /// Non-interactive on purpose, so it needs no focus target on tvOS.
-    private var xtreamHintLabel: some View {
-        Label {
-            Text(Self.xtreamHintMessage)
-        } icon: {
-            Image(systemName: "info.circle.fill")
-        }
-        .foregroundStyle(.secondary)
+    /// The Xtream account behind the entered m3u URL, when that URL is really an
+    /// Xtream `get.php` endpoint. Drives the hint and its "Add as Xtream Login"
+    /// button, which adds a *new* Xtream playlist from these credentials — it
+    /// never converts an m3u playlist in place, because the two pipelines
+    /// disagree on content identity (see `XtreamCredentialsHint`).
+    private var xtreamHint: XtreamCredentialsHint? {
+        guard sourceType == .m3u else { return nil }
+        return M3UClient.xtreamCredentials(in: m3uURL.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
     var body: some View {
@@ -213,10 +201,9 @@ struct LoginView: View {
                 Text("Enter the playlist URL or choose a local m3u/m3u8 file. The EPG URL is read from the playlist when left empty.")
             }
 
-            if showsXtreamHint {
+            if let xtreamHint {
                 Section {
-                    xtreamHintLabel
-                        .font(.callout)
+                    XtreamLoginHint(isLoading: isLoading) { addAsXtream(xtreamHint) }
                 }
             }
         }
@@ -318,10 +305,8 @@ struct LoginView: View {
                         .foregroundStyle(.secondary)
                         .padding(.horizontal, TVSettingsMetrics.rowHPadding)
 
-                    if showsXtreamHint {
-                        xtreamHintLabel
-                            .font(.system(size: TVSettingsMetrics.secondaryFontSize))
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                    if let xtreamHint {
+                        XtreamLoginHint(isLoading: isLoading) { addAsXtream(xtreamHint) }
                             .padding(.horizontal, TVSettingsMetrics.rowHPadding)
                     }
 
@@ -367,17 +352,34 @@ struct LoginView: View {
 
     private func addPlaylist() {
         switch sourceType {
-        case .xtream: loginXtream()
+        case .xtream:
+            loginXtream(
+                serverURL: serverURL.trimmingCharacters(in: .whitespacesAndNewlines),
+                username: username.trimmingCharacters(in: .whitespacesAndNewlines),
+                password: password
+            )
         case .m3u: addM3UPlaylist()
         case .stalker: addStalkerPlaylist()
         }
+    }
+
+    /// Adds the provider behind an Xtream `get.php` m3u URL as an Xtream
+    /// playlist, using the credentials the URL carries. The form is switched
+    /// over and pre-filled as well, so a login that fails leaves the user on a
+    /// ready-to-edit Xtream form instead of the m3u one.
+    private func addAsXtream(_ hint: XtreamCredentialsHint) {
+        serverURL = hint.baseURL
+        username = hint.username
+        password = hint.password
+        sourceType = .xtream
+        loginXtream(serverURL: hint.baseURL, username: hint.username, password: hint.password)
     }
 
     private var trimmedName: String {
         name.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private func loginXtream() {
+    private func loginXtream(serverURL: String, username: String, password: String) {
         isLoading = true
         errorMessage = nil
 
@@ -386,8 +388,8 @@ struct LoginView: View {
         Task {
             let playlist = Playlist(
                 name: playlistName,
-                serverURL: serverURL.trimmingCharacters(in: .whitespacesAndNewlines),
-                username: username.trimmingCharacters(in: .whitespacesAndNewlines),
+                serverURL: serverURL,
+                username: username,
                 password: password
             )
 

--- a/Lume/Views/XtreamLoginHint.swift
+++ b/Lume/Views/XtreamLoginHint.swift
@@ -1,0 +1,51 @@
+//
+//  XtreamLoginHint.swift
+//  Lume
+//
+//  Shown while adding an m3u playlist whose URL turns out to be an Xtream
+//  `get.php` link.
+//
+
+import SwiftUI
+
+/// The advisory for an m3u URL that is really an Xtream `get.php` endpoint,
+/// plus the button that adds the provider as an Xtream playlist instead.
+///
+/// Adding always creates a *new* playlist from the credentials the URL carries;
+/// an existing m3u playlist is never converted in place, because the two
+/// pipelines disagree on content identity (see `XtreamCredentialsHint`).
+struct XtreamLoginHint: View {
+    let isLoading: Bool
+    let add: () -> Void
+
+    /// Non-interactive on purpose, so on tvOS only the button takes focus.
+    private var message: some View {
+        Label {
+            Text("This is an Xtream provider link. It works as an m3u playlist, or add the provider as an Xtream login instead — Xtream syncs far less data for the same catalog.")
+        } icon: {
+            Image(systemName: "info.circle.fill")
+        }
+        .foregroundStyle(.secondary)
+    }
+
+    private var button: some View {
+        Button("Add as Xtream Login", action: add)
+            .disabled(isLoading)
+    }
+
+    var body: some View {
+        #if os(tvOS)
+            VStack(alignment: .leading, spacing: 16) {
+                message
+                    .font(.system(size: TVSettingsMetrics.secondaryFontSize))
+                button
+                    .buttonStyle(TVSettingsActionButtonStyle())
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        #else
+            message
+                .font(.callout)
+            button
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary
The add-playlist sheet already warns when an m3u URL is really an Xtream `get.php` endpoint ("This is an Xtream provider link…"), but acting on it meant switching the picker and retyping server, username and password by hand. The hint now carries an **Add as Xtream Login** button that adds the provider as an Xtream playlist right away, using the credentials the URL already carries.

## Implementation
`showsXtreamHint: Bool` becomes `xtreamHint: XtreamCredentialsHint?`, so the view has the parsed account and not just a flag. The message and button moved into a small `XtreamLoginHint` view (iOS/macOS renders them as two Form rows, tvOS as a leading-aligned VStack with a focusable `TVSettingsActionButtonStyle` button), which also kept `LoginView` under the SwiftLint file/type-length caps.

Tapping the button pre-fills the Xtream fields, switches `sourceType` to `.xtream`, and runs the existing Xtream login path — `loginXtream` now takes server/username/password as parameters instead of reading state, so no `@State` write has to land first. It always creates a **new** Xtream playlist and never rewrites the m3u one: the two pipelines derive stream ids differently, so converting in place would orphan favorites, watch progress and enrichment (the reason `XtreamCredentialsHint` says the hint must not drive an automatic conversion — its doc comment now says where the button fits). Switching the form over also means a failed login lands the user on a ready-to-edit Xtream form rather than the m3u one.

## Testing
- [x] Acceptance criteria met
- [x] Builds clean (XcodeBuildMCP `build_sim`; plus `xcodebuild` for tvOS and macOS)
- [x] Tests pass (`LumeTests/M3UParserTests`, iPhone 17 Pro / iOS 26.4 — 9/9)
- [x] SwiftLint clean (pre-commit hooks: normalize-xcstrings, swiftformat, swiftlint)
- [x] Tests added — or skipped: no new isolated logic; `M3UClient.xtreamCredentials(in:)`, which the button consumes, is already covered by `M3UParserTests`
- [x] UI verified on simulator (light + dark): typed `…/get.php?username=test&password=test&type=m3u_plus` against the local example IPTV server, tapped the button, and the sheet added an Xtream playlist whose stored row is `sourceType=xtream`, `serverURL=http://localhost:8080`, `username=test` — with `Status: Active` / `Expires` / `Max Connections` filled in, so the real Xtream handshake ran. Survives a cold relaunch.

## Platforms
- [x] iOS / iPadOS
- [ ] tvOS
- [ ] macOS
- [ ] visionOS
<!-- tvOS and macOS compile clean but were not driven by hand; the tvOS button sits in the same VStack as the existing hint text. -->

## Related
Follow-up to the Xtream `get.php` detection warning.