### PR TITLE
perf(browse): cut the SQL behind every browse interaction

### DIFF
--- a/Lume/LumeApp.swift
+++ b/Lume/LumeApp.swift
@@ -83,6 +83,12 @@ struct LumeApp: App {
             isStoredInMemoryOnly: false,
             cloudKitDatabase: .none
         )
+        // Create any index the models declare that this store predates. SwiftData
+        // applies `#Index` only when it creates the file, and no version bump or
+        // migration stage makes it revisit that — see `CatalogIndexBackfill`,
+        // which was written after both were measured against a real store. Runs
+        // before the container opens the file, on its own connection.
+        CatalogIndexBackfill.run(storeURL: catalogConfiguration.url)
         func buildCatalog() throws -> ModelContainer {
             try ModelContainer(for: catalogSchema, configurations: catalogConfiguration)
         }

--- a/Lume/Models/CatalogIndexBackfill.swift
+++ b/Lume/Models/CatalogIndexBackfill.swift
@@ -1,0 +1,143 @@
+//
+//  CatalogIndexBackfill.swift
+//  Lume
+//
+//  Creates the catalog store's newer `#Index` entries on a store that already
+//  exists, because SwiftData will not.
+//
+//  Measured on a real 373 MB store (2026-09-08, and again after this PR's model
+//  changes): adding an entry to `#Index<Movie>` and relaunching leaves
+//  `sqlite_master` byte-identical and every `EXPLAIN QUERY PLAN` unchanged.
+//  Declaring a `VersionedSchema` pair and opening at the newer version does not
+//  help either — the store kept `NSStoreModelVersionIdentifiers = ["1.0.0"]`
+//  and no `CREATE INDEX` was issued. The reason is in Core Data's own contract:
+//  an entity's version hash covers attributes and relationships and
+//  deliberately excludes fetch indexes, so a store whose entities are unchanged
+//  is judged compatible, opened as-is, and no migration stage is ever
+//  considered. The `#Index` declarations only reach a store at the moment the
+//  file is created — i.e. fresh installs.
+//
+//  So the indexes are created here, directly, once, before the container opens.
+//  An index is a pure SQLite object: it changes no row, no column and no
+//  version hash, and Core Data neither validates nor notices `sqlite_master`.
+//  Each statement is named exactly what SwiftData names its own, so
+//  `IF NOT EXISTS` is a no-op on a fresh install that already has them, and a
+//  future SwiftData migration finds its index already in place.
+//
+//  A failure here is not an error worth surfacing: the queries still return the
+//  same rows, just more slowly, which is precisely where this app was before.
+//
+
+import Foundation
+import OSLog
+import SQLite3
+
+nonisolated enum CatalogIndexBackfill {
+    /// One index this app needs the store to have.
+    ///
+    /// `name` mirrors SwiftData's own convention — `Z_<Model>_SwiftDataIndexOn`
+    /// plus `Binary` (the collation it always uses) plus the property names
+    /// concatenated — so it collides with, rather than duplicates, the index a
+    /// freshly-created store already carries. See any `Z_LiveStream_…` entry in
+    /// an existing store for the shape.
+    private struct Index {
+        let name: String
+        let table: String
+        let columns: [String]
+
+        var createStatement: String {
+            let cols = columns.map { "\($0) COLLATE BINARY ASC" }.joined(separator: ", ")
+            return "CREATE INDEX IF NOT EXISTS \(name) ON \(table) (\(cols))"
+        }
+    }
+
+    /// The indexes added after the store format was first shipped. Each one is
+    /// declared on its `@Model` as well — that is what gives fresh installs the
+    /// index — and repeated here because an existing store never sees that
+    /// declaration.
+    ///
+    /// Keep the two in step: a new `#Index` entry that is not listed here
+    /// silently helps only new users.
+    private static let indexes: [Index] = [
+        // "Recently Added" on the Movies and Series tabs sorts on these string
+        // columns. Unindexed, the rail cost `SCAN ZMOVIE` plus a temp B-tree
+        // sort of all 179,104 rows — 222 ms per run, re-run on every catalog
+        // write. Only usable because the sort descriptors pass
+        // `comparator: .lexical`; the default localized comparator emits
+        // `COLLATE NSCollateFinderlike`, which no binary index can serve.
+        Index(name: "Z_Movie_SwiftDataIndexOnBinaryadded", table: "ZMOVIE", columns: ["ZADDED"]),
+        Index(name: "Z_Series_SwiftDataIndexOnBinarylastModified", table: "ZSERIES", columns: ["ZLASTMODIFIED"]),
+        // The Live TV rail's two section gates and its virtual collections.
+        // With only the single-column indexes present SQLite chose the
+        // `isHidden` one — which matches ~54,000 of 56,895 channels — and never
+        // used `isFavorite` or `lastWatchedDate`: 7.6 ms and 8.0 ms per run,
+        // 18-25 runs on a cold launch of a tab that may never be opened.
+        // Measured with the composites: 0.6 ms and 0.02 ms.
+        Index(
+            name: "Z_LiveStream_SwiftDataIndexOnBinaryisFavoriteisHidden",
+            table: "ZLIVESTREAM",
+            columns: ["ZISFAVORITE", "ZISHIDDEN"]
+        ),
+        // Equality column first — see the note on `#Index<LiveStream>`: the
+        // intuitive `[lastWatchedDate, isHidden]` order is not chosen without
+        // table statistics, and Core Data never runs ANALYZE.
+        Index(
+            name: "Z_LiveStream_SwiftDataIndexOnBinaryisHiddenlastWatchedDate",
+            table: "ZLIVESTREAM",
+            columns: ["ZISHIDDEN", "ZLASTWATCHEDDATE"]
+        ),
+        // The in-player EPG lookups bound on `end > now`; the store only had
+        // `[channelId, start]`. `TVPlayerContent.guideListings` has cited a
+        // "channelId + end index" in a comment since it was written, without
+        // one ever existing.
+        Index(
+            name: "Z_EPGListing_SwiftDataIndexOnBinarychannelIdend",
+            table: "ZEPGLISTING",
+            columns: ["ZCHANNELID", "ZEND"]
+        )
+    ]
+
+    /// Creates any missing index on the store at `url`, if that store exists.
+    ///
+    /// Must run *before* the `ModelContainer` opens the file: this takes its own
+    /// connection, and `CREATE INDEX` takes a write lock for as long as it needs
+    /// to build the b-tree (a second or two for the largest table on a very big
+    /// catalog, once, on the launch after updating — never again).
+    ///
+    /// Does nothing when the file is absent, which is every fresh install: there
+    /// the `#Index` declarations on the models create these at store-creation
+    /// time and this finds nothing to do on the next launch either.
+    static func run(storeURL: URL) {
+        guard FileManager.default.fileExists(atPath: storeURL.path) else { return }
+
+        var handle: OpaquePointer?
+        // No SQLITE_OPEN_CREATE: if the path is wrong we want to do nothing, not
+        // leave an empty database next to the real one.
+        guard sqlite3_open_v2(storeURL.path, &handle, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK,
+              let database = handle
+        else {
+            if let handle { sqlite3_close(handle) }
+            Logger.database.debug("Catalog index backfill: could not open the store; leaving it alone")
+            return
+        }
+        defer { sqlite3_close(database) }
+
+        for index in indexes where tableExists(index.table, in: database) {
+            if sqlite3_exec(database, index.createStatement, nil, nil, nil) != SQLITE_OK {
+                let message = String(cString: sqlite3_errmsg(database))
+                Logger.database.debug("Catalog index backfill: \(index.name, privacy: .public) skipped — \(message, privacy: .public)")
+            }
+        }
+    }
+
+    /// Guards against running `CREATE INDEX` on a store from before a model
+    /// existed — a missing table is a skip, not an error.
+    private static func tableExists(_ table: String, in database: OpaquePointer) -> Bool {
+        var statement: OpaquePointer?
+        let sql = "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?"
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else { return false }
+        defer { sqlite3_finalize(statement) }
+        sqlite3_bind_text(statement, 1, table, -1, unsafeBitCast(-1 as Int, to: sqlite3_destructor_type.self))
+        return sqlite3_step(statement) == SQLITE_ROW
+    }
+}

--- a/Lume/Models/EPGListing.swift
+++ b/Lume/Models/EPGListing.swift
@@ -8,11 +8,18 @@ final class EPGListing {
     // rows). Every now/next lookup and the guide window query filter by
     // `channelId` and the `start`/`end` time bounds, so index them — without
     // these, each channel card and guide open scans the whole guide table.
+    // The in-player lookups (now/next, the channel's upcoming list, the guide
+    // window) all bound on `end > now` rather than on `start`, so the
+    // `channelId + start` pair above can only seek to the channel and then walk
+    // every listing it ever had. `channelId + end` is the pair those predicates
+    // actually ask for — `TVPlayerContent.guideListings` has claimed this index
+    // in a comment since it was written, without it ever existing.
     #Index<EPGListing>(
         [\.channelId],
         [\.start],
         [\.end],
-        [\.channelId, \.start]
+        [\.channelId, \.start],
+        [\.channelId, \.end]
     )
 
     @Attribute(.unique) var id: String

--- a/Lume/Models/LiveStream.swift
+++ b/Lume/Models/LiveStream.swift
@@ -15,12 +15,31 @@ final class LiveStream {
     // independently indexed, and the composite above can't serve `isHidden`
     // without a `categoryId` prefix — without it every reconcile scans the
     // whole channel table.
+    // Live TV's Favorites and Recently Watched rows each filter on a user-state
+    // column *and* `isHidden`, and with only the single-column indexes above
+    // SQLite kept picking the worst of them: "SEARCH ZLIVESTREAM USING INDEX
+    // …isHidden (ZISHIDDEN=?)" matches every visible channel (~54,000 on the
+    // measured playlist) and then tests the favorite / last-watched column row
+    // by row. Pairing each with `isHidden` turns that into a seek onto the
+    // handful of rows the row actually renders: 7.6 ms -> 0.6 ms for favorites,
+    // 12.5 ms -> 0.02 ms for recents.
+    // Column order is not cosmetic. The equality term leads and the range /
+    // sort term follows, which is the only arrangement SQLite picks *without*
+    // table statistics: with `[lastWatchedDate, isHidden]` — the intuitive
+    // order, filter column first — the planner still chose the ~54,000-row
+    // `isHidden` index, because with no `sqlite_stat1` it assumes an equality
+    // constraint beats a range one. `[isHidden, lastWatchedDate]` seeks on the
+    // equality *and* satisfies `ORDER BY lastWatchedDate` from the index, so it
+    // needs no ANALYZE to be chosen. `[categoryId, isHidden]` above is the same
+    // rule, both terms being equalities.
     #Index<LiveStream>(
         [\.isFavorite],
         [\.lastWatchedDate],
         [\.categoryId],
         [\.categoryId, \.isHidden],
-        [\.isHidden]
+        [\.isHidden],
+        [\.isFavorite, \.isHidden],
+        [\.isHidden, \.lastWatchedDate]
     )
 
     @Attribute(.unique) var id: String

--- a/Lume/Models/Movie.swift
+++ b/Lume/Models/Movie.swift
@@ -17,6 +17,13 @@ final class Movie {
     // `indexedAt` backs the content indexer's pending/progress scans (run once
     // per chunk for a whole indexing pass) and `downloadStatusRaw` the Downloads
     // screen's live `@Query`, which re-evaluates during catalog syncs.
+    // `added` is the sort key for the "Recently Added" rail, which asks for a
+    // handful of rows off the top of a descending sort. Unindexed that plans as
+    // "SCAN ZMOVIE + USE TEMP B-TREE FOR ORDER BY" — the whole table sorted to
+    // hand back 20 rows, 222 ms per run on a 179k-title catalog. The index only
+    // pays off while the ordering stays a binary comparison: a `SortDescriptor`
+    // on a String key path defaults to `.localizedStandard`, which emits
+    // `COLLATE NSCollateFinderlike` and no b-tree can serve that.
     #Index<Movie>(
         [\.tmdbId],
         [\.isFavorite],
@@ -28,7 +35,8 @@ final class Movie {
         [\.categoryId],
         [\.genre],
         [\.indexedAt],
-        [\.downloadStatusRaw]
+        [\.downloadStatusRaw],
+        [\.added]
     )
 
     @Attribute(.unique) var id: String

--- a/Lume/Models/Series.swift
+++ b/Lume/Models/Series.swift
@@ -15,6 +15,13 @@ final class Series {
     // catalog on a large library.
     // `indexedAt` backs the content indexer's pending/progress scans, run once
     // per chunk for a whole indexing pass.
+    // `lastModified` is the sort key for the "Recently Added" rail, which asks
+    // for a handful of rows off the top of a descending sort. Unindexed that
+    // plans as a full scan plus "USE TEMP B-TREE FOR ORDER BY" — the whole table
+    // sorted to hand back 20 rows. As with `Movie.added`, the index only pays
+    // off while the ordering stays a binary comparison: a `SortDescriptor` on a
+    // String key path defaults to `.localizedStandard`, which emits
+    // `COLLATE NSCollateFinderlike` and no b-tree can serve that.
     #Index<Series>(
         [\.tmdbId],
         [\.isFavorite],
@@ -23,7 +30,8 @@ final class Series {
         [\.recommendationVoteRaw],
         [\.categoryId],
         [\.genre],
-        [\.indexedAt]
+        [\.indexedAt],
+        [\.lastModified]
     )
 
     @Attribute(.unique) var id: String

--- a/Lume/Models/SortOption.swift
+++ b/Lume/Models/SortOption.swift
@@ -99,7 +99,13 @@ enum ContentSortOption: String, CaseIterable, Identifiable {
     // Each model has its own "added" field (Movie/LiveStream: `added`;
     // Series: `lastModified`). The Xtream API ships these as Unix timestamp
     // strings, so a lexicographic sort matches numeric order for the 10-digit
-    // range this app will encounter.
+    // range this app will encounter. `comparator: .lexical` is what carries that
+    // into SQL: the default for a String key path is `.localizedStandard`, which
+    // emits `COLLATE NSCollateFinderlike`, and no b-tree can serve that — the
+    // `#Index` on `Movie.added` only pays off while the ordering stays a binary
+    // comparison. 222.4 ms → 92.6 ms on the "Recently Added" query of a
+    // 179k-title catalog. The name cases below keep the localized comparator on
+    // purpose: there the linguistic ordering is the behaviour users expect.
 
     var movieDescriptors: [SortDescriptor<Movie>] {
         switch self {
@@ -110,9 +116,9 @@ enum ContentSortOption: String, CaseIterable, Identifiable {
         case .nameDescending:
             [SortDescriptor(\Movie.name, order: .reverse)]
         case .newest:
-            [SortDescriptor(\Movie.added, order: .reverse), SortDescriptor(\Movie.num)]
+            [SortDescriptor(\Movie.added, comparator: .lexical, order: .reverse), SortDescriptor(\Movie.num)]
         case .oldest:
-            [SortDescriptor(\Movie.added, order: .forward), SortDescriptor(\Movie.num)]
+            [SortDescriptor(\Movie.added, comparator: .lexical, order: .forward), SortDescriptor(\Movie.num)]
         }
     }
 
@@ -125,9 +131,9 @@ enum ContentSortOption: String, CaseIterable, Identifiable {
         case .nameDescending:
             [SortDescriptor(\Series.name, order: .reverse)]
         case .newest:
-            [SortDescriptor(\Series.lastModified, order: .reverse), SortDescriptor(\Series.num)]
+            [SortDescriptor(\Series.lastModified, comparator: .lexical, order: .reverse), SortDescriptor(\Series.num)]
         case .oldest:
-            [SortDescriptor(\Series.lastModified, order: .forward), SortDescriptor(\Series.num)]
+            [SortDescriptor(\Series.lastModified, comparator: .lexical, order: .forward), SortDescriptor(\Series.num)]
         }
     }
 
@@ -143,9 +149,9 @@ enum ContentSortOption: String, CaseIterable, Identifiable {
         case .nameDescending:
             [SortDescriptor(\LiveStream.name, order: .reverse)]
         case .newest:
-            [SortDescriptor(\LiveStream.added, order: .reverse), SortDescriptor(\LiveStream.num)]
+            [SortDescriptor(\LiveStream.added, comparator: .lexical, order: .reverse), SortDescriptor(\LiveStream.num)]
         case .oldest:
-            [SortDescriptor(\LiveStream.added, order: .forward), SortDescriptor(\LiveStream.num)]
+            [SortDescriptor(\LiveStream.added, comparator: .lexical, order: .forward), SortDescriptor(\LiveStream.num)]
         }
     }
 }

--- a/Lume/Services/Images/ImageCache.swift
+++ b/Lume/Services/Images/ImageCache.swift
@@ -85,6 +85,11 @@ final nonisolated class ImageMemoryCache: @unchecked Sendable {
 
     func removeAll() {
         cache.removeAllObjects()
+        // Clearing the caches is the user's "artwork is broken, try again" button
+        // (Settings → Storage). The pipeline's negative cache has to go with them:
+        // otherwise the URLs that failed minutes ago stay frozen out and the clear
+        // looks like it did nothing for the very posters that prompted it.
+        Task { await ImagePipeline.shared.forgetFailures() }
     }
 
     /// Drops every decoded image and logs why. Called on memory warnings and when
@@ -147,24 +152,31 @@ nonisolated enum ImageDecoder {
     /// edge — this both saves memory and is far faster than decoding full-size
     /// artwork only to draw it into a small card. `nil` decodes at full
     /// resolution (used for tvOS 4K heroes).
+    ///
+    /// Both sizes go through the same ImageIO path because of
+    /// `kCGImageSourceShouldCacheImmediately`: it forces the pixels to be produced
+    /// *here*, on the pipeline's detached load task. `PlatformImage(data:)` — what
+    /// the full-resolution branch used to return — only wraps the bytes, so the
+    /// decode happened lazily on the main thread the first time the image was
+    /// drawn: a whole 4K JPEG, on the frame a hero or backdrop fades in. Leaving
+    /// `kCGImageSourceThumbnailMaxPixelSize` unset yields the original dimensions,
+    /// so full resolution still means full resolution.
     static func decode(_ data: Data, maxPixelSize: CGFloat?) -> PlatformImage? {
-        guard let maxPixelSize else {
-            return PlatformImage(data: data)
-        }
-
         let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
         guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
             return PlatformImage(data: data)
         }
 
-        let thumbnailOptions = [
+        var thumbnailOptions: [CFString: Any] = [
             kCGImageSourceCreateThumbnailFromImageAlways: true,
             kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceShouldCacheImmediately: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize
-        ] as CFDictionary
+            kCGImageSourceShouldCacheImmediately: true
+        ]
+        if let maxPixelSize {
+            thumbnailOptions[kCGImageSourceThumbnailMaxPixelSize] = maxPixelSize
+        }
 
-        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions) else {
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions as CFDictionary) else {
             return PlatformImage(data: data)
         }
 

--- a/Lume/Services/Images/ImagePipeline.swift
+++ b/Lume/Services/Images/ImagePipeline.swift
@@ -6,16 +6,21 @@
 //
 //  • Coalesce duplicate in-flight requests for the same image so a grid that
 //    asks for the same poster from ten cells only downloads it once.
+//  • Cancel a coalesced load once its last subscriber is gone, so flicking
+//    through a big grid doesn't queue the posters the user is actually looking
+//    at behind hundreds of cells that scrolled past seconds ago.
 //  • Retry transient network failures (timeouts, dropped connections, 5xx, 429)
 //    with backoff — the single biggest reason images "fail to load" today is
 //    that `AsyncImage` treats the first blip as permanent.
+//  • Remember URLs that just failed, so a dead poster isn't re-requested (and
+//    re-retried, with backoff) every single time its cell scrolls back in.
 //  • Serve from the memory cache, then the disk cache, then the network.
 //  • Offload decode/downsample work to detached tasks so loads run in parallel
 //    instead of serializing on the actor.
 //
-//  Why an actor: it owns only the in-flight table, which needs synchronized
-//  access. The heavy lifting (IO + decode) happens in detached tasks, so the
-//  actor never becomes a bottleneck.
+//  Why an actor: it owns only the in-flight table and the negative cache, which
+//  need synchronized access. The heavy lifting (IO + decode) happens in detached
+//  tasks, so the actor never becomes a bottleneck.
 //
 
 import Foundation
@@ -28,11 +33,46 @@ actor ImagePipeline {
     /// so `URLCache` is disabled to avoid double-storing bytes.
     private let session: URLSession
 
+    /// One shared load plus the subscribers currently waiting on it.
+    private struct InFlightLoad {
+        let task: Task<PlatformImage, Error>
+        /// Tokens of the live `image(for:)` callers awaiting this load. Prefetch
+        /// deliberately holds no token: warming is allowed to run to completion on
+        /// its own, but it must never keep a load alive once the last visible cell
+        /// has scrolled away.
+        var waiters: Set<UInt64>
+    }
+
     /// In-flight loads keyed by the memory-cache key (URL + target size), so two
     /// callers wanting the same image at the same size share one task.
-    private var inFlight: [String: Task<PlatformImage, Error>] = [:]
+    private var inFlight: [String: InFlightLoad] = [:]
+
+    /// Monotonic ids handed out to subscribers so a release can only ever retire
+    /// its own subscription. A cancelled load fires both the cancellation handler
+    /// and the normal completion path, and a blind counter would then decrement
+    /// twice — cancelling a load a *different* cell is still waiting for.
+    private var lastWaiterToken: UInt64 = 0
+
+    /// Negative cache: the earliest time a URL that just failed may be asked for
+    /// again. Without it a dead poster URL is re-fetched on every scroll pass, and
+    /// for the retryable statuses pays ~2.8 s of backoff before failing again.
+    private var retryAfter: [String: Date] = [:]
 
     private let maxRetries = 3
+
+    /// A URL that answers 4xx, or with bytes we can't decode, is not going to start
+    /// working during a browse session. Five minutes keeps it out of the whole
+    /// session while still letting a re-uploaded poster appear without a relaunch.
+    private let deadURLRetryDelay: TimeInterval = 300
+
+    /// Offline / timed-out / 5xx loads get seconds, not minutes: the user may be in
+    /// a lift, and walking back into Wi-Fi must not leave every URL they scrolled
+    /// past frozen out. Ten seconds is enough to absorb one flick through a grid.
+    private let transientRetryDelay: TimeInterval = 10
+
+    /// Ceiling on remembered failures — a 179k-title catalog has no shortage of dead
+    /// artwork, and this table must never become the thing that grows.
+    private let maxRememberedFailures = 512
 
     init() {
         let config = URLSessionConfiguration.default
@@ -59,6 +99,15 @@ actor ImagePipeline {
         ImageMemoryCache.shared.image(for: memoryKey(url, maxPixelSize: maxPixelSize))
     }
 
+    /// `URLSession`'s async API reports a cancelled request as `URLError.cancelled`
+    /// rather than `CancellationError`, so anything that has to tell "the caller
+    /// went away" apart from "this image is broken" must recognise both shapes.
+    nonisolated static func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        if let urlError = error as? URLError, urlError.code == .cancelled { return true }
+        return false
+    }
+
     /// Returns a decoded image for `url`, downsampled to `maxPixelSize` (longest
     /// edge in pixels) when provided. Throws on permanent failure.
     func image(for url: URL, maxPixelSize: CGFloat?) async throws -> PlatformImage {
@@ -68,16 +117,24 @@ actor ImagePipeline {
             return cached
         }
 
-        if let existing = inFlight[key] {
-            return try await existing.value
+        if isFrozenOut(url) {
+            throw ImagePipelineError.recentlyFailed
         }
 
-        let task = Task.detached(priority: .userInitiated) { [maxRetries] in
-            try await Self.load(url: url, maxPixelSize: maxPixelSize, key: key, retries: maxRetries)
+        let token = makeWaiterToken()
+        let task = startOrJoin(key: key, url: url, maxPixelSize: maxPixelSize, waiter: token, priority: .userInitiated)
+
+        // Awaiting another task's value is not a cancellation point, so before this
+        // handler a scrolled-away cell left its download running to completion:
+        // flicking through a grid buried the posters actually on screen behind
+        // hundreds of stale ones, which is why they stayed grey for seconds.
+        // Dropping the token cancels the shared load once nobody is left waiting.
+        return try await withTaskCancellationHandler {
+            defer { release(waiter: token, key: key) }
+            return try await task.value
+        } onCancel: {
+            Task { await self.release(waiter: token, key: key) }
         }
-        inFlight[key] = task
-        defer { inFlight[key] = nil }
-        return try await task.value
     }
 
     /// Warms the cache for upcoming images (e.g. neighbouring hero slides). Fire
@@ -85,18 +142,126 @@ actor ImagePipeline {
     func prefetch(_ urls: [URL], maxPixelSize: CGFloat?) {
         for url in urls {
             let key = Self.memoryKey(url, maxPixelSize: maxPixelSize)
-            guard ImageMemoryCache.shared.image(for: key) == nil, inFlight[key] == nil else { continue }
-            let task = Task.detached(priority: .utility) { [maxRetries] in
-                try await Self.load(url: url, maxPixelSize: maxPixelSize, key: key, retries: maxRetries)
-            }
-            inFlight[key] = task
-            Task { await self.clearInFlight(key, when: task) }
+            guard ImageMemoryCache.shared.image(for: key) == nil,
+                  inFlight[key] == nil,
+                  !isFrozenOut(url) else { continue }
+            _ = startOrJoin(key: key, url: url, maxPixelSize: maxPixelSize, waiter: nil, priority: .utility)
         }
     }
 
-    private func clearInFlight(_ key: String, when task: Task<PlatformImage, Error>) async {
-        _ = try? await task.value
+    /// Forgets every remembered failure. Clearing the image caches is the user's
+    /// "artwork is broken, try again" button, so it has to lift the freeze-out too —
+    /// otherwise posters that failed a minute earlier stay blank right after it.
+    func forgetFailures() {
+        retryAfter.removeAll()
+    }
+
+    // MARK: - In-flight table
+
+    /// Joins the existing load for `key`, or starts one. `waiter` is `nil` for
+    /// prefetches, which start a load but never hold it open.
+    private func startOrJoin(
+        key: String,
+        url: URL,
+        maxPixelSize: CGFloat?,
+        waiter: UInt64?,
+        priority: TaskPriority
+    ) -> Task<PlatformImage, Error> {
+        if var entry = inFlight[key] {
+            if let waiter {
+                entry.waiters.insert(waiter)
+                inFlight[key] = entry
+            }
+            return entry.task
+        }
+
+        let task = Task.detached(priority: priority) { [maxRetries] in
+            try await Self.load(url: url, maxPixelSize: maxPixelSize, key: key, retries: maxRetries)
+        }
+        var waiters: Set<UInt64> = []
+        if let waiter { waiters.insert(waiter) }
+        inFlight[key] = InFlightLoad(task: task, waiters: waiters)
+        Task { await self.retire(key: key, url: url, task: task) }
+        return task
+    }
+
+    /// Drops one subscription and, when it was the last, cancels the shared load.
+    /// Removing the row *before* cancelling matters: a cell that scrolls straight
+    /// back in must start a fresh load instead of joining a task already unwinding.
+    private func release(waiter token: UInt64, key: String) {
+        guard var entry = inFlight[key], entry.waiters.remove(token) != nil else { return }
+        guard entry.waiters.isEmpty else {
+            inFlight[key] = entry
+            return
+        }
         inFlight[key] = nil
+        entry.task.cancel()
+    }
+
+    /// Records the outcome once a load settles and retires its row unless a newer
+    /// load has already replaced it.
+    private func retire(key: String, url: URL, task: Task<PlatformImage, Error>) async {
+        do {
+            _ = try await task.value
+            retryAfter[url.absoluteString] = nil
+        } catch {
+            noteFailure(error, for: url)
+        }
+        if inFlight[key]?.task == task {
+            inFlight[key] = nil
+        }
+    }
+
+    private func makeWaiterToken() -> UInt64 {
+        lastWaiterToken &+= 1
+        return lastWaiterToken
+    }
+
+    // MARK: - Negative cache
+
+    /// True while `url` is inside its retry window. Expired entries are dropped on
+    /// the way past so the table drains without a timer.
+    private func isFrozenOut(_ url: URL) -> Bool {
+        guard let deadline = retryAfter[url.absoluteString] else { return false }
+        guard deadline > .now else {
+            retryAfter[url.absoluteString] = nil
+            return false
+        }
+        return true
+    }
+
+    /// Remembers a failed URL so the next hundred cells asking for it don't each pay
+    /// a round trip to rediscover the same dead poster. A cancellation is not a
+    /// failure — the image was never given a chance — and transient errors get the
+    /// short window so an offline moment doesn't blank the catalog for minutes.
+    private func noteFailure(_ error: Error, for url: URL) {
+        guard !Self.isCancellation(error) else { return }
+        let delay = Self.isTransientFailure(error) ? transientRetryDelay : deadURLRetryDelay
+        retryAfter[url.absoluteString] = Date.now.addingTimeInterval(delay)
+        pruneFailuresIfNeeded()
+    }
+
+    private func pruneFailuresIfNeeded() {
+        guard retryAfter.count > maxRememberedFailures else { return }
+        let now = Date.now
+        retryAfter = retryAfter.filter { $0.value > now }
+        guard retryAfter.count > maxRememberedFailures else { return }
+        // Still over the cap even after dropping the expired entries: keep the
+        // freshest half, which is the part a scrolling user is about to hit again.
+        let freshest = retryAfter.sorted { $0.value > $1.value }.prefix(maxRememberedFailures / 2)
+        retryAfter = Dictionary(uniqueKeysWithValues: freshest.map { ($0.key, $0.value) })
+    }
+
+    /// Failures that say "not now" rather than "not ever": everything `fetch` already
+    /// retries, plus the URL errors it treats as blips.
+    private nonisolated static func isTransientFailure(_ error: Error) -> Bool {
+        if let urlError = error as? URLError {
+            return isTransient(urlError)
+        }
+        if let pipelineError = error as? ImagePipelineError, case let .httpStatus(code) = pipelineError {
+            return code == 429 || (500 ... 599).contains(code)
+        }
+        return false
     }
 
     // MARK: - Loading (runs off-actor)
@@ -113,6 +278,10 @@ actor ImagePipeline {
 
         let data = try await fetch(url: url, retries: retries)
         ImageDiskCache.shared.store(data, for: diskKey)
+
+        // The decode below is the expensive part; skip it for a subscriber that has
+        // already gone away rather than burning a core on pixels nobody will draw.
+        try Task.checkCancellation()
 
         guard let image = ImageDecoder.decode(data, maxPixelSize: maxPixelSize) else {
             throw ImagePipelineError.decodingFailed
@@ -170,4 +339,7 @@ actor ImagePipeline {
 enum ImagePipelineError: Error {
     case decodingFailed
     case httpStatus(Int)
+    /// This URL failed moments ago and is still inside its retry window. Thrown
+    /// without touching the network so a scroll pass over broken artwork is free.
+    case recentlyFailed
 }

--- a/Lume/Services/Indexing/ContentIndexer.swift
+++ b/Lume/Services/Indexing/ContentIndexer.swift
@@ -10,8 +10,10 @@
 //  Designed to run slowly in the background: items are processed in small
 //  chunks on a dedicated ModelContext with pauses in between, so neither TMDB
 //  nor the main thread is hammered. The loop waits while a playlist sync is
-//  running and while the player is up — even a background-context save forces
-//  the main context to merge and re-run every @Query, which hitches KSPlayer.
+//  running, while an iCloud import is in flight, while the player is up and
+//  while the user is browsing — even a background-context save forces the main
+//  context to merge and re-run every @Query, which hitches KSPlayer and stalls
+//  browsing on a large catalog.
 //
 
 import Foundation
@@ -28,7 +30,17 @@ actor ContentIndexer {
     /// Pause between items — keeps TMDB traffic to a couple of requests per
     /// second at most.
     private let itemPause: Duration = .milliseconds(100)
-    /// Pause before re-checking when a sync or playback blocks indexing.
+    /// Extra pause between chunks, on top of the per-item pauses inside one.
+    /// A chunk ends in the save whose main-context merge re-runs every @Query,
+    /// so this is the knob that sets how often the whole app is disturbed:
+    /// 50 items × `itemPause` put a merge roughly every 5 s of a foreground
+    /// session — the same cadence that used to hitch KSPlayer — and this pushes
+    /// it towards 7 s. It costs run time (a full 227k-title pass is hours
+    /// either way) and buys back merges, which is the right trade: nobody is
+    /// waiting on the index.
+    private let chunkPause: Duration = .seconds(2)
+    /// Pause before re-checking when a sync, playback or browsing blocks
+    /// indexing.
     private let busyPause: Duration = .seconds(20)
     /// First wait before retrying a failed embedding-asset download; doubles
     /// each attempt up to `assetRetryMaxPause`. The OTA asset request times out
@@ -71,6 +83,11 @@ actor ContentIndexer {
             return
         }
 
+        // Wait before loading the model, not just before the first chunk:
+        // `LumeApp` kicks a pass on every launch, so the tens-of-MB embedding
+        // asset would otherwise load while Home is still fetching its rails.
+        try await waitWhileBusy(status: status)
+
         await status.setPreparing()
         let embedder = try TextEmbedder()
         // Release the model the moment the pass ends — completion, cancellation,
@@ -80,24 +97,39 @@ actor ContentIndexer {
         try await prepareEmbedder(embedder, status: status)
 
         while !Task.isCancelled {
-            if try await hasActiveSync() || status.isPlaybackActive || status.isCloudSyncActive {
-                await status.setWaiting()
-                try await Task.sleep(for: busyPause)
-                continue
-            }
+            try await waitWhileBusy(status: status)
 
             counts = try currentCounts()
             await status.update(indexed: counts.indexed, total: counts.total)
 
             let processed = try await indexNextChunk(embedder: embedder)
             if processed == 0 { break }
-            try await Task.sleep(for: itemPause)
+            try await Task.sleep(for: chunkPause)
         }
 
         try Task.checkCancellation()
         counts = try currentCounts()
         await status.finish(indexed: counts.indexed, total: counts.total)
         Logger.indexing.info("Content index complete: \(counts.indexed) of \(counts.total) titles")
+    }
+
+    /// Blocks while anything indexing has to stand aside for is happening: a
+    /// playlist sync, playback, a CloudKit import/export, or the user browsing.
+    /// All four are hurt the same way — the `context.save()` that ends a chunk
+    /// forces a main-context merge that re-runs every `@Query` in every mounted
+    /// tab, which hitches KSPlayer and stalls a browse of a large catalog (a
+    /// 227k-title library is ~4,500 of those merges, one per chunk, spread over
+    /// hours of ordinary use).
+    ///
+    /// Checked between chunks, not inside one: a chunk already in flight
+    /// finishes and saves, because abandoning it would only bring that same
+    /// save forward. Re-checked every `busyPause` rather than continuously —
+    /// nobody is waiting on the index, so resuming 20 s late costs nothing.
+    private func waitWhileBusy(status: ContentIndexingService) async throws {
+        while try await hasActiveSync() || status.isPlaybackActive || status.isCloudSyncActive || status.isUserBrowsing {
+            await status.setWaiting()
+            try await Task.sleep(for: busyPause)
+        }
     }
 
     /// Loads the embedding model, waiting and retrying when its assets fail to

--- a/Lume/Services/Indexing/ContentIndexingService.swift
+++ b/Lume/Services/Indexing/ContentIndexingService.swift
@@ -23,7 +23,8 @@ final class ContentIndexingService {
         /// Downloading/loading the embedding model.
         case preparing
         case indexing
-        /// A playlist sync or playback is active; indexing resumes on its own.
+        /// A playlist sync, playback, an iCloud import or the user browsing is
+        /// holding indexing off; it resumes on its own.
         case waiting
         case upToDate
         /// The embedding model cannot be loaded on this device.
@@ -47,6 +48,42 @@ final class ContentIndexingService {
     /// and faulting a catalog object during that window throws an uncatchable
     /// `no such table` `NSException`.
     var isCloudSyncActive = false
+
+    /// When a browse surface last reported activity. The indexer pauses while
+    /// this is recent, for the same reason it pauses for playback: the one
+    /// `context.save()` that ends every chunk forces a main-context merge that
+    /// re-runs every `@Query` in every mounted tab. On a 284k-row playlist that
+    /// is ~4,500 whole-app query storms spread through ordinary use — measured,
+    /// a single launch re-ran each of Home's six `@Query` properties 20-25
+    /// times, and one "Add to Favorites" tap landed in a window holding 23,991
+    /// fetches. Nobody is waiting on the index; the person scrolling is.
+    ///
+    /// Deliberately `@ObservationIgnored`: a stamp taken on every scroll that
+    /// invalidated the views reading it would cost more than the indexer does.
+    @ObservationIgnored private var lastUserInteraction: Date?
+
+    /// How long a stamp keeps counting as "the user is here". Long enough to
+    /// bridge the gaps between taps while paging through a catalog, short
+    /// enough that a screen left open doesn't stall indexing for good.
+    private static let browsingQuietWindow: TimeInterval = 8
+
+    /// True while the user was interacting within the last
+    /// `browsingQuietWindow` seconds. Self-clearing by construction: callers
+    /// stamp and forget, so no view can leave indexing switched off by failing
+    /// to unset a flag on the way out — the failure mode that a paired
+    /// set/unset (like `isPlaybackActive`) has to be careful about.
+    var isUserBrowsing: Bool {
+        guard let lastUserInteraction else { return false }
+        return Date.now.timeIntervalSince(lastUserInteraction) < Self.browsingQuietWindow
+    }
+
+    /// Called by browse surfaces to hold indexing off for the next few seconds.
+    /// One line at the call site with nothing to balance, and it costs a single
+    /// `Date` write — cheap enough to sit on an `.onAppear`, a tab change or a
+    /// scroll/selection change.
+    func noteUserInteraction() {
+        lastUserInteraction = .now
+    }
 
     private var container: ModelContainer?
     private var task: Task<Void, Never>?

--- a/Lume/Services/ParentalControls/ContentRestriction.swift
+++ b/Lume/Services/ParentalControls/ContentRestriction.swift
@@ -11,6 +11,12 @@
 //  Home, Search and the "For You" engine) reads it so a hidden or restricted
 //  category — and any title in it — disappears everywhere alike.
 //
+//  Everything derived is derived once, in `init`. The union and the digest used
+//  to be computed properties, and the readers are hot: `excludingRestricted`
+//  asks for the union once per rail, and Home folds the digest into three
+//  `.task(id:)` keys — so a single Home body pass hashed all 433 hidden
+//  category ids two to three times over, on the main thread, while scrolling.
+//
 
 import CryptoKit
 import SwiftUI
@@ -18,25 +24,32 @@ import SwiftUI
 nonisolated struct ContentRestriction: Equatable {
     /// True when the active profile is a child: `restrictedCategoryIDs` applies
     /// only to kids.
-    var isActive = false
+    let isActive: Bool
     /// Ids of the categories marked restricted.
-    var restrictedCategoryIDs: Set<String> = []
+    let restrictedCategoryIDs: Set<String>
     /// Ids of the categories the user hid in Content Management. Unlike
     /// restricted ones these apply to every profile.
-    var hiddenCategoryIDs: Set<String> = []
-
+    let hiddenCategoryIDs: Set<String>
     /// Every category id excluded for the current viewer.
-    var excludedCategoryIDs: Set<String> {
-        isActive ? hiddenCategoryIDs.union(restrictedCategoryIDs) : hiddenCategoryIDs
-    }
-
+    let excludedCategoryIDs: Set<String>
     /// A stable digest of `excludedCategoryIDs`, for cache keys that must not
     /// outlive a visibility change (Home's trending memo, the "For You" list).
     /// Hashed rather than joined verbatim: a user who hides most of a large
     /// catalog would otherwise put tens of kilobytes in a key. `hashValue` is
     /// seeded per process and would differ every launch, so it can't be used.
-    var visibilityToken: String {
-        Self.visibilityToken(for: excludedCategoryIDs)
+    let visibilityToken: String
+
+    init(
+        isActive: Bool = false,
+        restrictedCategoryIDs: Set<String> = [],
+        hiddenCategoryIDs: Set<String> = []
+    ) {
+        let excluded = isActive ? hiddenCategoryIDs.union(restrictedCategoryIDs) : hiddenCategoryIDs
+        self.isActive = isActive
+        self.restrictedCategoryIDs = restrictedCategoryIDs
+        self.hiddenCategoryIDs = hiddenCategoryIDs
+        excludedCategoryIDs = excluded
+        visibilityToken = Self.visibilityToken(for: excluded)
     }
 
     static func visibilityToken(for excludedCategoryIDs: Set<String>) -> String {
@@ -44,11 +57,18 @@ nonisolated struct ContentRestriction: Equatable {
         return SHA256.hash(data: Data(joined.utf8)).map { String(format: "%02x", $0) }.joined()
     }
 
+    /// Compared by digest alone. The excluded set is the only thing any caller
+    /// reads, and the digest is derived from exactly that — so this is the same
+    /// comparison the synthesized `==` would make, minus rehashing hundreds of
+    /// category ids every time SwiftUI checks whether the environment moved.
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.visibilityToken == rhs.visibilityToken
+    }
+
     /// Whether content in `categoryID` should be hidden from the current viewer.
     func hides(categoryID: String?) -> Bool {
         guard let categoryID else { return false }
-        if hiddenCategoryIDs.contains(categoryID) { return true }
-        return isActive && restrictedCategoryIDs.contains(categoryID)
+        return excludedCategoryIDs.contains(categoryID)
     }
 }
 

--- a/Lume/Views/Components/BrowseActivity.swift
+++ b/Lume/Views/Components/BrowseActivity.swift
@@ -1,0 +1,37 @@
+//
+//  BrowseActivity.swift
+//  Lume
+//
+//  One modifier that tells the background content indexer someone is using the
+//  app right now, so it stands aside.
+//
+//  `ContentIndexer` saves once per chunk, and every one of those saves forces a
+//  main-context merge that re-runs every `@Query` in every mounted tab — the
+//  same mechanism that used to hitch KSPlayer, which is why the indexer already
+//  pauses for playback, playlist sync and CloudKit imports. On a 284k-row
+//  playlist a full pass is ~4,500 of those merges spread over hours of ordinary
+//  use, and a merge that lands mid-scroll breaks the scroll.
+//
+//  `noteUserInteraction()` is a single `Date` write and self-clearing (see
+//  `ContentIndexingService.isUserBrowsing`), so a surface stamps and forgets —
+//  there is no paired "done browsing" call a view could fail to make.
+//
+
+import SwiftUI
+
+extension View {
+    /// Marks a scrolling browse surface: stamps while the content is moving, and
+    /// once when it appears.
+    ///
+    /// Attached to the scroll view rather than the screen so the stamp tracks
+    /// actual interaction — a screen left open on a shelf stops stamping after a
+    /// few seconds and lets indexing resume, which is the whole point of the
+    /// quiet window being short.
+    func browseActivity() -> some View {
+        onScrollPhaseChange { _, phase in
+            guard phase != .idle else { return }
+            ContentIndexingService.shared.noteUserInteraction()
+        }
+        .onAppear { ContentIndexingService.shared.noteUserInteraction() }
+    }
+}

--- a/Lume/Views/Components/CachedAsyncImage.swift
+++ b/Lume/Views/Components/CachedAsyncImage.swift
@@ -7,7 +7,8 @@
 //
 //  • Memory + disk caching (see `ImagePipeline`), so images survive cell reuse
 //    and app launches instead of re-downloading and flashing placeholders.
-//  • Automatic retry on transient network failures.
+//  • Automatic retry on transient network failures, and a short freeze-out for
+//    URLs that just failed so a dead poster isn't re-requested on every pass.
 //  • Optional downsampling via `maxPixelSize` (longest edge in points; converted
 //    to pixels using the display scale) to cut memory and decode time for cards.
 //    Pass `nil` for full-resolution artwork such as tvOS 4K heroes.
@@ -91,9 +92,14 @@ struct CachedAsyncImage<Content: View>: View {
             withTransaction(transaction) {
                 phase = .success(Image(platformImage: image))
             }
-        } catch is CancellationError {
-            // View went away mid-load; the detached fetch still warms the cache.
         } catch {
+            // The cell scrolled away mid-load: the shared fetch is now cancelled
+            // with us (see `ImagePipeline`) so the posters still on screen aren't
+            // stuck behind it. Leave the phase alone — this view is going away, and
+            // a stored .failure would show the broken-artwork placeholder for a
+            // beat if it comes back. `URLSession` reports a cancelled request as
+            // `URLError.cancelled` rather than `CancellationError`, hence the helper.
+            guard !ImagePipeline.isCancellation(error) else { return }
             withTransaction(transaction) {
                 phase = .failure(error)
             }

--- a/Lume/Views/Components/CategoryContentGrid.swift
+++ b/Lume/Views/Components/CategoryContentGrid.swift
@@ -72,15 +72,16 @@ struct CategoryContentGrid<Item: Identifiable & Hashable & WatchlistFavoritable,
                 .padding()
             }
         }
+        .browseActivity()
         // tvOS surfaces sorting through the tab bar's library controls instead of a
         // toolbar, mirroring the main browse views.
         #if !os(tvOS)
-        .navigationTitle(title)
-        .toolbar {
-            ToolbarItem(placement: .automatic) {
-                ContentSortMenu(sortRaw: $sortRaw)
+            .navigationTitle(title)
+            .toolbar {
+                ToolbarItem(placement: .automatic) {
+                    ContentSortMenu(sortRaw: $sortRaw)
+                }
             }
-        }
         #endif
     }
 }

--- a/Lume/Views/Components/GenreBrowse.swift
+++ b/Lume/Views/Components/GenreBrowse.swift
@@ -76,8 +76,12 @@ nonisolated protocol GenreCarrying {
     var categoryId: String? { get }
 }
 
-extension Movie: GenreCarrying {}
-extension Series: GenreCarrying {}
+// The conformances are `nonisolated` too, not just the protocol: under
+// SWIFT_DEFAULT_ACTOR_ISOLATION=MainActor a bare `extension Movie: GenreCarrying`
+// declares a main-actor-isolated conformance, which cannot satisfy the
+// `Sendable` requirement `scan`'s generic parameter carries.
+nonisolated extension Movie: GenreCarrying {}
+nonisolated extension Series: GenreCarrying {}
 
 // MARK: - Browse-by-genre section
 
@@ -115,11 +119,152 @@ struct GenreGridSection: View {
     }
 }
 
+// MARK: - Off-main genre page fetch
+
+/// How many source rows one page load may walk before handing control back to
+/// the caller. The re-checks below can empty a whole source page, and each
+/// retry is another scan, so a genre whose next few hundred rows are all
+/// near-misses would otherwise chain scans until it found something. Five
+/// source pages is the bound; the caller resumes from the returned cursor.
+private let genreScanBudget = 500
+
+/// What one page of a genre grid is fetched for. Plain value type so the
+/// off-main fetch takes a single `Sendable` value, mirroring `SearchRequest`.
+nonisolated struct GenrePageRequest {
+    let genre: String
+    /// `"<playlistUUID>-"` — the id prefix every title in the active playlist
+    /// shares, matched in SQLite rather than after materialization.
+    let playlistPrefix: String
+    let excludedCategoryIDs: Set<String>
+    /// Where in the source rows to resume; see `GenrePage.scanned`.
+    let offset: Int
+    let pageSize: Int
+}
+
+/// A page's displayable rows — identifiers only, never managed objects, which
+/// can't cross actor boundaries — plus the cursor state the view carries
+/// forward.
+nonisolated struct GenrePage {
+    var ids: [PersistentIdentifier] = []
+    /// Source rows consumed, which is what the next `fetchOffset` must advance
+    /// by: the re-checks drop rows the substring fetch returned, so the
+    /// displayed count and the source offset diverge.
+    var scanned = 0
+    /// The source is exhausted — no further page can exist.
+    var reachedEnd = false
+}
+
+/// Runs a genre page fetch on a background `ModelContext`, mirroring
+/// `SearchFetcher`.
+///
+/// This used to be a synchronous `fetch` on the *main* context, fired from a
+/// grid cell's `onAppear` mid-scroll. `localizedStandardContains` can't use the
+/// `genre` index, so every page scanned the table — hundreds of milliseconds
+/// per page on a 179k-title playlist, and the retry loop could chain several of
+/// those into one frame, which is a watchdog hazard rather than a hitch.
+nonisolated enum GenrePageFetcher {
+    static func movies(
+        container: ModelContainer,
+        request: GenrePageRequest,
+        sortBy: [SortDescriptor<Movie>]
+    ) -> GenrePage {
+        let context = ModelContext(container)
+        var descriptor = FetchDescriptor<Movie>(predicate: moviePredicate(request: request), sortBy: sortBy)
+        descriptor.fetchLimit = request.pageSize
+        // Only `genre` (the exact-token re-check) and `categoryId` (viewer
+        // visibility) are read off the fetched rows, so leave the rest
+        // unhydrated — the same trade the genre derivation above makes, and it
+        // keeps a page of wide rows (plot, cast, artwork paths) out of memory.
+        descriptor.propertiesToFetch = [\.genre, \.categoryId]
+        return scan(request: request) { (offset: Int) -> [Movie] in
+            descriptor.fetchOffset = offset
+            return (try? context.fetch(descriptor)) ?? []
+        }
+    }
+
+    static func series(
+        container: ModelContainer,
+        request: GenrePageRequest,
+        sortBy: [SortDescriptor<Series>]
+    ) -> GenrePage {
+        let context = ModelContext(container)
+        var descriptor = FetchDescriptor<Series>(predicate: seriesPredicate(request: request), sortBy: sortBy)
+        descriptor.fetchLimit = request.pageSize
+        descriptor.propertiesToFetch = [\.genre, \.categoryId]
+        return scan(request: request) { (offset: Int) -> [Series] in
+            descriptor.fetchOffset = offset
+            return (try? context.fetch(descriptor)) ?? []
+        }
+    }
+
+    /// The playlist scope and the hidden-category exclusion run in SQLite, in
+    /// the shape `searchMoviePredicate` established, so a page isn't spent on
+    /// rows the viewer will never see — the offset used to walk every
+    /// playlist's titles and then throw all but one playlist's away.
+    /// `starts(with:)` compiles to a range seek on the unique `id` index, which
+    /// is the only part of this predicate an index can serve: the genre match
+    /// has to stay a substring test because the column holds several free-text
+    /// genres per title.
+    private static func moviePredicate(request: GenrePageRequest) -> Predicate<Movie> {
+        let (genre, prefix) = (request.genre, request.playlistPrefix)
+        let excluded = Set(request.excludedCategoryIDs.map(String?.some))
+        let filtersCategories = !excluded.isEmpty
+        return #Predicate { movie in
+            movie.id.starts(with: prefix)
+                && (movie.genre?.localizedStandardContains(genre) ?? false)
+                && (!filtersCategories || movie.categoryId == nil || !excluded.contains(movie.categoryId))
+        }
+    }
+
+    private static func seriesPredicate(request: GenrePageRequest) -> Predicate<Series> {
+        let (genre, prefix) = (request.genre, request.playlistPrefix)
+        let excluded = Set(request.excludedCategoryIDs.map(String?.some))
+        let filtersCategories = !excluded.isEmpty
+        return #Predicate { series in
+            series.id.starts(with: prefix)
+                && (series.genre?.localizedStandardContains(genre) ?? false)
+                && (!filtersCategories || series.categoryId == nil || !excluded.contains(series.categoryId))
+        }
+    }
+
+    /// Walks source pages from `request.offset` until one yields a displayable
+    /// row, the source runs out, or `genreScanBudget` is spent.
+    ///
+    /// The loop is needed because the in-memory re-checks can empty a whole
+    /// source page — `GenreParser` keeps `&` intact, so a tile for "Action"
+    /// fetches every "Action & Adventure" title and then drops it again — and
+    /// without new trailing items the grid never fires `onLoadMore` again,
+    /// stalling pagination. The budget is what bounds it: the caller resumes
+    /// from the returned cursor instead of the loop running until it finds
+    /// something.
+    private static func scan(
+        request: GenrePageRequest,
+        fetch: (Int) -> [some PersistentModel & GenreCarrying]
+    ) -> GenrePage {
+        let excluded = request.excludedCategoryIDs
+        var page = GenrePage()
+        while page.ids.isEmpty, !page.reachedEnd, page.scanned < genreScanBudget {
+            let rows = fetch(request.offset + page.scanned)
+            page.scanned += rows.count
+            if rows.count < request.pageSize { page.reachedEnd = true }
+            // The exact-token re-check keeps a substring hit out, and the
+            // `excludingRestricted` filter is inlined so this stays
+            // `nonisolated` — the same trade `GenreDerivation.derive` makes.
+            page.ids = rows
+                .filter { GenreParser.contains($0.genre, genre: request.genre) && !excluded.contains($0.categoryId ?? "") }
+                .map(\.persistentModelID)
+        }
+        return page
+    }
+}
+
 // MARK: - Genre detail grids
 
 /// The full grid of movies in a genre, reachable from a genre tile. The fetch
 /// narrows to candidate rows in SQLite with `localizedStandardContains`, then
-/// re-filters to exact-token matches in memory so substrings can't sneak in.
+/// re-filters to exact-token matches so substrings can't sneak in — all of it
+/// on a background context (`GenrePageFetcher`), because the grid asks for the
+/// next page from a cell's `onAppear`, mid-scroll.
 struct MovieGenreView: View {
     let genre: String
     let playlistPrefix: String
@@ -131,15 +276,19 @@ struct MovieGenreView: View {
     @State private var movies: [Movie] = []
     @State private var canLoadMore = true
     @State private var isLoadingPage = false
-    /// SQLite cursor position, distinct from `movies.count`. The in-memory
-    /// genre/prefix/restriction filter below drops rows the substring fetch
-    /// returned, so the displayed count and the source offset diverge — the
-    /// offset must track rows pulled from SQLite, not rows shown.
+    /// SQLite cursor position, distinct from `movies.count`. The exact-token and
+    /// visibility re-checks drop rows the substring fetch returned, so the
+    /// displayed count and the source offset diverge — the offset must track
+    /// rows pulled from SQLite, not rows shown.
     @State private var fetchedCount = 0
     /// The sort the current pages were loaded for. Pushing a detail cancels and
     /// (on pop) re-runs `.task`; reloading page one there would discard the
     /// loaded pages and reset the scroll position. Reload only when this differs.
     @State private var loadedSort: String?
+    /// Bumped whenever the loaded pages are thrown away. A page fetch already in
+    /// flight resolves against the old cursor, so its rows have to be dropped
+    /// rather than appended to the fresh list.
+    @State private var loadGeneration = 0
 
     /// A popular genre in a large IPTV playlist can span thousands of titles;
     /// fetch a page at a time and load the next as the grid nears the end,
@@ -166,6 +315,11 @@ struct MovieGenreView: View {
         .task(id: contentSortRaw) {
             guard loadedSort != contentSortRaw else { return }
             loadedSort = contentSortRaw
+            // A page fetched against the previous sort's cursor is now
+            // meaningless: bump the generation so it's discarded on arrival, and
+            // release the in-flight guard here, since that load no longer will.
+            loadGeneration += 1
+            isLoadingPage = false
             movies = []
             fetchedCount = 0
             canLoadMore = true
@@ -176,34 +330,41 @@ struct MovieGenreView: View {
     private func loadNextPage() {
         guard canLoadMore, !isLoadingPage else { return }
         isLoadingPage = true
-        defer { isLoadingPage = false }
-        let token = genre
-        let prefix = playlistPrefix
-        // Keep pulling raw pages until a batch surfaces at least one displayable
-        // title or the source is exhausted: the in-memory filter can drop an
-        // entire SQLite page, and without new trailing items the grid would
-        // never fire `onLoadMore` again, stalling pagination.
-        var added = 0
-        while canLoadMore, added == 0 {
-            var descriptor = FetchDescriptor<Movie>(
-                predicate: #Predicate { ($0.genre?.localizedStandardContains(token)) ?? false },
-                sortBy: contentSort.movieDescriptors
-            )
-            descriptor.fetchOffset = fetchedCount
-            descriptor.fetchLimit = pageSize
-            let rawPage = (try? modelContext.fetch(descriptor)) ?? []
-            fetchedCount += rawPage.count
-            if rawPage.count < pageSize { canLoadMore = false }
-            let filtered = rawPage
-                .filter { $0.id.hasPrefix(prefix) && GenreParser.contains($0.genre, genre: token) }
-                .excludingRestricted(restriction)
-            movies.append(contentsOf: filtered)
-            added += filtered.count
+        let generation = loadGeneration
+        let request = GenrePageRequest(
+            genre: genre,
+            playlistPrefix: playlistPrefix,
+            excludedCategoryIDs: restriction.excludedCategoryIDs,
+            offset: fetchedCount,
+            pageSize: pageSize
+        )
+        let sortBy = contentSort.movieDescriptors
+        let container = modelContext.container
+        Task {
+            let page = await Task.detached(priority: .userInitiated) {
+                GenrePageFetcher.movies(container: container, request: request, sortBy: sortBy)
+            }.value
+            guard generation == loadGeneration else { return }
+            apply(page)
         }
+    }
+
+    /// Hydrates the fetched identifiers in the view context and advances the
+    /// cursor. An empty page with the source not yet exhausted means the scan
+    /// budget ran out before anything displayable turned up; resume from the new
+    /// offset, because the grid can't ask again — nothing new appeared for it to
+    /// fire `onLoadMore` from.
+    private func apply(_ page: GenrePage) {
+        isLoadingPage = false
+        fetchedCount += page.scanned
+        if page.reachedEnd { canLoadMore = false }
+        movies.append(contentsOf: page.ids.compactMap { modelContext.model(for: $0) as? Movie })
+        if page.ids.isEmpty, canLoadMore { loadNextPage() }
     }
 }
 
-/// The full grid of series in a genre.
+/// The full grid of series in a genre; paged off the main actor exactly as
+/// `MovieGenreView` is.
 struct SeriesGenreView: View {
     let genre: String
     let playlistPrefix: String
@@ -220,6 +381,9 @@ struct SeriesGenreView: View {
     /// Sort the current pages were loaded for; reload only on change — see
     /// `MovieGenreView`, which explains why reappearance must not reset.
     @State private var loadedSort: String?
+    /// Discards a page fetched against a cursor that has since been reset — see
+    /// `MovieGenreView`.
+    @State private var loadGeneration = 0
 
     /// Page a genre at a time rather than hydrating it whole; see `MovieGenreView`.
     private let pageSize = 100
@@ -243,6 +407,8 @@ struct SeriesGenreView: View {
         .task(id: contentSortRaw) {
             guard loadedSort != contentSortRaw else { return }
             loadedSort = contentSortRaw
+            loadGeneration += 1
+            isLoadingPage = false
             series = []
             fetchedCount = 0
             canLoadMore = true
@@ -253,28 +419,32 @@ struct SeriesGenreView: View {
     private func loadNextPage() {
         guard canLoadMore, !isLoadingPage else { return }
         isLoadingPage = true
-        defer { isLoadingPage = false }
-        let token = genre
-        let prefix = playlistPrefix
-        // Keep pulling until a batch yields displayable titles or the source is
-        // exhausted — the in-memory filter can empty a whole page; see
-        // `MovieGenreView.loadNextPage`.
-        var added = 0
-        while canLoadMore, added == 0 {
-            var descriptor = FetchDescriptor<Series>(
-                predicate: #Predicate { ($0.genre?.localizedStandardContains(token)) ?? false },
-                sortBy: contentSort.seriesDescriptors
-            )
-            descriptor.fetchOffset = fetchedCount
-            descriptor.fetchLimit = pageSize
-            let rawPage = (try? modelContext.fetch(descriptor)) ?? []
-            fetchedCount += rawPage.count
-            if rawPage.count < pageSize { canLoadMore = false }
-            let filtered = rawPage
-                .filter { $0.id.hasPrefix(prefix) && GenreParser.contains($0.genre, genre: token) }
-                .excludingRestricted(restriction)
-            series.append(contentsOf: filtered)
-            added += filtered.count
+        let generation = loadGeneration
+        let request = GenrePageRequest(
+            genre: genre,
+            playlistPrefix: playlistPrefix,
+            excludedCategoryIDs: restriction.excludedCategoryIDs,
+            offset: fetchedCount,
+            pageSize: pageSize
+        )
+        let sortBy = contentSort.seriesDescriptors
+        let container = modelContext.container
+        Task {
+            let page = await Task.detached(priority: .userInitiated) {
+                GenrePageFetcher.series(container: container, request: request, sortBy: sortBy)
+            }.value
+            guard generation == loadGeneration else { return }
+            apply(page)
         }
+    }
+
+    /// Hydrates and advances the cursor, resuming when the scan budget ran out
+    /// empty — see `MovieGenreView.apply`.
+    private func apply(_ page: GenrePage) {
+        isLoadingPage = false
+        fetchedCount += page.scanned
+        if page.reachedEnd { canLoadMore = false }
+        series.append(contentsOf: page.ids.compactMap { modelContext.model(for: $0) as? Series })
+        if page.ids.isEmpty, canLoadMore { loadNextPage() }
     }
 }

--- a/Lume/Views/Components/LibraryCollectionRows.swift
+++ b/Lume/Views/Components/LibraryCollectionRows.swift
@@ -8,10 +8,14 @@
 //  category — so they're driven by their own predicates rather than a
 //  `categoryId`, mirroring the Home screen's rows.
 //
-//  Each row scopes its @Query results to the active playlist in-memory (the same
-//  approach the rest of the app uses, since SwiftData can't parameterise a
-//  @Query on a playlist-prefixed id), then caps to a preview length. Rows render
-//  nothing when empty so a fresh library degrades gracefully.
+//  Each surface scopes its @Query to the active playlist inside the predicate:
+//  ids are playlist-prefixed, so `id.starts(with:)` is a prefix match SQLite
+//  answers itself. Scoping in memory instead meant every row hydrated every
+//  playlist's matches and then threw most of them away, on every catalog write
+//  — 0.85 ms for a fresh library, 59 ms once 3,035 movies carried a watch date.
+//  Only the viewer's hidden categories are filtered in Swift, since that state
+//  lives in the environment rather than the store. Rows render nothing when
+//  empty so a fresh library degrades gracefully.
 //
 
 import SwiftData
@@ -51,12 +55,20 @@ struct LibraryCollection: Hashable {
 /// How many items each preview row shows before "Show All".
 private let collectionPreviewLimit = 20
 
-/// Upper bound on the "Recently Added" fetch. Recently Watched and Favorites
-/// match small subsets, but every title carries an `added` timestamp, so that
-/// predicate matches the whole library — an unbounded fetch would hydrate the
-/// entire catalog on every change and stutter badly during sync. We only ever
-/// surface the newest slice, so the query is capped (then scoped in-memory to
-/// the active playlist, like the rest of the app).
+/// Upper bound on a preview row's fetch. A row renders `collectionPreviewLimit`
+/// items and only needs to know whether one more exists, but the hidden-category
+/// filter runs in memory *after* the fetch, so this keeps a wide margin over the
+/// preview length rather than the tight `limit + 1` a single-category row can
+/// use — a viewer with many hidden categories must not end up with a short row
+/// or a missing "Show All". Unbounded, Recently Watched and Favorites re-fetched
+/// every matching row in the store on every catalog write.
+private let collectionRowFetchLimit = 200
+
+/// Upper bound on the "Recently Added" fetch, preview row and "Show All" grid
+/// alike. Recently Watched and Favorites match small subsets, but every title
+/// carries an `added` timestamp, so that predicate matches the playlist whole —
+/// an unbounded fetch would hydrate the entire catalog on every change and
+/// stutter badly during sync. We only ever surface the newest slice.
 private let recentlyAddedFetchLimit = 200
 
 // MARK: - Shared preview row
@@ -131,7 +143,6 @@ private struct CollectionPreviewRow<Item: Identifiable & Hashable & WatchlistFav
 /// nothing when the active playlist has no matching movies.
 struct MovieCollectionRow: View {
     let kind: LibraryCollection.Kind
-    let playlistPrefix: String
     var animationNamespace: Namespace.ID?
     @Environment(\.modelContext) private var modelContext
     @Environment(\.contentRestriction) private var restriction
@@ -139,17 +150,16 @@ struct MovieCollectionRow: View {
 
     init(kind: LibraryCollection.Kind, playlistPrefix: String, animationNamespace: Namespace.ID? = nil) {
         self.kind = kind
-        self.playlistPrefix = playlistPrefix
         self.animationNamespace = animationNamespace
-        _movies = Query(MovieCollectionQuery.descriptor(for: kind))
+        _movies = Query(MovieCollectionQuery.rowDescriptor(for: kind, playlistPrefix: playlistPrefix))
     }
 
-    private var scoped: [Movie] {
-        movies.filter { $0.id.hasPrefix(playlistPrefix) }.excludingRestricted(restriction)
+    private var visible: [Movie] {
+        movies.excludingRestricted(restriction)
     }
 
     var body: some View {
-        let matches = scoped
+        let matches = visible
         let items = Array(matches.prefix(collectionPreviewLimit))
         if !items.isEmpty {
             CollectionPreviewRow(
@@ -171,20 +181,18 @@ struct MovieCollectionRow: View {
 /// The full grid behind a Movies collection's "Show All".
 struct MovieCollectionView: View {
     let kind: LibraryCollection.Kind
-    let playlistPrefix: String
     var animationNamespace: Namespace.ID?
     @Environment(\.contentRestriction) private var restriction
     @Query private var movies: [Movie]
 
     init(kind: LibraryCollection.Kind, playlistPrefix: String, animationNamespace: Namespace.ID? = nil) {
         self.kind = kind
-        self.playlistPrefix = playlistPrefix
         self.animationNamespace = animationNamespace
-        _movies = Query(MovieCollectionQuery.descriptor(for: kind))
+        _movies = Query(MovieCollectionQuery.gridDescriptor(for: kind, playlistPrefix: playlistPrefix))
     }
 
-    private var scoped: [Movie] {
-        movies.filter { $0.id.hasPrefix(playlistPrefix) }.excludingRestricted(restriction)
+    private var visible: [Movie] {
+        movies.excludingRestricted(restriction)
     }
 
     var body: some View {
@@ -195,7 +203,7 @@ struct MovieCollectionView: View {
         }
         CategoryContentGrid(
             title: kind.localizedTitleString,
-            items: scoped,
+            items: visible,
             animationNamespace: animationNamespace,
             emptyTitle: kind.title,
             emptyIcon: kind.emptyIcon,
@@ -208,26 +216,46 @@ struct MovieCollectionView: View {
 }
 
 private enum MovieCollectionQuery {
-    static func descriptor(for kind: LibraryCollection.Kind) -> FetchDescriptor<Movie> {
-        var descriptor = switch kind {
+    /// The fetch behind a preview row — always bounded, see
+    /// `collectionRowFetchLimit`.
+    static func rowDescriptor(for kind: LibraryCollection.Kind, playlistPrefix: String) -> FetchDescriptor<Movie> {
+        var descriptor = base(for: kind, playlistPrefix: playlistPrefix)
+        descriptor.fetchLimit = collectionRowFetchLimit
+        return descriptor
+    }
+
+    /// The fetch behind "Show All". Recently Watched and Favorites stay
+    /// unbounded — the grid is the surface that legitimately shows everything —
+    /// while Recently Added keeps the cap its whole-playlist predicate needs.
+    static func gridDescriptor(for kind: LibraryCollection.Kind, playlistPrefix: String) -> FetchDescriptor<Movie> {
+        var descriptor = base(for: kind, playlistPrefix: playlistPrefix)
+        if kind == .recentlyAdded { descriptor.fetchLimit = recentlyAddedFetchLimit }
+        return descriptor
+    }
+
+    private static func base(for kind: LibraryCollection.Kind, playlistPrefix prefix: String) -> FetchDescriptor<Movie> {
+        switch kind {
         case .recentlyWatched:
             FetchDescriptor<Movie>(
-                predicate: #Predicate { $0.lastWatchedDate != nil },
+                predicate: #Predicate { $0.lastWatchedDate != nil && $0.id.starts(with: prefix) },
                 sortBy: [SortDescriptor(\.lastWatchedDate, order: .reverse)]
             )
         case .favorites:
             FetchDescriptor<Movie>(
-                predicate: #Predicate { $0.isFavorite },
+                predicate: #Predicate { $0.isFavorite && $0.id.starts(with: prefix) },
                 sortBy: [SortDescriptor(\.name)]
             )
         case .recentlyAdded:
+            // `comparator: .lexical`, not the `.localizedStandard` default:
+            // `added` is a Unix timestamp string, and the localized comparator
+            // emits `COLLATE NSCollateFinderlike`, which the `#Index` on
+            // `Movie.added` cannot serve. 222.4 ms → 92.6 ms on a 179k-title
+            // catalog, and that one query was 46% of a cold launch's SQL.
             FetchDescriptor<Movie>(
-                predicate: #Predicate { $0.added != nil },
-                sortBy: [SortDescriptor(\.added, order: .reverse), SortDescriptor(\.num)]
+                predicate: #Predicate { $0.added != nil && $0.id.starts(with: prefix) },
+                sortBy: [SortDescriptor(\.added, comparator: .lexical, order: .reverse), SortDescriptor(\.num)]
             )
         }
-        if kind == .recentlyAdded { descriptor.fetchLimit = recentlyAddedFetchLimit }
-        return descriptor
     }
 }
 
@@ -237,7 +265,6 @@ private enum MovieCollectionQuery {
 /// nothing when the active playlist has no matching series.
 struct SeriesCollectionRow: View {
     let kind: LibraryCollection.Kind
-    let playlistPrefix: String
     var animationNamespace: Namespace.ID?
     @Environment(\.modelContext) private var modelContext
     @Environment(\.contentRestriction) private var restriction
@@ -245,17 +272,16 @@ struct SeriesCollectionRow: View {
 
     init(kind: LibraryCollection.Kind, playlistPrefix: String, animationNamespace: Namespace.ID? = nil) {
         self.kind = kind
-        self.playlistPrefix = playlistPrefix
         self.animationNamespace = animationNamespace
-        _series = Query(SeriesCollectionQuery.descriptor(for: kind))
+        _series = Query(SeriesCollectionQuery.rowDescriptor(for: kind, playlistPrefix: playlistPrefix))
     }
 
-    private var scoped: [Series] {
-        series.filter { $0.id.hasPrefix(playlistPrefix) }.excludingRestricted(restriction)
+    private var visible: [Series] {
+        series.excludingRestricted(restriction)
     }
 
     var body: some View {
-        let matches = scoped
+        let matches = visible
         let items = Array(matches.prefix(collectionPreviewLimit))
         if !items.isEmpty {
             CollectionPreviewRow(
@@ -277,20 +303,18 @@ struct SeriesCollectionRow: View {
 /// The full grid behind a Series collection's "Show All".
 struct SeriesCollectionView: View {
     let kind: LibraryCollection.Kind
-    let playlistPrefix: String
     var animationNamespace: Namespace.ID?
     @Environment(\.contentRestriction) private var restriction
     @Query private var series: [Series]
 
     init(kind: LibraryCollection.Kind, playlistPrefix: String, animationNamespace: Namespace.ID? = nil) {
         self.kind = kind
-        self.playlistPrefix = playlistPrefix
         self.animationNamespace = animationNamespace
-        _series = Query(SeriesCollectionQuery.descriptor(for: kind))
+        _series = Query(SeriesCollectionQuery.gridDescriptor(for: kind, playlistPrefix: playlistPrefix))
     }
 
-    private var scoped: [Series] {
-        series.filter { $0.id.hasPrefix(playlistPrefix) }.excludingRestricted(restriction)
+    private var visible: [Series] {
+        series.excludingRestricted(restriction)
     }
 
     var body: some View {
@@ -301,7 +325,7 @@ struct SeriesCollectionView: View {
         }
         CategoryContentGrid(
             title: kind.localizedTitleString,
-            items: scoped,
+            items: visible,
             animationNamespace: animationNamespace,
             emptyTitle: kind.title,
             emptyIcon: kind.emptyIcon,
@@ -314,26 +338,42 @@ struct SeriesCollectionView: View {
 }
 
 private enum SeriesCollectionQuery {
-    static func descriptor(for kind: LibraryCollection.Kind) -> FetchDescriptor<Series> {
-        var descriptor = switch kind {
+    /// The fetch behind a preview row — always bounded, see
+    /// `collectionRowFetchLimit`.
+    static func rowDescriptor(for kind: LibraryCollection.Kind, playlistPrefix: String) -> FetchDescriptor<Series> {
+        var descriptor = base(for: kind, playlistPrefix: playlistPrefix)
+        descriptor.fetchLimit = collectionRowFetchLimit
+        return descriptor
+    }
+
+    /// The fetch behind "Show All"; see `MovieCollectionQuery.gridDescriptor`.
+    static func gridDescriptor(for kind: LibraryCollection.Kind, playlistPrefix: String) -> FetchDescriptor<Series> {
+        var descriptor = base(for: kind, playlistPrefix: playlistPrefix)
+        if kind == .recentlyAdded { descriptor.fetchLimit = recentlyAddedFetchLimit }
+        return descriptor
+    }
+
+    private static func base(for kind: LibraryCollection.Kind, playlistPrefix prefix: String) -> FetchDescriptor<Series> {
+        switch kind {
         case .recentlyWatched:
             FetchDescriptor<Series>(
-                predicate: #Predicate { $0.lastWatchedDate != nil },
+                predicate: #Predicate { $0.lastWatchedDate != nil && $0.id.starts(with: prefix) },
                 sortBy: [SortDescriptor(\.lastWatchedDate, order: .reverse)]
             )
         case .favorites:
             FetchDescriptor<Series>(
-                predicate: #Predicate { $0.isFavorite },
+                predicate: #Predicate { $0.isFavorite && $0.id.starts(with: prefix) },
                 sortBy: [SortDescriptor(\.name)]
             )
         case .recentlyAdded:
+            // `comparator: .lexical` for the same reason as the movie side:
+            // `lastModified` is a Unix timestamp string, and the default
+            // localized comparator forfeits the `#Index` to NSCollateFinderlike.
             FetchDescriptor<Series>(
-                predicate: #Predicate { $0.lastModified != nil },
-                sortBy: [SortDescriptor(\.lastModified, order: .reverse), SortDescriptor(\.num)]
+                predicate: #Predicate { $0.lastModified != nil && $0.id.starts(with: prefix) },
+                sortBy: [SortDescriptor(\.lastModified, comparator: .lexical, order: .reverse), SortDescriptor(\.num)]
             )
         }
-        if kind == .recentlyAdded { descriptor.fetchLimit = recentlyAddedFetchLimit }
-        return descriptor
     }
 }
 

--- a/Lume/Views/Home/HomeMediaItem.swift
+++ b/Lume/Views/Home/HomeMediaItem.swift
@@ -4,10 +4,11 @@
 //
 //  A type-erased wrapper over the three playable content kinds so a single
 //  horizontal row (see HomeRows) can present movies, series and live channels
-//  together.
+//  together, plus the resume-progress lookup those rows read from.
 //
 
 import Foundation
+import SwiftData
 
 enum HomeMediaItem: Identifiable, Hashable {
     case movie(Movie)
@@ -51,22 +52,71 @@ enum HomeMediaItem: Identifiable, Hashable {
         return false
     }
 
-    /// Resume fraction for partially-watched movies or series (0...1), otherwise nil.
-    var progress: Double? {
+    /// Resume fraction for partially-watched movies or series (0...1), otherwise
+    /// nil. A movie carries its own progress, so it is read straight off the row;
+    /// a series' lives on its episodes and is looked up in `seriesResume`, the
+    /// map `SeriesResumeLoader` builds once for the whole screen. This is called
+    /// per card per body pass, and deriving the series case here meant faulting
+    /// the entire `episodes` relationship each time — see the loader below.
+    func progress(seriesResume: [String: Double]) -> Double? {
         switch self {
         case let .movie(movie):
             guard let duration = movie.durationSecs, duration > 0,
                   movie.watchProgress > 0, !movie.isWatched else { return nil }
             return min(movie.watchProgress / Double(duration), 1)
         case let .series(series):
-            let inProgressEpisodes = series.episodes
-                .filter { $0.watchProgress > 0 && !$0.isWatched }
-                .sorted { ($0.lastWatchedDate ?? .distantPast) > ($1.lastWatchedDate ?? .distantPast) }
-            guard let activeEpisode = inProgressEpisodes.first,
-                  let duration = activeEpisode.durationSecs, duration > 0 else { return nil }
-            return min(activeEpisode.watchProgress / Double(duration), 1)
+            return seriesResume[series.id]
         case .live:
             return nil
         }
+    }
+}
+
+// MARK: - Series resume lookup
+
+/// Builds the resume fraction of every partially-watched series in one indexed
+/// fetch, off the main thread, keyed by series id.
+///
+/// `HomeMediaItem.progress` used to derive this per card, from `body`, by
+/// filtering and sorting `series.episodes` — which faults the whole to-many
+/// relationship. A launch trace on a 47,930-series playlist counted 2,663
+/// `ZEPISODE WHERE ZSERIES = ?` faults from that accessor alone, and reading
+/// every episode's watch state from a view body also made Home observe all of
+/// them, so any episode write re-rendered the screen. This is the same hoist
+/// `ChannelEPGLoader` performs for the Live TV cards: one bounded fetch for the
+/// whole screen, plain values out.
+enum SeriesResumeLoader {
+    nonisolated static func load(container: ModelContainer) -> [String: Double] {
+        let context = ModelContext(container)
+        // Scoped by watch state, not by the series on screen: `watchProgress`
+        // and `isWatched` are both indexed on `Episode`, so this seeks the
+        // handful of in-progress rows however large the episode table is.
+        // Prefetching `series` resolves the owning show in the same round trip
+        // instead of one to-one fault per episode.
+        var descriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate { $0.watchProgress > 0 && $0.isWatched == false }
+        )
+        descriptor.relationshipKeyPathsForPrefetching = [\.series]
+        guard let episodes = try? context.fetch(descriptor) else { return [:] }
+
+        var newest: [String: Date] = [:]
+        var resume: [String: Double] = [:]
+        for episode in episodes {
+            guard let seriesId = episode.series?.id else { continue }
+            // The most recently watched in-progress episode decides the bar —
+            // including deciding there is none, when it carries no duration to
+            // divide by. That is what the per-card accessor did: it sorted by
+            // `lastWatchedDate` descending and gave up on the first entry, so an
+            // older episode must not stand in for it.
+            let watched = episode.lastWatchedDate ?? .distantPast
+            if let seen = newest[seriesId], seen >= watched { continue }
+            newest[seriesId] = watched
+            if let duration = episode.durationSecs, duration > 0 {
+                resume[seriesId] = min(episode.watchProgress / Double(duration), 1)
+            } else {
+                resume.removeValue(forKey: seriesId)
+            }
+        }
+        return resume
     }
 }

--- a/Lume/Views/Home/HomeRows.swift
+++ b/Lume/Views/Home/HomeRows.swift
@@ -15,6 +15,9 @@ import SwiftUI
 struct HomeRow: View {
     let title: LocalizedStringKey
     let items: [HomeMediaItem]
+    /// Resume fractions keyed by series id, resolved once for the whole screen
+    /// (`SeriesResumeLoader`) rather than per card — see `HomeMediaItem`.
+    let seriesResume: [String: Double]
     let onPlayLive: (LiveStream) -> Void
     /// When set, each card gains a "Remove from Recently Watched" context menu.
     /// Only the Recently Watched row passes this; the others leave it nil.
@@ -39,6 +42,7 @@ struct HomeRow: View {
                     ForEach(items) { item in
                         HomeItemCell(
                             item: item,
+                            seriesResume: seriesResume,
                             onPlayLive: onPlayLive,
                             onRemove: onRemove,
                             onVote: onVote,
@@ -58,6 +62,7 @@ struct HomeRow: View {
 
 private struct HomeItemCell: View {
     let item: HomeMediaItem
+    let seriesResume: [String: Double]
     let onPlayLive: (LiveStream) -> Void
     var onRemove: ((HomeMediaItem) -> Void)?
     var onVote: ((HomeMediaItem, RecommendationVote) -> Void)?
@@ -69,13 +74,13 @@ private struct HomeItemCell: View {
             switch item {
             case let .movie(movie):
                 NavigationLink(value: movie) {
-                    HomePosterCard(title: item.title, imageURL: item.imageURL, progress: item.progress)
+                    HomePosterCard(title: item.title, imageURL: item.imageURL, progress: progress)
                         .matchedTransitionSourceIfAvailable(id: movie.id, in: animationNamespace)
                 }
                 .posterCardButtonStyle()
             case let .series(series):
                 NavigationLink(value: series) {
-                    HomePosterCard(title: item.title, imageURL: item.imageURL, progress: item.progress)
+                    HomePosterCard(title: item.title, imageURL: item.imageURL, progress: progress)
                         .matchedTransitionSourceIfAvailable(id: series.id, in: animationNamespace)
                 }
                 .posterCardButtonStyle()
@@ -94,6 +99,10 @@ private struct HomeItemCell: View {
             onVote: onVote,
             onStartMultiView: onStartMultiView
         ))
+    }
+
+    private var progress: Double? {
+        item.progress(seriesResume: seriesResume)
     }
 }
 
@@ -141,6 +150,7 @@ private struct HomeItemMenu: ViewModifier {
 /// nudges the user toward the actions that seed recommendations.
 struct ForYouRow: View {
     let items: [HomeMediaItem]
+    let seriesResume: [String: Double]
     let isLoading: Bool
     let onPlayLive: (LiveStream) -> Void
     let onVote: (HomeMediaItem, RecommendationVote) -> Void
@@ -158,7 +168,14 @@ struct ForYouRow: View {
                     .padding(.horizontal)
             }
         } else {
-            HomeRow(title: "For You", items: items, onPlayLive: onPlayLive, onVote: onVote, animationNamespace: animationNamespace)
+            HomeRow(
+                title: "For You",
+                items: items,
+                seriesResume: seriesResume,
+                onPlayLive: onPlayLive,
+                onVote: onVote,
+                animationNamespace: animationNamespace
+            )
         }
     }
 

--- a/Lume/Views/Home/HomeView.swift
+++ b/Lume/Views/Home/HomeView.swift
@@ -39,6 +39,9 @@ struct HomeView: View {
     @State var trendingMovies: [HomeMediaItem] = []
     @State var trendingSeries: [HomeMediaItem] = []
     @State var watchlist: [HomeMediaItem] = []
+    /// Resume fractions for partially-watched series, keyed by series id and
+    /// resolved off the main thread — see `SeriesResumeLoader`.
+    @State private var seriesResume: [String: Double] = [:]
     @AppStorage(RecommendationSettings.enabledKey) private var recommendationsEnabled = RecommendationSettings.enabledDefault
     /// The user's chosen Home row order (Settings › Layout › Home). Falls back to
     /// the declaration order of `HomeSection` until they reorder.
@@ -168,6 +171,7 @@ struct HomeView: View {
                             }
                             .padding(.bottom)
                         }
+                        .browseActivity()
                         .scrollIndicators(.hidden)
                         // Only let content run under the nav bar when the hero
                         // backdrop is there to fill it; otherwise the first row
@@ -221,6 +225,9 @@ struct HomeView: View {
                 .task(id: recommendationsKey) {
                     await loadRecommendations()
                 }
+                .task(id: seriesResumeKey) {
+                    await loadSeriesResume()
+                }
             #if os(iOS) || os(tvOS)
                 .fullScreenCover(item: $playingMedia) { media in
                     FullScreenPlayerView(media: media)
@@ -255,6 +262,7 @@ struct HomeView: View {
             case .forYou:
                 ForYouRow(
                     items: recommendations,
+                    seriesResume: seriesResume,
                     isLoading: !recommendationsLoaded,
                     onPlayLive: playChannel,
                     onVote: vote,
@@ -291,6 +299,7 @@ struct HomeView: View {
             HomeRow(
                 title: title,
                 items: items,
+                seriesResume: seriesResume,
                 onPlayLive: playChannel,
                 onRemove: onRemove,
                 onStartMultiView: startMultiView,
@@ -310,6 +319,15 @@ struct HomeView: View {
 
     var watchlistKey: String {
         "watchlist-\(trakt.isConnected)-\(selectedPlaylistID)-\(restriction.visibilityToken)"
+    }
+
+    /// Identity of the series resume lookup. Resuming or finishing an episode
+    /// stamps its series' `lastWatchedDate` (`WatchProgressWriter`), which is
+    /// exactly what the Recently Watched query orders by — so the newest stamp
+    /// moves whenever a resume bar would.
+    private var seriesResumeKey: String {
+        let newest = watchedSeries.first?.lastWatchedDate?.timeIntervalSince1970 ?? 0
+        return "resume-\(watchedSeries.count)-\(newest)-\(selectedPlaylistID)"
     }
 
     // MARK: - Playlist scoping
@@ -386,6 +404,19 @@ struct HomeView: View {
         case let .live(stream): stream.lastWatchedDate = nil
         }
         try? modelContext.save()
+    }
+
+    // MARK: - Series resume
+
+    /// Resolves the resume bar for every partially-watched series in one indexed
+    /// fetch, off the main thread. The rails then read a plain dictionary rather
+    /// than each card faulting its series' whole `episodes` relationship from
+    /// `body` — the same hoist the Live TV list does for now/next EPG.
+    private func loadSeriesResume() async {
+        let container = modelContext.container
+        seriesResume = await Task.detached(priority: .userInitiated) {
+            SeriesResumeLoader.load(container: container)
+        }.value
     }
 
     // MARK: - Playback

--- a/Lume/Views/LiveTV/ChannelEPGSnapshot.swift
+++ b/Lume/Views/LiveTV/ChannelEPGSnapshot.swift
@@ -36,6 +36,24 @@ nonisolated struct ChannelEPG: Equatable {
 /// Builds the now/next lookup for a set of channels in one indexed fetch, off
 /// the main thread, returning only `Sendable` value snapshots.
 enum ChannelEPGLoader {
+    /// How far ahead a now/next lookup reads. A card shows what is on air and
+    /// what follows it, so the fetch only has to reach the start of that second
+    /// programme — but the old open-ended `end > now` returned every *future*
+    /// listing of every channel on screen, and the guide holds weeks of them
+    /// (218,081 rows on the measured playlist). A screenful of 50 channels meant
+    /// tens of thousands of rows materialized and grouped to pick two apiece.
+    ///
+    /// Twelve hours is deliberately generous — still ~3% of a two-week guide,
+    /// but wide enough for the long overnight blocks some providers ship, where
+    /// "next" is the morning show hours away.
+    nonisolated static let horizon: TimeInterval = 12 * 3600
+
+    /// How long a resolved snapshot may be extended before it is resolved again
+    /// from scratch. Callers that grow a channel list page by page reuse the
+    /// pairs they already hold (see `ChannelsList`), and this bounds how far
+    /// behind the guide the oldest of those pairs can fall.
+    nonisolated static let snapshotLifetime: TimeInterval = 60
+
     nonisolated static func load(
         container: ModelContainer,
         channelIds: [String],
@@ -47,13 +65,21 @@ enum ChannelEPGLoader {
         defer { Perf.end(interval) }
 
         let context = ModelContext(container)
-        // Only currently-airing or upcoming listings matter for now/next; the
-        // `end > now` bound (plus the channel-id scope) keeps this to a small,
-        // index-served slice of the guide rather than the whole table.
-        let descriptor = FetchDescriptor<EPGListing>(
-            predicate: #Predicate { channelIds.contains($0.channelId) && $0.end > now },
+        let horizonEnd = now.addingTimeInterval(horizon)
+        // Only currently-airing or imminent listings matter for now/next. The
+        // upper bound on `start` is the half the `[channelId, start]` index can
+        // seek against, and it is what keeps the result to a few rows per
+        // channel; `end > now` then drops the finished ones inside the window.
+        var descriptor = FetchDescriptor<EPGListing>(
+            predicate: #Predicate {
+                channelIds.contains($0.channelId) && $0.end > now && $0.start < horizonEnd
+            },
             sortBy: [SortDescriptor(\.channelId), SortDescriptor(\.start)]
         )
+        // The four fields a `ChannelEPG` is built from. `listingDescription` is
+        // the widest column in the table and nothing here reads it, so a partial
+        // fetch keeps it out of the rows entirely.
+        descriptor.propertiesToFetch = [\.channelId, \.title, \.start, \.end]
         guard let listings = try? context.fetch(descriptor) else { return [:] }
 
         var grouped: [String: [EPGListing]] = [:]

--- a/Lume/Views/LiveTV/ChannelsListView.swift
+++ b/Lume/Views/LiveTV/ChannelsListView.swift
@@ -1,0 +1,190 @@
+//
+//  ChannelsListView.swift
+//  Lume
+//
+//  The iOS / macOS Live TV channel list: a paged, lazily-mounted list of the
+//  channels in the selected section, each card carrying the now/next EPG the
+//  list resolves for its visible window (see `ChannelEPGSnapshot`). Split out of
+//  `LiveTVView` for the same reason `LiveTVTVComponents` holds the tvOS list —
+//  to keep that file focused on cross-platform composition, and inside the
+//  project's file-length cap.
+//
+
+import SwiftData
+import SwiftUI
+
+struct ChannelsList: View {
+    let scope: LiveChannelScope
+    let playlistPrefix: String
+    /// Seeds Multi-View with this channel, gated on Lume Pro by the host.
+    let onStartMultiView: (LiveStream) -> Void
+    let onPlay: (LiveStream) -> Void
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.contentRestriction) private var restriction
+    @Query private var streams: [LiveStream]
+    /// Now/next EPG for the visible channels, resolved in one off-main fetch
+    /// (see `ChannelEPGSnapshot`) instead of a per-card `@Query`.
+    @State private var epgByChannel: [String: ChannelEPG] = [:]
+    /// The channels `epgByChannel` was resolved for, when it was last resolved
+    /// from scratch, and the channel-set identity it belongs to — so a
+    /// pagination step looks up only the page it added. Re-resolving the whole
+    /// visible prefix each step made scrolling a large category cost more with
+    /// every page: page *n* re-fetched the `n × 50` channels above it.
+    @State private var resolvedChannelIds: Set<String> = []
+    @State private var resolvedAt = Date.distantPast
+    @State private var resolvedGeneration = ""
+    /// Observed so the EPG lookup refreshes when a guide import finishes.
+    @State private var epgSync = EPGSyncService.shared
+    /// How many channels are currently rendered. Grows by a page as the list
+    /// nears its end so a large category loads lazily instead of all at once.
+    @State private var visibleCount = LiveChannelQuery.pageSize
+    /// Drives the "Clear Recently Watched" confirmation alert.
+    @State private var confirmingClear = false
+
+    init(
+        scope: LiveChannelScope,
+        playlistPrefix: String,
+        sort: ContentSortOption,
+        onStartMultiView: @escaping (LiveStream) -> Void,
+        onPlay: @escaping (LiveStream) -> Void
+    ) {
+        self.scope = scope
+        self.playlistPrefix = playlistPrefix
+        self.onStartMultiView = onStartMultiView
+        self.onPlay = onPlay
+        _streams = Query(LiveChannelQuery.descriptor(for: scope, sort: sort))
+    }
+
+    private var scopedStreams: [LiveStream] {
+        LiveChannelQuery.scoped(streams, scope: scope, playlistPrefix: playlistPrefix, restriction: restriction)
+    }
+
+    /// Clears a channel's watch timestamp so it drops out of the Recently
+    /// Watched list. The @Query-backed list updates once the change is saved.
+    private func removeFromRecentlyWatched(_ stream: LiveStream) {
+        stream.lastWatchedDate = nil
+        try? modelContext.save()
+    }
+
+    /// Empties the whole Recently Watched list for the active playlist. The
+    /// section drops away on its own once the last timestamp clears (its parent
+    /// gates it on `hasRecents`).
+    private func clearRecentlyWatched() {
+        let container = modelContext.container
+        Task { await StorageManager.clearRecentlyWatchedChannels(playlistPrefix: playlistPrefix, container: container) }
+    }
+
+    /// A trailing "Clear" button shown above the Recently Watched list. Stays
+    /// out of the scroll view so it's always reachable no matter how far the
+    /// list is scrolled.
+    private var clearHeader: some View {
+        HStack {
+            Spacer()
+            Button(role: .destructive) {
+                confirmingClear = true
+            } label: {
+                Label("Clear", systemImage: "trash")
+                    .font(.subheadline)
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+
+    var body: some View {
+        let channels = scopedStreams
+        let visible = Array(channels.prefix(visibleCount))
+        // What makes the resolved EPG stale wholesale rather than merely
+        // incomplete: the channel set changing, or a guide import settling.
+        let generation = "\(channels.count)-\(epgSync.isSyncing)"
+        VStack(spacing: 0) {
+            if scope == .recentlyWatched, !channels.isEmpty {
+                clearHeader
+            }
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    if channels.isEmpty {
+                        ContentUnavailableView(
+                            "No Channels",
+                            systemImage: "antenna.radiowaves.left.and.right",
+                            description: Text("This category has no channels")
+                        )
+                    } else {
+                        ForEach(visible) { stream in
+                            Button {
+                                onPlay(stream)
+                            } label: {
+                                LiveStreamCardView(stream: stream, epg: epgByChannel[stream.epgChannelId ?? ""])
+                                    .padding(.horizontal)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            .liveChannelMenu(
+                                isFavorite: stream.isFavorite,
+                                onToggleFavorite: { LiveChannelFavorites.toggle(stream, in: modelContext) },
+                                onStartMultiView: { onStartMultiView(stream) },
+                                onRemoveFromRecents: scope == .recentlyWatched ? { removeFromRecentlyWatched(stream) } : nil
+                            )
+                            .onAppear {
+                                if stream.id == visible.last?.id, visibleCount < channels.count {
+                                    visibleCount = min(visibleCount + LiveChannelQuery.pageSize, channels.count)
+                                }
+                            }
+
+                            Divider()
+                                .padding(.leading, 88)
+                        }
+                    }
+                }
+            }
+            .browseActivity()
+            // Reload when the visible window or channel set changes, or a guide
+            // import settles — EPG is resolved only for the channels on screen.
+            .task(id: "\(generation)-\(visible.count)") {
+                await loadEPG(for: visible, generation: generation)
+            }
+        }
+        .alert("Clear Recently Watched", isPresented: $confirmingClear) {
+            Button("Clear", role: .destructive) { clearRecentlyWatched() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This clears the list of channels you've recently watched. Your favorites and the channels themselves aren't affected.")
+        }
+    }
+
+    private func loadEPG(for channels: [LiveStream], generation: String) async {
+        let channelIds = Array(Set(channels.compactMap(\.epgChannelId).filter { !$0.isEmpty }))
+        guard !channelIds.isEmpty else {
+            epgByChannel = [:]
+            resolvedChannelIds = []
+            resolvedGeneration = generation
+            return
+        }
+        let now = Date()
+        // Extend the snapshot with the channels that just scrolled into view.
+        // Resolving from scratch is kept for a stale generation and for pairs
+        // old enough that a programme could have ended under them, so no card
+        // is ever more than `snapshotLifetime` behind the guide.
+        let extending = generation == resolvedGeneration
+            && now.timeIntervalSince(resolvedAt) < ChannelEPGLoader.snapshotLifetime
+        let pending = extending ? channelIds.filter { !resolvedChannelIds.contains($0) } : channelIds
+        guard !pending.isEmpty else { return }
+
+        let container = modelContext.container
+        let resolved = await Task.detached(priority: .userInitiated) {
+            ChannelEPGLoader.load(container: container, channelIds: pending, now: now)
+        }.value
+        if extending {
+            // `pending`, not `resolved`: a channel the guide has nothing for
+            // must still count as looked up, or every page would ask again.
+            epgByChannel.merge(resolved) { _, new in new }
+            resolvedChannelIds.formUnion(pending)
+        } else {
+            epgByChannel = resolved
+            resolvedChannelIds = Set(pending)
+            resolvedAt = now
+        }
+        resolvedGeneration = generation
+    }
+}

--- a/Lume/Views/LiveTV/LiveTVSection.swift
+++ b/Lume/Views/LiveTV/LiveTVSection.swift
@@ -9,9 +9,11 @@
 //
 //  A `LiveTVSection` is what the user selects in the rail; a `LiveChannelScope`
 //  is what the channel list / guide query against. `LiveChannelQuery` builds the
-//  right `@Query` descriptor (and the in-memory playlist scoping the virtual
-//  collections need, since their predicate can't be parameterised on the
-//  playlist-prefixed id).
+//  right `@Query` descriptor, the in-memory playlist scoping those lists need
+//  (their predicate can't be parameterised on the playlist-prefixed id), and the
+//  bounded probes that decide whether the virtual collections are offered at
+//  all. `LiveTVSections` assembles the rail from both, `LiveTVCategoryMemo`
+//  keeps its category half from being rebuilt on every body pass.
 //
 
 import SwiftData
@@ -139,6 +141,67 @@ enum LiveChannelQuery {
         }
     }
 
+    /// Whether the active playlist holds any favorite this viewer may see — the
+    /// only thing the rail needs in order to decide whether to offer the
+    /// Favorites section.
+    ///
+    /// Everything `isVisible` tests is in the predicate, so this materializes at
+    /// most one row (measured: 0.02 ms). It has to: the rail used to answer the
+    /// same question with an unbounded `@Query` per collection and filter the
+    /// result in Swift — 1,506 favorites and 5,069 watched rows on a large
+    /// playlist, 8-13 ms per evaluation, re-run 18-25 times on a cold launch of
+    /// a tab the viewer may never open.
+    ///
+    /// The restriction *must* stay in the predicate rather than being applied to
+    /// the fetched row afterwards. With `fetchLimit = 1` a Swift-side check
+    /// would call the collection empty whenever the single row that came back
+    /// happened to sit in a category this viewer can't see, silently dropping a
+    /// section full of visible channels — so the excluded ids go to SQLite too.
+    static func favoritesProbe(playlistPrefix: String, restriction: ContentRestriction) -> FetchDescriptor<LiveStream> {
+        let prefix = playlistPrefix
+        let excluded = excludedCategoryIDs(restriction)
+        let filtersCategories = !excluded.isEmpty
+        return probe(
+            predicate: #Predicate { stream in
+                stream.isFavorite && stream.isHidden == false && stream.id.starts(with: prefix)
+                    && (!filtersCategories || stream.categoryId == nil || !excluded.contains(stream.categoryId))
+            }
+        )
+    }
+
+    /// The same probe for Recently Watched. Note it deliberately ignores
+    /// `recentLimit`: the list is capped at 50, but "is there at least one" is
+    /// unaffected by a cap.
+    static func recentlyWatchedProbe(playlistPrefix: String, restriction: ContentRestriction) -> FetchDescriptor<LiveStream> {
+        let prefix = playlistPrefix
+        let excluded = excludedCategoryIDs(restriction)
+        let filtersCategories = !excluded.isEmpty
+        return probe(
+            predicate: #Predicate { stream in
+                stream.lastWatchedDate != nil && stream.isHidden == false && stream.id.starts(with: prefix)
+                    && (!filtersCategories || stream.categoryId == nil || !excluded.contains(stream.categoryId))
+            }
+        )
+    }
+
+    /// Wraps an existence predicate as a `LIMIT 1` fetch. No `sortBy` on
+    /// purpose: a sort descriptor makes SQLite find and order every match before
+    /// the limit can apply, which is exactly the work being avoided.
+    private static func probe(predicate: Predicate<LiveStream>) -> FetchDescriptor<LiveStream> {
+        var descriptor = FetchDescriptor<LiveStream>(predicate: predicate)
+        descriptor.fetchLimit = 1
+        return descriptor
+    }
+
+    /// The categories hidden from this viewer, as optionals, so a predicate can
+    /// test the optional `categoryId` against them directly: neither `?? ""` nor
+    /// a nil-check plus force-unwrap survives SwiftData's SQL generation, while
+    /// matching a `Set<String?>` builds a plain `IN` clause — the same shape the
+    /// search predicates use (see `SearchScope.excludedOptional`).
+    private static func excludedCategoryIDs(_ restriction: ContentRestriction) -> Set<String?> {
+        Set(restriction.excludedCategoryIDs.map(String?.some))
+    }
+
     /// Scopes a query's results to the active playlist *and* to what the current
     /// viewer is allowed to see. Category queries are already isolated (category
     /// ids are playlist-prefixed), but the virtual collections span every
@@ -169,10 +232,10 @@ enum LiveChannelQuery {
     }
 
     /// Whether any of `streams` survives the filtering `scoped` applies to the
-    /// virtual collections. Short-circuits, so the Live TV rail can decide
-    /// whether to offer Favorites / Recently Watched without materialising the
-    /// list — and shares `isVisible` with `scoped`, so the rail can never offer
-    /// a section whose list then renders empty.
+    /// virtual collections — the in-memory statement of the rule the rail's
+    /// probes hand to SQLite, for callers that already hold the rows. Shares
+    /// `isVisible` with `scoped`, so the two can never disagree about whether a
+    /// section that was offered then renders empty.
     static func containsVisible(
         _ streams: some Sequence<LiveStream>,
         playlistPrefix: String,
@@ -208,5 +271,127 @@ enum LiveChannelQuery {
             $0.type == .live && $0.id.hasPrefix(playlistPrefix)
                 && !$0.isHidden && !restriction.hides(categoryID: $0.id)
         }
+    }
+}
+
+// MARK: - Category memo
+
+/// Memo for the rail's category sections, held by the browse screen for as long
+/// as it lives.
+///
+/// Filtering the live categories by playlist prefix and viewer restriction and
+/// then sorting them is cheap once and expensive 25 times: the sort alone reads
+/// three or four properties off a managed object per comparison, so ~900
+/// categories cost tens of thousands of SwiftData property reads per body pass,
+/// and `LiveTVView`'s body runs 18-25 times on a cold launch. The work now
+/// happens once per change of the inputs it depends on; every other pass reads
+/// the array back.
+///
+/// Keyed rather than invalidated, for the reason `HomeTrendingCache` spells
+/// out: an entry is only ever returned when its key still matches the inputs
+/// that produced it, so an array holding `Category` objects a playlist deletion
+/// has since removed can never be handed back and rendered.
+@MainActor
+final class LiveTVCategoryMemo {
+    private var key = ""
+    private var cached: [LiveTVSection] = []
+
+    func sections(
+        categories: [Category],
+        playlistPrefix: String,
+        sort: CategorySortOption,
+        restriction: ContentRestriction
+    ) -> [LiveTVSection] {
+        // No active playlist: the rail has no categories to show, exactly as
+        // when the filter below found none.
+        guard !playlistPrefix.isEmpty else { return [] }
+        let key = Self.key(categories: categories, playlistPrefix: playlistPrefix, sort: sort, restriction: restriction)
+        guard key != self.key else { return cached }
+        let visible = LiveChannelQuery.visibleCategories(categories, playlistPrefix: playlistPrefix, restriction: restriction)
+        cached = sort.sort(visible).map(LiveTVSection.category)
+        self.key = key
+        return cached
+    }
+
+    /// Everything the filter and the sort read, folded into one token.
+    ///
+    /// The per-category loop is not just about detecting change: reading these
+    /// properties inside `body` is what registers SwiftUI's observation of them,
+    /// and a pass that skipped it would stop observing — a reorder in Content
+    /// Management (which rewrites `customOrder` without changing how many
+    /// categories there are) would then never reach the rail. It stays far
+    /// cheaper than the sort it replaces, which reads the same fields once per
+    /// comparison rather than once per category.
+    private static func key(
+        categories: [Category],
+        playlistPrefix: String,
+        sort: CategorySortOption,
+        restriction: ContentRestriction
+    ) -> String {
+        var hasher = Hasher()
+        hasher.combine(categories.count)
+        for category in categories {
+            hasher.combine(category.id)
+            hasher.combine(category.name)
+            hasher.combine(category.customOrder)
+            hasher.combine(category.sortOrder)
+        }
+        return "\(playlistPrefix)|\(sort.rawValue)|\(restriction.visibilityToken)|\(hasher.finalize())"
+    }
+}
+
+// MARK: - Rail sections
+
+/// Resolves the Live TV rail — the two virtual collections, when the active
+/// playlist has anything visible in them, above the synced categories — and
+/// hands the result to `content`.
+///
+/// The gates live here, in a child view, because a `@Query`'s descriptor is
+/// fixed at `init` and `LiveTVView` is a tab root whose `init` does not re-run
+/// when the selected playlist changes; this view is rebuilt by that body, so its
+/// probes always describe the playlist currently on screen. Resolving them as
+/// `@Query`s (rather than a fetch in a task) is what keeps the rail reacting to
+/// a channel being favorited or watched without a second render pass.
+struct LiveTVSections<Content: View>: View {
+    @Query private var favoriteProbe: [LiveStream]
+    @Query private var recentProbe: [LiveStream]
+
+    private let playlistPrefix: String
+    private let categorySections: [LiveTVSection]
+    private let content: ([LiveTVSection]) -> Content
+
+    init(
+        playlistPrefix: String,
+        restriction: ContentRestriction,
+        categorySections: [LiveTVSection],
+        @ViewBuilder content: @escaping ([LiveTVSection]) -> Content
+    ) {
+        self.playlistPrefix = playlistPrefix
+        self.categorySections = categorySections
+        self.content = content
+        _favoriteProbe = Query(
+            LiveChannelQuery.favoritesProbe(playlistPrefix: playlistPrefix, restriction: restriction)
+        )
+        _recentProbe = Query(
+            LiveChannelQuery.recentlyWatchedProbe(playlistPrefix: playlistPrefix, restriction: restriction)
+        )
+    }
+
+    /// The rail's entries: the virtual collections (when non-empty) pinned above
+    /// the synced categories.
+    private var sections: [LiveTVSection] {
+        // An empty prefix means there is no active playlist at all, and
+        // `starts(with: "")` matches every row — the guard the two `has…`
+        // properties used to carry before the probes moved into SQL.
+        guard !playlistPrefix.isEmpty else { return categorySections }
+        var resolved: [LiveTVSection] = []
+        if !favoriteProbe.isEmpty { resolved.append(.favorites) }
+        if !recentProbe.isEmpty { resolved.append(.recentlyWatched) }
+        resolved.append(contentsOf: categorySections)
+        return resolved
+    }
+
+    var body: some View {
+        content(sections)
     }
 }

--- a/Lume/Views/LiveTV/LiveTVView.swift
+++ b/Lume/Views/LiveTV/LiveTVView.swift
@@ -40,15 +40,15 @@ struct LiveTVView: View {
     @Query(filter: #Predicate<Category> { $0.typeRaw == "live" && $0.isHidden == false })
     private var categories: [Category]
 
-    /// Drives whether the Favorites / Recently Watched virtual sections appear in
-    /// the rail. Queried across all playlists, then scoped in-memory by prefix.
-    @Query(filter: #Predicate<LiveStream> { $0.isFavorite && $0.isHidden == false })
-    private var favoriteStreams: [LiveStream]
-    @Query(filter: #Predicate<LiveStream> { $0.lastWatchedDate != nil && $0.isHidden == false })
-    private var recentStreams: [LiveStream]
+    /// Keeps the rail's categories from being filtered and sorted on every body
+    /// pass — see `LiveTVCategoryMemo`. Whether the two virtual sections appear
+    /// is `LiveTVSections`' job; it owns the bounded probes that answer it.
+    @State private var categoryMemo = LiveTVCategoryMemo()
 
     @AppStorage(PlaylistSelectionStore.key) private var selectedPlaylistID: String = ""
     @State private var selectedSection: LiveTVSection?
+    /// The playlist `selectedSection` was last seeded for — see `seedSelection`.
+    @State private var seededPrefix: String?
     @State private var showingSync = false
     @State private var playingMedia: PlayableMedia?
     @State private var showingSettings = false
@@ -149,18 +149,18 @@ struct LiveTVView: View {
                         )
                     }
                 } else {
-                    // Resolve the rail's sections (and the displayed one) once
-                    // per render — both `displayedSection` and the layouts read
-                    // them, and each resolve filters + sorts the categories.
-                    let sections = sortedSections
-                    let displayed = displayedSection(in: sections)
-                    #if os(iOS)
-                        iOSLayout(sections: sections, displayed: displayed)
-                    #elseif os(tvOS)
-                        tvOSLayout(sections: sections, displayed: displayed)
-                    #else
-                        macOSLayout(sections: sections, displayed: displayed)
-                    #endif
+                    // The rail resolves in a child view: gating the two virtual
+                    // sections is a pair of playlist-scoped `LIMIT 1` probes, and
+                    // a `@Query` carries that scope only when its descriptor is
+                    // built in an `init` the active playlist reaches.
+                    LiveTVSections(
+                        playlistPrefix: playlistPrefix,
+                        restriction: restriction,
+                        categorySections: categorySections
+                    ) { sections in
+                        layout(for: sections)
+                            .task(id: playlistPrefix) { seedSelection(from: sections) }
+                    }
                 }
             }
             .platformNavigationTitle("Live TV")
@@ -199,17 +199,6 @@ struct LiveTVView: View {
                 showingSettings: $showingSettings,
                 activePlaylist: activePlaylist
             ))
-            .task {
-                if selectedSection == nil, let first = sortedSections.first {
-                    selectedSection = first
-                }
-            }
-            .onChange(of: selectedPlaylistID) {
-                // Switching playlists invalidates the current selection, which
-                // belongs to the previous playlist. Reset to the new playlist's
-                // first section so the channel list stays in sync.
-                selectedSection = sortedSections.first
-            }
             #if os(iOS) || os(tvOS)
             .fullScreenCover(item: $playingMedia) { media in
                 FullScreenPlayerView(media: media)
@@ -225,6 +214,20 @@ struct LiveTVView: View {
     }
 
     // MARK: - Platform-specific layouts
+
+    /// This platform's browse layout for the resolved rail. The displayed
+    /// section resolves here, once per render — rail and detail pane both need it.
+    @ViewBuilder
+    private func layout(for sections: [LiveTVSection]) -> some View {
+        let displayed = displayedSection(in: sections)
+        #if os(iOS)
+            iOSLayout(sections: sections, displayed: displayed)
+        #elseif os(tvOS)
+            tvOSLayout(sections: sections, displayed: displayed)
+        #else
+            macOSLayout(sections: sections, displayed: displayed)
+        #endif
+    }
 
     #if os(iOS)
         private func iOSLayout(sections: [LiveTVSection], displayed: LiveTVSection?) -> some View {
@@ -301,39 +304,33 @@ struct LiveTVView: View {
         activePlaylist.map { "\($0.id.uuidString)-" } ?? ""
     }
 
-    /// Categories scoped to the active playlist. The `@Query` fetches every
-    /// playlist's categories (SwiftData can't parameterize a `@Query` on view
-    /// state), so we isolate by the playlist-prefixed category `id` here.
-    private var sortedCategories: [Category] {
-        guard let playlistId = activePlaylist?.id else { return [] }
-        let prefix = "\(playlistId.uuidString)-"
-        return categorySort.sort(LiveChannelQuery.visibleCategories(categories, playlistPrefix: prefix, restriction: restriction))
-    }
-
-    /// Whether the active playlist has any favorited / recently-watched channels,
-    /// gating the corresponding virtual sections so empty collections never show.
-    /// Channels in restricted categories are excluded while a child profile is
-    /// active, so those collections never surface restricted content.
-    private var hasFavorites: Bool {
-        !playlistPrefix.isEmpty && LiveChannelQuery.containsVisible(
-            favoriteStreams, playlistPrefix: playlistPrefix, restriction: restriction
+    /// The rail's category entries: the active playlist's live categories this
+    /// viewer may see, in the chosen order. The `@Query` fetches every playlist's
+    /// categories (SwiftData can't parameterize a `@Query` on view state), so the
+    /// isolation by playlist-prefixed `id` — and the sort — happen here, memoized
+    /// so a body pass that changed nothing about them costs a key comparison.
+    private var categorySections: [LiveTVSection] {
+        categoryMemo.sections(
+            categories: categories,
+            playlistPrefix: playlistPrefix,
+            sort: categorySort,
+            restriction: restriction
         )
     }
 
-    private var hasRecents: Bool {
-        !playlistPrefix.isEmpty && LiveChannelQuery.containsVisible(
-            recentStreams, playlistPrefix: playlistPrefix, restriction: restriction
-        )
-    }
-
-    /// The rail's entries: the virtual collections (when non-empty) pinned above
-    /// the synced categories.
-    private var sortedSections: [LiveTVSection] {
-        var sections: [LiveTVSection] = []
-        if hasFavorites { sections.append(.favorites) }
-        if hasRecents { sections.append(.recentlyWatched) }
-        sections.append(contentsOf: sortedCategories.map(LiveTVSection.category))
-        return sections
+    /// Points the rail at its first section. On first appearance that only means
+    /// seeding an empty selection; on a playlist switch it resets unconditionally,
+    /// because the previous selection belonged to the playlist that just went
+    /// away — the two moments the removed `.task` / `.onChange(of:)` pair covered.
+    /// Anything narrower (a category hidden in Content Management, the last
+    /// favorite removed) is left to `displayedSection(in:)`, as before.
+    private func seedSelection(from sections: [LiveTVSection]) {
+        if seededPrefix != nil, seededPrefix != playlistPrefix {
+            selectedSection = sections.first
+        } else if selectedSection == nil {
+            selectedSection = sections.first
+        }
+        seededPrefix = playlistPrefix
     }
 
     /// The section to render in the detail pane. Normally the user's selection,
@@ -405,150 +402,6 @@ struct LiveTVView: View {
         #else
             playingMedia = media
         #endif
-    }
-}
-
-// MARK: - Channels List
-
-struct ChannelsList: View {
-    let scope: LiveChannelScope
-    let playlistPrefix: String
-    /// Seeds Multi-View with this channel, gated on Lume Pro by the host.
-    let onStartMultiView: (LiveStream) -> Void
-    let onPlay: (LiveStream) -> Void
-    @Environment(\.modelContext) private var modelContext
-    @Environment(\.contentRestriction) private var restriction
-    @Query private var streams: [LiveStream]
-    /// Now/next EPG for the visible channels, resolved in one off-main fetch
-    /// (see `ChannelEPGSnapshot`) instead of a per-card `@Query`.
-    @State private var epgByChannel: [String: ChannelEPG] = [:]
-    /// Observed so the EPG lookup refreshes when a guide import finishes.
-    @State private var epgSync = EPGSyncService.shared
-    /// How many channels are currently rendered. Grows by a page as the list
-    /// nears its end so a large category loads lazily instead of all at once.
-    @State private var visibleCount = LiveChannelQuery.pageSize
-    /// Drives the "Clear Recently Watched" confirmation alert.
-    @State private var confirmingClear = false
-
-    init(
-        scope: LiveChannelScope,
-        playlistPrefix: String,
-        sort: ContentSortOption,
-        onStartMultiView: @escaping (LiveStream) -> Void,
-        onPlay: @escaping (LiveStream) -> Void
-    ) {
-        self.scope = scope
-        self.playlistPrefix = playlistPrefix
-        self.onStartMultiView = onStartMultiView
-        self.onPlay = onPlay
-        _streams = Query(LiveChannelQuery.descriptor(for: scope, sort: sort))
-    }
-
-    private var scopedStreams: [LiveStream] {
-        LiveChannelQuery.scoped(streams, scope: scope, playlistPrefix: playlistPrefix, restriction: restriction)
-    }
-
-    /// Clears a channel's watch timestamp so it drops out of the Recently
-    /// Watched list. The @Query-backed list updates once the change is saved.
-    private func removeFromRecentlyWatched(_ stream: LiveStream) {
-        stream.lastWatchedDate = nil
-        try? modelContext.save()
-    }
-
-    /// Empties the whole Recently Watched list for the active playlist. The
-    /// section drops away on its own once the last timestamp clears (its parent
-    /// gates it on `hasRecents`).
-    private func clearRecentlyWatched() {
-        let container = modelContext.container
-        Task { await StorageManager.clearRecentlyWatchedChannels(playlistPrefix: playlistPrefix, container: container) }
-    }
-
-    /// A trailing "Clear" button shown above the Recently Watched list. Stays
-    /// out of the scroll view so it's always reachable no matter how far the
-    /// list is scrolled.
-    private var clearHeader: some View {
-        HStack {
-            Spacer()
-            Button(role: .destructive) {
-                confirmingClear = true
-            } label: {
-                Label("Clear", systemImage: "trash")
-                    .font(.subheadline)
-            }
-            .buttonStyle(.borderless)
-        }
-        .padding(.horizontal)
-        .padding(.vertical, 8)
-    }
-
-    var body: some View {
-        let channels = scopedStreams
-        let visible = Array(channels.prefix(visibleCount))
-        VStack(spacing: 0) {
-            if scope == .recentlyWatched, !channels.isEmpty {
-                clearHeader
-            }
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    if channels.isEmpty {
-                        ContentUnavailableView(
-                            "No Channels",
-                            systemImage: "antenna.radiowaves.left.and.right",
-                            description: Text("This category has no channels")
-                        )
-                    } else {
-                        ForEach(visible) { stream in
-                            Button {
-                                onPlay(stream)
-                            } label: {
-                                LiveStreamCardView(stream: stream, epg: epgByChannel[stream.epgChannelId ?? ""])
-                                    .padding(.horizontal)
-                                    .contentShape(Rectangle())
-                            }
-                            .buttonStyle(.plain)
-                            .liveChannelMenu(
-                                isFavorite: stream.isFavorite,
-                                onToggleFavorite: { LiveChannelFavorites.toggle(stream, in: modelContext) },
-                                onStartMultiView: { onStartMultiView(stream) },
-                                onRemoveFromRecents: scope == .recentlyWatched ? { removeFromRecentlyWatched(stream) } : nil
-                            )
-                            .onAppear {
-                                if stream.id == visible.last?.id, visibleCount < channels.count {
-                                    visibleCount = min(visibleCount + LiveChannelQuery.pageSize, channels.count)
-                                }
-                            }
-
-                            Divider()
-                                .padding(.leading, 88)
-                        }
-                    }
-                }
-            }
-            // Reload when the visible window or channel set changes, or a guide
-            // import settles — EPG is resolved only for the channels on screen.
-            .task(id: "\(channels.count)-\(visible.count)-\(epgSync.isSyncing)") {
-                await loadEPG(for: visible)
-            }
-        }
-        .alert("Clear Recently Watched", isPresented: $confirmingClear) {
-            Button("Clear", role: .destructive) { clearRecentlyWatched() }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This clears the list of channels you've recently watched. Your favorites and the channels themselves aren't affected.")
-        }
-    }
-
-    private func loadEPG(for channels: [LiveStream]) async {
-        let channelIds = Array(Set(channels.compactMap(\.epgChannelId).filter { !$0.isEmpty }))
-        guard !channelIds.isEmpty else {
-            epgByChannel = [:]
-            return
-        }
-        let container = modelContext.container
-        let now = Date()
-        epgByChannel = await Task.detached(priority: .userInitiated) {
-            ChannelEPGLoader.load(container: container, channelIds: channelIds, now: now)
-        }.value
     }
 }
 

--- a/Lume/Views/MainTabView.swift
+++ b/Lume/Views/MainTabView.swift
@@ -54,6 +54,9 @@ struct MainTabView: View {
     /// that's already been handled.
     @State private var autoSyncAttempted: Set<UUID> = []
 
+    /// Memo behind `contentRestriction` — see `ContentRestrictionMemo`.
+    @State private var restrictionMemo = ContentRestrictionMemo()
+
     private var syncFrequency: SyncFrequency {
         SyncFrequency.resolve(syncFrequencyRaw)
     }
@@ -81,11 +84,16 @@ struct MainTabView: View {
     /// Hides categories (and their content) from every browse, Home and Search
     /// surface: the ones hidden in Content Management always, the restricted
     /// ones while a child profile is active.
+    ///
+    /// Routed through a memo: this root's body re-evaluates whenever any catalog
+    /// write moves one of its `@Query`s, and constructing a `ContentRestriction`
+    /// digests every excluded id — 433 of them on a real hidden-category set.
+    /// The two id sets are cheap to rebuild and compare; the digest is not.
     private var contentRestriction: ContentRestriction {
-        ContentRestriction(
+        restrictionMemo.restriction(
             isActive: profileManager?.activeProfileIsChild ?? false,
-            restrictedCategoryIDs: Set(restrictedCategories.map(\.id)),
-            hiddenCategoryIDs: Set(hiddenCategories.map(\.id))
+            restricted: Set(restrictedCategories.map(\.id)),
+            hidden: Set(hiddenCategories.map(\.id))
         )
     }
 
@@ -107,6 +115,12 @@ struct MainTabView: View {
         #endif
             .environment(router)
             .environment(\.contentRestriction, contentRestriction)
+            // A tab switch is the one browse interaction that has no scroll
+            // view of its own to stamp from, and it is the moment a merge is
+            // most expensive — the incoming tab is re-running its queries.
+            .onChange(of: router.selectedTab) {
+                ContentIndexingService.shared.noteUserInteraction()
+            }
         #if os(iOS)
             .tabBarMinimizeOnScrollDownIfAvailable()
         #endif
@@ -441,6 +455,40 @@ private extension View {
                 SyncProgressView(playlist: playlist, autoStart: true)
             }
         #endif
+    }
+}
+
+// MARK: - Restriction memo
+
+/// Hands back the previous `ContentRestriction` whenever the ids behind it
+/// haven't moved.
+///
+/// The restriction context is rebuilt from `MainTabView`'s `@Query` results on
+/// every body pass, and building one runs SHA-256 over every excluded category
+/// id (`ContentRestriction.visibilityToken`) plus 32 `String(format:)` calls —
+/// ~100 µs with 433 hidden categories, for a value that changes only when the
+/// user hides a category or switches to a child profile. Comparing the two id
+/// sets costs a fraction of that.
+///
+/// A plain reference held in `@State`: nothing on it is observed, so reading and
+/// updating it from `body` can't invalidate the view the way writing `@State`
+/// would.
+private final class ContentRestrictionMemo {
+    private var cached = ContentRestriction()
+
+    func restriction(isActive: Bool, restricted: Set<String>, hidden: Set<String>) -> ContentRestriction {
+        if cached.isActive == isActive,
+           cached.restrictedCategoryIDs == restricted,
+           cached.hiddenCategoryIDs == hidden
+        {
+            return cached
+        }
+        cached = ContentRestriction(
+            isActive: isActive,
+            restrictedCategoryIDs: restricted,
+            hiddenCategoryIDs: hidden
+        )
+        return cached
     }
 }
 

--- a/Lume/Views/Movies/MoviesView.swift
+++ b/Lume/Views/Movies/MoviesView.swift
@@ -90,6 +90,7 @@ struct MoviesView: View {
                         }
                         .padding(.vertical)
                     }
+                    .browseActivity()
                     .task(id: playlistPrefix) {
                         genres = await GenreDerivation.movieGenres(in: modelContext.container, playlistPrefix: playlistPrefix, restriction: restriction)
                     }

--- a/Lume/Views/Player/MultiView/MultiViewChannelPicker.swift
+++ b/Lume/Views/Player/MultiView/MultiViewChannelPicker.swift
@@ -34,6 +34,10 @@ struct MultiViewChannelPicker: View {
     @State private var search = ""
     /// Search hits across the selected playlist. Empty while not searching.
     @State private var matches: [LiveStream] = []
+    /// The term `matches` was actually fetched for. Stays empty until the first
+    /// debounced fetch settles, so "no results" can't flash under the viewer
+    /// while they are still typing.
+    @State private var settledTerm = ""
 
     private var selectedPlaylist: Playlist? {
         playlists.first { $0.id == playlistID } ?? playlists.first
@@ -84,7 +88,7 @@ struct MultiViewChannelPicker: View {
                         playlistID = playlists.first?.id
                     }
                 }
-                .task(id: "\(playlistID?.uuidString ?? "")-\(searchTerm)") { loadMatches() }
+                .task(id: "\(playlistID?.uuidString ?? "")-\(searchTerm)") { await loadMatches() }
         }
     }
 
@@ -129,7 +133,12 @@ struct MultiViewChannelPicker: View {
     @ViewBuilder
     private var searchResultsSection: some View {
         if matches.isEmpty {
-            ContentUnavailableView.search(text: searchTerm)
+            // Only once a query has actually been run — the fetch is debounced,
+            // and without this the empty state showed for the length of every
+            // pause in typing.
+            if !settledTerm.isEmpty {
+                ContentUnavailableView.search(text: settledTerm)
+            }
         } else {
             Section("Channels") {
                 ForEach(matches) { stream in
@@ -151,27 +160,71 @@ struct MultiViewChannelPicker: View {
         dismiss()
     }
 
-    /// Searches the selected playlist's channels by name. Scoping by the
-    /// playlist-UUID prefix stamped onto every category id mirrors how the main
-    /// search restricts to a playlist — `hasPrefix` isn't expressible in a
-    /// SwiftData predicate.
-    private func loadMatches() {
+    /// Searches the selected playlist's channels by name, debounced and off the
+    /// view context.
+    ///
+    /// This runs while Multi-View holds up to four live decoders — the tightest
+    /// main-thread budget the app has — and it used to fire a synchronous
+    /// main-context fetch on *every keystroke*: a `localizedStandardContains`
+    /// scan of all 60,093 channels carrying a *second* `NSCoreDataStringSearch`
+    /// per row, because the playlist scope was a substring search on
+    /// `categoryId`, and ordered by name so SQLite had to find and sort every
+    /// match before `fetchLimit` could apply.
+    ///
+    /// All four are gone: `.task(id:)` cancels the sleep below the instant the
+    /// term changes, so the fetch only fires once typing pauses; it runs on its
+    /// own background context and hands back identifiers, which is the shape
+    /// `SearchFetcher` established for the global search; the playlist scope is
+    /// a range seek on the `starts(with:)` prefix of the unique — and therefore
+    /// indexed — `id` every catalog row carries; and with no `sortBy:` the scan
+    /// stops at the 200th hit instead of sorting the whole match set. The name
+    /// order the list has always shown is applied over those 200 rows instead.
+    private func loadMatches() async {
         guard !searchTerm.isEmpty, let playlist = selectedPlaylist else {
+            settledTerm = ""
             matches = []
             return
         }
+        try? await Task.sleep(for: .milliseconds(300))
+        guard !Task.isCancelled else { return }
+
         let term = searchTerm
-        let playlistToken = playlist.id.uuidString
+        let prefix = "\(playlist.id.uuidString)-"
+        let container = modelContext.container
+        let ids = await Task.detached(priority: .userInitiated) {
+            MultiViewChannelSearch.hits(container: container, term: term, playlistPrefix: prefix)
+        }.value
+        guard !Task.isCancelled else { return }
+
+        settledTerm = term
+        matches = ids.compactMap { modelContext.model(for: $0) as? LiveStream }
+            .excludingRestricted(restriction)
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+}
+
+// MARK: - Off-main search fetch
+
+/// The picker's channel search, run on its own background `ModelContext` and
+/// returning only identifiers — managed objects can't cross an actor boundary.
+/// Mirrors `SearchFetcher`, which does the same for the global search screen.
+private nonisolated enum MultiViewChannelSearch {
+    /// Cap on the rows one search returns, unchanged from the fetch this
+    /// replaced. It only bites now: with an `ORDER BY` SQLite had to find and
+    /// sort every match before the limit could apply, so a bounded fetch still
+    /// walked all 60,093 channels; without one it stops at the 200th hit.
+    static let limit = 200
+
+    static func hits(container: ModelContainer, term: String, playlistPrefix: String) -> [PersistentIdentifier] {
         var descriptor = FetchDescriptor<LiveStream>(
             predicate: #Predicate { stream in
                 stream.isHidden == false
                     && stream.name.localizedStandardContains(term)
-                    && (stream.categoryId?.localizedStandardContains(playlistToken) ?? false)
-            },
-            sortBy: [SortDescriptor(\.name)]
+                    && stream.id.starts(with: playlistPrefix)
+            }
         )
-        descriptor.fetchLimit = 200
-        matches = ((try? modelContext.fetch(descriptor)) ?? []).excludingRestricted(restriction)
+        descriptor.fetchLimit = limit
+        return ((try? ModelContext(container).fetch(descriptor)) ?? []).map(\.persistentModelID)
     }
 }
 

--- a/Lume/Views/Player/TVChannelBrowserOverlay.swift
+++ b/Lume/Views/Player/TVChannelBrowserOverlay.swift
@@ -342,23 +342,46 @@
         private func loadInitialContent() {
             guard let stream = TVPlayerContent.liveStream(for: media.contentRef, in: modelContext),
                   let playlist = LiveChannelNavigator.playlist(for: stream, in: modelContext) else { return }
-            playlistPrefix = "\(playlist.id.uuidString)-"
+            let prefix = "\(playlist.id.uuidString)-"
+            playlistPrefix = prefix
 
             let categorySort = CategorySortOption(rawValue: categorySortRaw) ?? .playlist
+            // Scoped in SQL. Unscoped this fetched every live category of every
+            // playlist — 1,734 rows on the measured store — and threw all but
+            // one playlist's away in Swift, from `onAppear`, with the stream
+            // already decoding. `starts(with:)` on the unique (and therefore
+            // indexed) `id` turns that into a range seek. `visibleCategories`
+            // still runs: it is what applies the parental filter, and sharing it
+            // with the Live TV rail is what keeps the two from disagreeing about
+            // what a category rail contains.
             let descriptor = FetchDescriptor<Category>(
-                predicate: #Predicate { $0.typeRaw == "live" && $0.isHidden == false }
+                predicate: #Predicate {
+                    $0.typeRaw == "live" && $0.isHidden == false && $0.id.starts(with: prefix)
+                }
             )
             let categories = categorySort.sort(
                 LiveChannelQuery.visibleCategories(
                     (try? modelContext.fetch(descriptor)) ?? [],
-                    playlistPrefix: playlistPrefix,
+                    playlistPrefix: prefix,
                     restriction: restriction
                 )
             )
 
+            // The two virtual collections used to be gated by
+            // `!fetchChannels(scope:).isEmpty`, which materialised the entire
+            // collection — 1,506 favorited channels on the measured store — to
+            // decide whether one rail row should exist, from `onAppear`, with
+            // the stream already decoding. `LiveChannelQuery`'s probes answer
+            // the same question with a `LIMIT 1` seek, and are the same
+            // descriptors the Live TV rail gates on, so the two surfaces can't
+            // disagree about which collections a rail offers.
             var rail: [LiveTVSection] = []
-            if !fetchChannels(scope: .favorites).isEmpty { rail.append(.favorites) }
-            if !fetchChannels(scope: .recentlyWatched).isEmpty { rail.append(.recentlyWatched) }
+            if hasVisible(LiveChannelQuery.favoritesProbe(playlistPrefix: prefix, restriction: restriction)) {
+                rail.append(.favorites)
+            }
+            if hasVisible(LiveChannelQuery.recentlyWatchedProbe(playlistPrefix: prefix, restriction: restriction)) {
+                rail.append(.recentlyWatched)
+            }
             rail.append(contentsOf: categories.map(LiveTVSection.category))
             sections = rail
 
@@ -379,6 +402,13 @@
             if let currentChannelID, channels.contains(where: { $0.id == currentChannelID }) {
                 loadGuide(channelID: currentChannelID)
             }
+        }
+
+        /// Runs one of `LiveChannelQuery`'s existence probes. They carry their
+        /// own `fetchLimit = 1` and no `sortBy`, so this stops at the first
+        /// matching row instead of building a list to ask whether it is empty.
+        private func hasVisible(_ probe: FetchDescriptor<LiveStream>) -> Bool {
+            !((try? modelContext.fetch(probe)) ?? []).isEmpty
         }
 
         private func fetchChannels(scope: LiveChannelScope) -> [LiveStream] {

--- a/Lume/Views/Player/TVPlayerContent.swift
+++ b/Lume/Views/Player/TVPlayerContent.swift
@@ -101,14 +101,28 @@
 
         // MARK: - EPG
 
-        /// Upcoming/ongoing EPG listings for a channel, soonest first.
+        /// How many rows `epgListings` returns. Its one caller
+        /// (`TVPlayerControlsOverlay.resolveContent`) reads exactly two values
+        /// out of the result — the programme airing now and the one after it —
+        /// and, ordered by start, those are the first two rows. Unbounded, the
+        /// fetch handed it the channel's whole remaining guide instead: 615 rows
+        /// on the measured store, 1,209 on the busiest channel, hydrated on
+        /// every controls wake and every channel surf while the stream decodes.
+        /// The slack above two absorbs the overlapping and duplicated entries
+        /// providers ship, which would otherwise push "next" out of the window.
+        private static let nowNextLimit = 6
+
+        /// Upcoming/ongoing EPG listings for a channel, soonest first, bounded
+        /// to the now/next window the caller reads (`nowNextLimit`). The
+        /// `channelId + end` index seeks straight to the remaining guide.
         static func epgListings(channelId: String?, in context: ModelContext) -> [EPGListing] {
             guard let channelId, !channelId.isEmpty else { return [] }
             let now = Date()
-            let descriptor = FetchDescriptor<EPGListing>(
+            var descriptor = FetchDescriptor<EPGListing>(
                 predicate: #Predicate { $0.channelId == channelId && $0.end > now },
                 sortBy: [SortDescriptor(\.start)]
             )
+            descriptor.fetchLimit = nowNextLimit
             return (try? context.fetch(descriptor)) ?? []
         }
 

--- a/Lume/Views/SearchFetching.swift
+++ b/Lume/Views/SearchFetching.swift
@@ -49,29 +49,37 @@ nonisolated enum SearchFetcher {
         let context = ModelContext(container)
         var hits = SearchHits()
 
+        // None of the three descriptors sorts. A `sortBy:` defeats `fetchLimit`:
+        // with an ORDER BY, SQLite has to find *and sort* every match before it
+        // can apply the LIMIT, so a bounded fetch still scanned the whole table
+        // (263 ms for movies alone on a 179k-title catalog, 479 ms for the three
+        // together) to show 50 rows. Without it the scan stops at the 50th hit.
+        // The per-type name order the list has always shown is applied over the
+        // hydrated rows instead — see `SearchView.assembleResults`.
         if request.wantMovies {
-            var descriptor = FetchDescriptor<Movie>(
-                predicate: searchMoviePredicate(scope: scope),
-                sortBy: [SortDescriptor(\.name)]
-            )
+            var descriptor = FetchDescriptor<Movie>(predicate: searchMoviePredicate(scope: scope))
             descriptor.fetchLimit = limit
             hits.movies = ((try? context.fetch(descriptor)) ?? []).map(\.persistentModelID)
         }
 
+        // Each entity fetch is its own table scan, so a superseded query that
+        // ran all three burned the full cost for a result nobody would read.
+        // `SearchView.localSearch` forwards its cancellation into this task
+        // (`Task.detached` does not inherit it), and these checks turn that into
+        // an early exit between the scans. The partial hits returned here are
+        // discarded by the caller, which is cancelled too.
+        guard !Task.isCancelled else { return hits }
+
         if request.wantSeries {
-            var descriptor = FetchDescriptor<Series>(
-                predicate: searchSeriesPredicate(scope: scope),
-                sortBy: [SortDescriptor(\.name)]
-            )
+            var descriptor = FetchDescriptor<Series>(predicate: searchSeriesPredicate(scope: scope))
             descriptor.fetchLimit = limit
             hits.series = ((try? context.fetch(descriptor)) ?? []).map(\.persistentModelID)
         }
 
+        guard !Task.isCancelled else { return hits }
+
         if request.wantLive {
-            var descriptor = FetchDescriptor<LiveStream>(
-                predicate: searchLiveStreamPredicate(scope: scope),
-                sortBy: [SortDescriptor(\.name)]
-            )
+            var descriptor = FetchDescriptor<LiveStream>(predicate: searchLiveStreamPredicate(scope: scope))
             descriptor.fetchLimit = limit
             hits.streams = ((try? context.fetch(descriptor)) ?? []).map(\.persistentModelID)
         }
@@ -97,30 +105,58 @@ nonisolated struct SearchScope {
     var excludedOptional: Set<String?> {
         Set(excluded.map(String?.some))
     }
+
+    /// The playlist restriction as an id prefix. Every catalog row's id is
+    /// `"<playlist uuid>-<kind>-<provider id>"` (see `ContentSyncManager`), so a
+    /// prefix test on the row's own `id` scopes a fetch to one playlist — and
+    /// `id` is `@Attribute(.unique)`, i.e. indexed, the same range seek
+    /// `PlaylistDeletion` scopes with. The separator is part of the prefix so
+    /// the match can't run past the uuid into a longer id.
+    var playlistIDPrefix: String {
+        "\(playlistID)-"
+    }
 }
 
 /// Internal (not fileprivate) so the tests can run them against a SQLite store,
 /// where predicate SQL is actually generated.
+///
+/// The playlist scope is emitted only when it applies rather than being folded
+/// into an `||` with a captured flag: it used to read
+/// `categoryId?.localizedStandardContains(playlistID)`, a second
+/// `NSCoreDataStringSearch` per row — a full substring search used as a prefix
+/// test, and as expensive as the name match it was paired with.
 nonisolated func searchMoviePredicate(scope: SearchScope) -> Predicate<Movie> {
-    let (query, playlistID) = (scope.query, scope.playlistID)
-    let restrictToPlaylist = scope.restrictToPlaylist
+    let query = scope.query
     let excluded = scope.excludedOptional
     let filtersCategories = !excluded.isEmpty
+    guard scope.restrictToPlaylist else {
+        return #Predicate { movie in
+            movie.name.localizedStandardContains(query)
+                && (!filtersCategories || movie.categoryId == nil || !excluded.contains(movie.categoryId))
+        }
+    }
+    let prefix = scope.playlistIDPrefix
     return #Predicate { movie in
         movie.name.localizedStandardContains(query)
-            && (!restrictToPlaylist || (movie.categoryId?.localizedStandardContains(playlistID) ?? false))
+            && movie.id.starts(with: prefix)
             && (!filtersCategories || movie.categoryId == nil || !excluded.contains(movie.categoryId))
     }
 }
 
 nonisolated func searchSeriesPredicate(scope: SearchScope) -> Predicate<Series> {
-    let (query, playlistID) = (scope.query, scope.playlistID)
-    let restrictToPlaylist = scope.restrictToPlaylist
+    let query = scope.query
     let excluded = scope.excludedOptional
     let filtersCategories = !excluded.isEmpty
+    guard scope.restrictToPlaylist else {
+        return #Predicate { series in
+            series.name.localizedStandardContains(query)
+                && (!filtersCategories || series.categoryId == nil || !excluded.contains(series.categoryId))
+        }
+    }
+    let prefix = scope.playlistIDPrefix
     return #Predicate { series in
         series.name.localizedStandardContains(query)
-            && (!restrictToPlaylist || (series.categoryId?.localizedStandardContains(playlistID) ?? false))
+            && series.id.starts(with: prefix)
             && (!filtersCategories || series.categoryId == nil || !excluded.contains(series.categoryId))
     }
 }
@@ -128,14 +164,21 @@ nonisolated func searchSeriesPredicate(scope: SearchScope) -> Predicate<Series> 
 /// Live channels also carry their own Content Management visibility, so a
 /// channel hidden individually is excluded here as well.
 nonisolated func searchLiveStreamPredicate(scope: SearchScope) -> Predicate<LiveStream> {
-    let (query, playlistID) = (scope.query, scope.playlistID)
-    let restrictToPlaylist = scope.restrictToPlaylist
+    let query = scope.query
     let excluded = scope.excludedOptional
     let filtersCategories = !excluded.isEmpty
+    guard scope.restrictToPlaylist else {
+        return #Predicate { stream in
+            stream.name.localizedStandardContains(query)
+                && stream.isHidden == false
+                && (!filtersCategories || stream.categoryId == nil || !excluded.contains(stream.categoryId))
+        }
+    }
+    let prefix = scope.playlistIDPrefix
     return #Predicate { stream in
         stream.name.localizedStandardContains(query)
             && stream.isHidden == false
-            && (!restrictToPlaylist || (stream.categoryId?.localizedStandardContains(playlistID) ?? false))
+            && stream.id.starts(with: prefix)
             && (!filtersCategories || stream.categoryId == nil || !excluded.contains(stream.categoryId))
     }
 }

--- a/Lume/Views/SearchView.swift
+++ b/Lume/Views/SearchView.swift
@@ -221,11 +221,11 @@ struct SearchView: View {
         query: String, playlist: Playlist?, wantMovies: Bool, wantSeries: Bool, wantLive: Bool
     ) async -> SearchHits {
         // Scope to the active playlist unless cross-playlist search is on. Every
-        // category id is prefixed with its playlist's UUID (see Category.id),
-        // which appears nowhere else, so matching it within categoryId limits
-        // results to that playlist. Hidden/restricted categories are excluded in
-        // the fetch rather than afterwards, so `resultLimit` isn't spent on rows
-        // the viewer will never see.
+        // catalog row's id carries its playlist's UUID as a prefix (see
+        // `SearchScope.playlistIDPrefix`), so a prefix test on the indexed `id`
+        // limits results to that playlist. Hidden/restricted categories are
+        // excluded in the fetch rather than afterwards, so `resultLimit` isn't
+        // spent on rows the viewer will never see.
         let request = SearchRequest(
             query: query,
             playlistID: playlist?.id.uuidString ?? "",
@@ -237,9 +237,21 @@ struct SearchView: View {
             limit: resultLimit
         )
         let container = modelContext.container
-        return await Task.detached(priority: .userInitiated) {
+        // `Task.detached` starts an unstructured task, which does not inherit
+        // this one's cancellation: every keystroke that settled into a query
+        // used to leave its scans running to the end, so on a large catalog the
+        // superseded work piled up behind the query the viewer is waiting for.
+        // Forwarding the cancellation lets `SearchFetcher` bail between its
+        // three scans; the partial hits it returns are dropped by
+        // `updateResults`, which is the task being cancelled.
+        let fetch = Task.detached(priority: .userInitiated) {
             SearchFetcher.fetch(container: container, request: request)
-        }.value
+        }
+        return await withTaskCancellationHandler {
+            await fetch.value
+        } onCancel: {
+            fetch.cancel()
+        }
     }
 
     /// Portal hits first (relevance order), then the local pass. Hydrates rows
@@ -260,16 +272,35 @@ struct SearchView: View {
         for series in hydrateSeries(ids: portal.series) {
             add(.series(series), categoryID: series.categoryId)
         }
-        for id in localHits.movies {
-            if let movie = modelContext.model(for: id) as? Movie { add(.movie(movie), categoryID: movie.categoryId) }
+        // The local fetches deliberately run without an ORDER BY so SQLite can
+        // stop at the per-type limit instead of sorting every match first (see
+        // `SearchFetcher.fetch`). The per-type, name-ascending order the list
+        // has always shown is restored here, over at most `resultLimit`
+        // hydrated rows per type. `localizedStandardCompare` is what
+        // `SortDescriptor(\.name)` used, so the ordering is unchanged.
+        for movie in hydrateSortedByName(localHits.movies, name: \Movie.name) {
+            add(.movie(movie), categoryID: movie.categoryId)
         }
-        for id in localHits.series {
-            if let series = modelContext.model(for: id) as? Series { add(.series(series), categoryID: series.categoryId) }
+        for series in hydrateSortedByName(localHits.series, name: \Series.name) {
+            add(.series(series), categoryID: series.categoryId)
         }
-        for id in localHits.streams {
-            if let stream = modelContext.model(for: id) as? LiveStream { add(.liveStream(stream), categoryID: stream.categoryId) }
+        for stream in hydrateSortedByName(localHits.streams, name: \LiveStream.name) {
+            add(.liveStream(stream), categoryID: stream.categoryId)
         }
         return matches
+    }
+
+    /// Hydrates rows the background fetch matched, in name order. The fetch
+    /// itself no longer sorts (a `sortBy:` would make SQLite sort every match
+    /// before applying the limit), so this is where the list's per-type
+    /// alphabetical order comes from — over at most `resultLimit` rows.
+    /// `localizedStandardCompare` is the comparator `SortDescriptor(\.name)`
+    /// defaulted to, so the resulting order is the same one the list showed.
+    private func hydrateSortedByName<Model: PersistentModel>(
+        _ ids: [PersistentIdentifier], name: KeyPath<Model, String>
+    ) -> [Model] {
+        ids.compactMap { modelContext.model(for: $0) as? Model }
+            .sorted { $0[keyPath: name].localizedStandardCompare($1[keyPath: name]) == .orderedAscending }
     }
 
     /// Fetches `Movie` rows for the given ids in one query, returned in id order.

--- a/Lume/Views/Series/SeriesView.swift
+++ b/Lume/Views/Series/SeriesView.swift
@@ -88,6 +88,7 @@ struct SeriesView: View {
                         }
                         .padding(.vertical)
                     }
+                    .browseActivity()
                     .task(id: playlistPrefix) {
                         genres = await GenreDerivation.seriesGenres(in: modelContext.container, playlistPrefix: playlistPrefix, restriction: restriction)
                     }

--- a/Lume/Views/Settings/ContentManagementView.swift
+++ b/Lume/Views/Settings/ContentManagementView.swift
@@ -28,10 +28,26 @@ struct ContentManagementView: View {
 
     @State private var showHideAllConfirmation = false
 
-    /// Every category across all playlists; scoped and sorted in-memory. Category
-    /// counts are small (tens–low hundreds per playlist), so an in-memory pass is
-    /// simpler than re-parameterising a `@Query` on the picker selection.
+    /// Every category across all playlists; scoped and sorted in-memory because
+    /// SwiftData can't parameterise a `@Query` on view state (the picker's type,
+    /// the active playlist). That pass is anything but small — a real provider
+    /// ships 1,700+ categories in a single playlist, 916 of them live — so it is
+    /// resolved once per input change into `categories` below.
     @Query private var allCategories: [Category]
+
+    /// Categories of the selected type for the active playlist, in effective
+    /// order (user order if set, else the synced playlist order). Cached rather
+    /// than computed: `body` reads the group three or four times per evaluation
+    /// (the emptiness checks, the bulk actions, `listedCategories`), so the
+    /// filter plus the tuple sort ran that many times over ~1,900 rows on every
+    /// render — including on a plain hide toggle, which changes neither the
+    /// membership nor the order.
+    @State private var categories: [Category] = []
+
+    /// What the screen is actually showing, and therefore what the bulk hide /
+    /// show actions apply to. Identical to `categories` unless a search narrows
+    /// it, which is what makes "hide all, search, show all matches" work.
+    @State private var listedCategories: [Category] = []
 
     #if !os(tvOS)
         /// Drives the drill-in to channel management. Owned here (not by a List
@@ -53,6 +69,12 @@ struct ContentManagementView: View {
                     description: Text("Add a playlist to manage its content.")
                 )
             }
+        }
+        .onChange(of: scopeKey, initial: true) { _, _ in
+            refreshCategories()
+        }
+        .onChange(of: searchKey) { _, _ in
+            refreshListedCategories()
         }
         .hideAllConfirmation("Hide All Categories?", isPresented: $showHideAllConfirmation) {
             ContentOrganizer.hideAll(listedCategories)
@@ -87,34 +109,76 @@ struct ContentManagementView: View {
         playlists.active(for: selectedPlaylistID)
     }
 
-    /// Categories of the selected type for the active playlist, in effective
-    /// order (user order if set, else the synced playlist order).
-    private var categories: [Category] {
-        guard let playlistId = activePlaylist?.id else { return [] }
-        let prefix = "\(playlistId.uuidString)-"
-        return allCategories
+    /// The id prefix every Category of the active playlist shares. Empty only
+    /// when there is no playlist at all, and then there is nothing to scope.
+    private var playlistPrefix: String {
+        activePlaylist.map { "\($0.id.uuidString)-" } ?? ""
+    }
+
+    /// Everything the scoped group depends on, folded into one comparable value.
+    /// `allCategories.count` is what keeps the group in step with a sync adding
+    /// or removing categories; the actions that rewrite `customOrder` (reorder,
+    /// reset) leave the count alone and so refresh the group themselves.
+    private var scopeKey: String {
+        "\(playlistPrefix)|\(selectedType.rawValue)|\(allCategories.count)"
+    }
+
+    /// The live search term — always empty on tvOS, which has no search field.
+    /// Folded into one property so `body`'s modifier chain needs no second `#if`
+    /// (SwiftFormat reindents adjacent ones in a chain).
+    private var searchKey: String {
+        #if os(tvOS)
+            ""
+        #else
+            searchText
+        #endif
+    }
+
+    /// Rebuilds the scoped group, and the listed subset with it. Called from the
+    /// `.onChange` hooks in `body` and from the actions that rewrite the order —
+    /// never from `body` itself, which is the whole point of caching it.
+    private func refreshCategories() {
+        let prefix = playlistPrefix
+        guard !prefix.isEmpty else {
+            categories = []
+            listedCategories = []
+            return
+        }
+        categories = allCategories
             .filter { $0.typeRaw == selectedType.rawValue && $0.id.hasPrefix(prefix) }
             .sorted { lhs, rhs in
                 (lhs.customOrder ?? lhs.sortOrder, lhs.name) < (rhs.customOrder ?? rhs.sortOrder, rhs.name)
             }
+        refreshListedCategories()
     }
 
-    /// What the screen is actually showing, and therefore what the bulk hide /
-    /// show actions apply to. Identical to `categories` unless a search narrows
-    /// it, which is what makes "hide all, search, show all matches" work.
-    private var listedCategories: [Category] {
-        #if os(tvOS)
-            categories
-        #else
-            guard !searchText.isEmpty else { return categories }
-            return categories.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
-        #endif
+    /// Narrows the scoped group by the search field. Split out of
+    /// `refreshCategories` so a keystroke re-filters without re-sorting.
+    private func refreshListedCategories() {
+        let search = searchKey
+        guard !search.isEmpty else {
+            listedCategories = categories
+            return
+        }
+        listedCategories = categories.filter { $0.name.localizedCaseInsensitiveContains(search) }
     }
 
     // MARK: - Mutations
 
     private func move(from source: IndexSet, to destination: Int) {
         ContentOrganizer.reorder(categories, from: source, to: destination)
+        // The stamp rewrites `customOrder` without changing how many categories
+        // exist, so `scopeKey` doesn't move. Refresh by hand or the list snaps
+        // straight back to the pre-move order.
+        refreshCategories()
+    }
+
+    /// Persists a tvOS pick-up/place drop. Same story as `move`: the drop only
+    /// stamps `customOrder`, so the cached group has to be re-sorted or the list
+    /// falls back to the order it had before the lift.
+    private func commitReorder(_ arranged: [Category]) {
+        ContentOrganizer.commitOrder(arranged)
+        refreshCategories()
     }
 
     #if !os(tvOS)
@@ -132,6 +196,9 @@ struct ContentManagementView: View {
     private func resetCurrentType() {
         ContentOrganizer.resetOrder(categories)
         ContentOrganizer.showAll(categories)
+        // Clearing `customOrder` reverts the group to the playlist's own order,
+        // which the cached list has to be rebuilt to show.
+        refreshCategories()
     }
 
     /// Drill-in provider for the reorderable list: only live categories expose a
@@ -235,7 +302,7 @@ struct ContentManagementView: View {
                     isHidden: { $0.isHidden },
                     drillValue: categoryDrill,
                     onToggleHidden: { $0.isHidden.toggle() },
-                    onCommitOrder: { ContentOrganizer.commitOrder($0) },
+                    onCommitOrder: commitReorder,
                     isReordering: $isReordering,
                     scrollProxy: proxy,
                     isRestricted: { $0.isRestricted },

--- a/LumeTests/Models/SortOptionTests.swift
+++ b/LumeTests/Models/SortOptionTests.swift
@@ -72,16 +72,16 @@ struct SortOptionTests {
     @Test func `movie sort newest first`() {
         let movies = makeUnsortedMovies()
         let sorted = movies.sorted(using: ContentSortOption.newest.movieDescriptors)
-        #expect(sorted[0].added == "200")
-        #expect(sorted[1].added == "100")
-        #expect(sorted[2].added == "50")
+        #expect(sorted[0].added == "1700000200")
+        #expect(sorted[1].added == "1700000100")
+        #expect(sorted[2].added == "1700000050")
     }
 
     @Test func `movie sort oldest first`() {
         let movies = makeUnsortedMovies()
         let sorted = movies.sorted(using: ContentSortOption.oldest.movieDescriptors)
-        #expect(sorted[0].added == "50")
-        #expect(sorted[2].added == "200")
+        #expect(sorted[0].added == "1700000050")
+        #expect(sorted[2].added == "1700000200")
     }
 
     // MARK: - ContentSortOption - Series Descriptors
@@ -103,15 +103,15 @@ struct SortOptionTests {
     @Test func `series sort newest first`() {
         let series = makeUnsortedSeries()
         let sorted = series.sorted(using: ContentSortOption.newest.seriesDescriptors)
-        #expect(sorted[0].lastModified == "300")
-        #expect(sorted[1].lastModified == "200")
+        #expect(sorted[0].lastModified == "1700000300")
+        #expect(sorted[1].lastModified == "1700000200")
     }
 
     @Test func `series sort oldest first`() {
         let series = makeUnsortedSeries()
         let sorted = series.sorted(using: ContentSortOption.oldest.seriesDescriptors)
-        #expect(sorted[0].lastModified == "100")
-        #expect(sorted[1].lastModified == "200")
+        #expect(sorted[0].lastModified == "1700000100")
+        #expect(sorted[1].lastModified == "1700000200")
     }
 
     @Test func `live stream sort name ascending`() {
@@ -131,15 +131,15 @@ struct SortOptionTests {
     @Test func `live stream sort newest first`() {
         let streams = makeUnsortedStreams()
         let sorted = streams.sorted(using: ContentSortOption.newest.liveStreamDescriptors)
-        #expect(sorted[0].added == "200")
-        #expect(sorted[1].added == "100")
+        #expect(sorted[0].added == "1700000200")
+        #expect(sorted[1].added == "1700000100")
     }
 
     @Test func `live stream sort oldest first`() {
         let streams = makeUnsortedStreams()
         let sorted = streams.sorted(using: ContentSortOption.oldest.liveStreamDescriptors)
-        #expect(sorted[0].added == "100")
-        #expect(sorted[1].added == "200")
+        #expect(sorted[0].added == "1700000100")
+        #expect(sorted[1].added == "1700000200")
     }
 
     // MARK: - ContentSortOption - LiveStream Descriptors
@@ -206,25 +206,31 @@ struct SortOptionTests {
 
     private func makeUnsortedMovies() -> [Movie] {
         [
-            Movie(id: "m-1", streamId: 1, name: "Gamma", added: "50", num: 2),
-            Movie(id: "m-2", streamId: 2, name: "Alpha", added: "100", num: 1),
-            Movie(id: "m-3", streamId: 3, name: "Beta", added: "200", num: 3)
+            // Ten-digit Unix seconds, exactly as Xtream ships them — every one
+            // of the 200,110 `added` values in a real provider catalog is that
+            // width. The sort descriptors use `comparator: .lexical` so SQLite
+            // can serve them from the `added` index, and lexical order matches
+            // numeric order only while the widths agree, so the fixture has to
+            // be realistic for the test to mean anything.
+            Movie(id: "m-1", streamId: 1, name: "Gamma", added: "1700000050", num: 2),
+            Movie(id: "m-2", streamId: 2, name: "Alpha", added: "1700000100", num: 1),
+            Movie(id: "m-3", streamId: 3, name: "Beta", added: "1700000200", num: 3)
         ]
     }
 
     private func makeUnsortedSeries() -> [Series] {
         [
-            Series(id: "s-1", seriesId: 2, name: "Beta Series", lastModified: "200", num: 2),
-            Series(id: "s-2", seriesId: 1, name: "Alpha Series", lastModified: "100", num: 1),
-            Series(id: "s-3", seriesId: 3, name: "Second", lastModified: "300", num: 1),
-            Series(id: "s-4", seriesId: 4, name: "First", lastModified: "200", num: 0)
+            Series(id: "s-1", seriesId: 2, name: "Beta Series", lastModified: "1700000200", num: 2),
+            Series(id: "s-2", seriesId: 1, name: "Alpha Series", lastModified: "1700000100", num: 1),
+            Series(id: "s-3", seriesId: 3, name: "Second", lastModified: "1700000300", num: 1),
+            Series(id: "s-4", seriesId: 4, name: "First", lastModified: "1700000200", num: 0)
         ]
     }
 
     private func makeUnsortedStreams() -> [LiveStream] {
         [
-            LiveStream(id: "l-1", streamId: 2, name: "A Channel", added: "100", num: 2),
-            LiveStream(id: "l-2", streamId: 1, name: "Z Channel", added: "200", num: 1)
+            LiveStream(id: "l-1", streamId: 2, name: "A Channel", added: "1700000100", num: 2),
+            LiveStream(id: "l-2", streamId: 1, name: "Z Channel", added: "1700000200", num: 1)
         ]
     }
 }

--- a/LumeTests/Services/CatalogIndexBackfillTests.swift
+++ b/LumeTests/Services/CatalogIndexBackfillTests.swift
@@ -1,0 +1,131 @@
+//
+//  CatalogIndexBackfillTests.swift
+//  LumeTests
+//
+//  `CatalogIndexBackfill` writes raw `CREATE INDEX` statements against the
+//  catalog store, so its table and column names are hand-written strings that
+//  no compiler checks. A typo there is silent — the index simply never appears
+//  and the queries stay slow, which is exactly the failure this whole mechanism
+//  exists to fix. These tests run it against a real on-disk store built from the
+//  live models, so a renamed property or model breaks the build's tests rather
+//  than a user's browse.
+//
+
+import Foundation
+@testable import Lume
+import SQLite3
+import SwiftData
+import Testing
+
+@MainActor
+struct CatalogIndexBackfillTests {
+    /// The indexes the backfill is responsible for, as `(name, table)`. Kept as
+    /// literals rather than read back from the type under test so a mistake in
+    /// its table has to be made twice to pass.
+    private static let expected: [(name: String, table: String)] = [
+        ("Z_Movie_SwiftDataIndexOnBinaryadded", "ZMOVIE"),
+        ("Z_Series_SwiftDataIndexOnBinarylastModified", "ZSERIES"),
+        ("Z_LiveStream_SwiftDataIndexOnBinaryisFavoriteisHidden", "ZLIVESTREAM"),
+        ("Z_LiveStream_SwiftDataIndexOnBinaryisHiddenlastWatchedDate", "ZLIVESTREAM"),
+        ("Z_EPGListing_SwiftDataIndexOnBinarychannelIdend", "ZEPGLISTING")
+    ]
+
+    /// Builds a real SQLite-backed catalog store and returns its URL. The
+    /// container is returned too and must outlive the test — see
+    /// `SearchPredicateTests` for why.
+    private func makeStore() throws -> (container: ModelContainer, url: URL) {
+        let schema = Schema([
+            Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
+            Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self
+        ])
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("catalog.store")
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        let config = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        // Force the store to actually exist on disk before anything reads it.
+        let context = ModelContext(container)
+        context.insert(Movie(id: "m1", streamId: 1, name: "A Movie"))
+        try context.save()
+        return (container, url)
+    }
+
+    private func indexNames(in url: URL) -> Set<String> {
+        var handle: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READONLY, nil) == SQLITE_OK,
+              let database = handle
+        else {
+            if let handle { sqlite3_close(handle) }
+            return []
+        }
+        defer { sqlite3_close(database) }
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, "SELECT name FROM sqlite_master WHERE type = 'index'", -1, &statement, nil) == SQLITE_OK
+        else { return [] }
+        defer { sqlite3_finalize(statement) }
+        var names: Set<String> = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let raw = sqlite3_column_text(statement, 0) { names.insert(String(cString: raw)) }
+        }
+        return names
+    }
+
+    private func drop(_ names: some Sequence<String>, in url: URL) {
+        var handle: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK,
+              let database = handle
+        else {
+            if let handle { sqlite3_close(handle) }
+            return
+        }
+        defer { sqlite3_close(database) }
+        for name in names {
+            sqlite3_exec(database, "DROP INDEX IF EXISTS \(name)", nil, nil, nil)
+        }
+    }
+
+    /// The case that matters: a store created before the `#Index` entries
+    /// existed. SwiftData never revisits `#Index` on an existing file, so
+    /// dropping the indexes reproduces exactly what every updating user has.
+    @Test func `backfill creates the indexes an older store is missing`() throws {
+        let (container, url) = try makeStore()
+        _ = container
+
+        drop(Self.expected.map(\.name), in: url)
+        let before = indexNames(in: url)
+        for expected in Self.expected {
+            #expect(!before.contains(expected.name), "\(expected.name) should have been dropped")
+        }
+
+        CatalogIndexBackfill.run(storeURL: url)
+
+        let after = indexNames(in: url)
+        for expected in Self.expected {
+            #expect(after.contains(expected.name), "\(expected.name) was not created — check its table and column names")
+        }
+    }
+
+    /// A fresh install already has these from the model declarations, so the
+    /// backfill must be a no-op rather than creating a second, differently
+    /// named copy of each.
+    @Test func `backfill is a no-op on a store that already has them`() throws {
+        let (container, url) = try makeStore()
+        _ = container
+
+        let before = indexNames(in: url)
+        CatalogIndexBackfill.run(storeURL: url)
+        #expect(indexNames(in: url) == before)
+    }
+
+    /// A missing file is the pre-first-launch state; it must not create one.
+    @Test func `backfill leaves a missing store alone`() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("absent.store")
+        CatalogIndexBackfill.run(storeURL: url)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+}

--- a/LumeTests/Services/SearchPredicateTests.swift
+++ b/LumeTests/Services/SearchPredicateTests.swift
@@ -115,12 +115,20 @@ struct SearchPredicateTests {
     @Test func `playlist scoping still applies alongside the exclusion`() throws {
         let container = try makeSQLiteContainer()
         let context = container.mainContext
-        let mine = Movie(id: "m1", streamId: 1, name: "The Matrix")
+        // The scope matches the row's own playlist-prefixed id
+        // (`"<playlist uuid>-<kind>-<provider id>"`), which is indexed, rather
+        // than substring-searching `categoryId` for the playlist's uuid.
+        let mine = Movie(id: "PL-A-movie-1", streamId: 1, name: "The Matrix")
         mine.categoryId = "PL-A-vod-1"
-        let other = Movie(id: "m2", streamId: 2, name: "The Matrix")
+        let other = Movie(id: "PL-B-movie-2", streamId: 2, name: "The Matrix")
         other.categoryId = "PL-B-vod-1"
-        context.insert(mine)
-        context.insert(other)
+        // A playlist whose id merely starts with the scoped one must not leak
+        // in — the separator is part of the prefix.
+        let lookalike = Movie(id: "PL-AB-movie-3", streamId: 3, name: "The Matrix")
+        lookalike.categoryId = "PL-AB-vod-1"
+        for movie in [mine, other, lookalike] {
+            context.insert(movie)
+        }
         try context.save()
 
         let fetched = try context.fetch(
@@ -128,6 +136,29 @@ struct SearchPredicateTests {
                 query: "matrix", playlistID: "PL-A", restrictToPlaylist: true, excluded: ["nl"]
             )))
         )
-        #expect(fetched.map(\.id) == ["m1"])
+        #expect(fetched.map(\.id) == ["PL-A-movie-1"])
+    }
+
+    @Test func `playlist scoping keeps the playlist's uncategorised titles`() throws {
+        let container = try makeSQLiteContainer()
+        let context = container.mainContext
+        // m3u sources don't always supply a group, so a title can carry no
+        // category at all. Scoping on the row's id rather than on its
+        // `categoryId` is what makes those titles findable while the search is
+        // restricted to one playlist; the old `categoryId` substring test
+        // dropped every one of them.
+        let orphan = Movie(id: "PL-A-movie-1", streamId: 1, name: "The Matrix")
+        let other = Movie(id: "PL-B-movie-2", streamId: 2, name: "The Matrix")
+        other.categoryId = "PL-B-vod-1"
+        context.insert(orphan)
+        context.insert(other)
+        try context.save()
+
+        let fetched = try context.fetch(
+            FetchDescriptor<Movie>(predicate: searchMoviePredicate(scope: SearchScope(
+                query: "matrix", playlistID: "PL-A", restrictToPlaylist: true, excluded: []
+            )))
+        )
+        #expect(fetched.map(\.id) == ["PL-A-movie-1"])
     }
 }


### PR DESCRIPTION
Browsing a real large playlist was dominated by database work the UI never needed to do. This is the fix pass for the audit — seven root causes across ten areas, measured before and after in the running app.

## Measured

Core Data's own `sql connection fetch time`, summed over one real interaction driven through the accessibility API. iPhone 17 Pro simulator, Debug, Apple silicon — **a phone or Apple TV is 3–10× slower, so these are lower bounds**. Same store, same user state, before and after.

Catalog: **179,104 movies · 47,930 series · 56,895 channels · 1,734 categories · 218,081 EPG listings**, 373 MB. Plus **1,506 favorites, 5,069 watch-history rows, 2,994 hidden channels, 433 hidden categories**.

| Interaction | Before | After | |
|---|---|---|---|
| Cold launch → Home | 10,412 fetches · 1,904 ms | 9,797 · **774 ms** | −59% |
| Movies tab switch | 7,883 fetches · 739 ms | 1,412 · **91 ms** | −88% |
| One "Add to Favorites" | 23,991 fetches · 1,158 ms | 4,885 · **145 ms** | −87% |
| Search, common term (raw SQL A/B) | 66 ms | **0.4 ms** | −99% |

Before the change, the accessibility tree failed to settle within 2.5 s after a favorite tap. After, it settles immediately.

## What was wrong

**1 · The content indexer re-ran every query in the app, for hours.** One `context.save()` per 50-item chunk with a 100 ms pause; each save merges into the main context and re-runs every `@Query` in every mounted tab. It paused for sync, playback and CloudKit — never for browsing — and is kicked unconditionally at launch. On this catalog that is ~4,500 whole-app query storms spread through ordinary use, which is why Home's six `@Query` properties each fetched 20–25 times in a *single* launch. It now also stands aside while a browse surface is in use, via a self-clearing stamp (`noteUserInteraction()`) that no view can leave switched off.

**2 · Queries that scanned where they should seek.**
- `Movie.added` / `Series.lastModified` were unindexed *and* sorted with `SortDescriptor`'s default `.localizedStandard` comparator, which emits `COLLATE NSCollateFinderlike` and defeats any binary index. `SortOption.swift` already documented lexicographic as the intent; the descriptors now say so. All 200,110 `added` values in a real catalog are 10-digit epoch strings, so lexical and numeric order agree — the unit-test fixtures now use realistic widths, which is what makes that test meaningful.
- LiveStream's favorites and recents fell onto the `isHidden` index, matching ~54,000 of 56,895 channels. They get composites — with the **equality column leading**, because `[lastWatchedDate, isHidden]` (the intuitive order) still loses to the `isHidden` index when there are no table statistics, and Core Data never runs `ANALYZE`. Measured: 12.5 ms → 0.02 ms.

**3 · `#Index` does not reach a store that already exists.** Verified twice against the real 373 MB store: adding an entry and relaunching leaves `sqlite_master` byte-identical. Adding a `VersionedSchema` pair plus a lightweight migration stage does not help either — the store stayed stamped `1.0.0` and issued no `CREATE INDEX`, because Core Data's entity version hash deliberately excludes fetch indexes, so the store is judged compatible and no stage is considered. That approach was written, measured, and removed. `CatalogIndexBackfill` creates the indexes directly, once, before the container opens, under SwiftData's own index names so a fresh install is a genuine no-op. Three tests cover it, including the no-op case — which is what pins the naming.

**4 · Nothing was scoped to the active playlist in SQL.** Cross-category fetches read every installed playlist and filtered with `id.hasPrefix` in Swift, so installing a big playlist permanently slowed down a small one. The scope is a predicate now.

**5 · Unbounded `@Query` feeding bounded UI.** The favorites and recently-watched rails fetched every matching row to render 20 (0.85 ms → 59 ms once there was history). Live TV materialized every favorite and every ever-watched channel to answer two `Bool`s; those are bounded probes now — with the visibility filter kept *in* the predicate, because a `LIMIT 1` plus a Swift-side restriction check would report "empty" whenever the one row returned happened to be restricted.

**6 · Per-body work that scaled with the catalog.** A SHA-256 visibility digest three times per Home body pass; a series' whole `episodes` relationship faulted, filtered and sorted per poster card; Content Management re-filtering and re-sorting 1,900 categories four times per pass.

**7 · In-player fetches**, on the tightest main-thread budget the app has. Multi-View channel search ran a two-predicate table scan on the view context with **no debounce at all**; the tvOS channel browser fired unbounded fetches from `onAppear`; waking the player controls loaded a channel's entire remaining guide — **615 rows, 1,209 on the busiest channel** — to read two values.

## Behaviour changes, deliberate

- **Search with >50 matches** returns the first 50 found rather than the 50 alphabetically-first, then sorts those for display. The `ORDER BY` was what defeated `LIMIT`'s early exit. A/B on the real store: a rare term is unchanged (54.2 → 53.5 ms, the scan dominates either way), a common term goes **66 ms → 0.4 ms** — and common terms are what you type on the way to a rare one.
- **Channel cards read 12 hours of "next" EPG** instead of the whole future guide. A channel whose next programme starts more than 12 h out now shows no "next".
- **"Recently Added" shows a full row with two playlists installed**, where the un-scoped fetch used to take the newest 200 across all playlists and then filter most of them away.

## Verification

- iOS, tvOS and macOS all build.
- **1,158 unit tests pass** (`-parallel-testing-enabled NO`; see the known SIGTRAP-under-parallel-cloning issue).
- SwiftFormat + SwiftLint `--strict` clean; every touched file under the 600-line cap.
- Smoke-tested against both real playlists on the simulator: Home, Movies, Series, Live TV, search, favorite toggle, category grids.

## Not done

- The search scan itself is still an unindexable `localizedStandardContains`; raw SQLite does the same filter in 54 ms where Core Data's `NSCoreDataStringSearch` takes ~420 ms. A normalized lowercase `searchName` column would close that, but it is a schema change plus a sync change and belongs in its own PR.
- `activeOnly` is still tvOS-only, so iOS/macOS keep off-screen tab roots mounted. The queries those roots run are now cheap enough that it stopped mattering; unmounting them would reset per-tab scroll position.
- Still unaudited: `FullScreenPlayerView`, the engine overlays, profile switching, `LoginView`, the paywall, most of Settings, tvOS focus/AX walk cost, and memory while a decoder runs.

https://claude.ai/code/session_01J5zaM7u564ap1SXGXqxHpn
