### PR TITLE
fix(player): give the subtitle search sheet a frame on macOS

### DIFF
--- a/Lume/Views/Player/SubtitleSearchView.swift
+++ b/Lume/Views/Player/SubtitleSearchView.swift
@@ -347,6 +347,13 @@ extension View {
                 // The player forces dark; a sheet raised from it inherits the
                 // app appearance otherwise and flashes light over the video.
                 .preferredColorScheme(.dark)
+            #if os(macOS)
+                // A macOS sheet is sized by its content, and a `List` has no
+                // ideal height to offer — without a frame the browser opened as
+                // a bare toolbar with the results collapsed to nothing, which
+                // reads as "no subtitles found".
+                .frame(minWidth: 460, idealWidth: 540, minHeight: 480, idealHeight: 600)
+            #endif
         }
     }
 }


### PR DESCRIPTION
## Summary
On macOS the in-player OpenSubtitles browser looked empty: the sheet opened as a bare toolbar — the "Subtitles" title and a Done button — with no sign-in section, no language row and no results, which read as "subtitle search finds nothing". The search itself was fine; the results were rendering into a sheet with zero content height. iOS was unaffected.

## Implementation
A macOS sheet is sized by its content, and the browser's `List` has no ideal height to offer, so the sheet collapsed to its chrome. Added the same macOS-only frame the rest of the app's list-in-a-sheet presentations already use (`MainTabView`, `MultiViewScreen`) to `subtitleSearch(isPresented:media:onPick:)`. One-line, macOS-gated; no change to the search, the API client, or any other platform.

## Testing
- [x] Acceptance criteria met — results now render
- [x] Builds clean (`xcodebuild`, macOS destination)
- [ ] Tests pass — n/a, no logic touched
- [x] SwiftLint clean (lefthook pre-commit: swiftformat + swiftlint)
- [x] Tests added — or skipped: pure layout fix, nothing unit-testable
- [x] UI verified on simulator — verified on the macOS app itself: pre-fix sheet showed only title + Done; post-fix it shows the OpenSubtitles sign-in section, the language row and four English results for the playing episode

## Platforms
- [ ] iOS / iPadOS
- [ ] tvOS
- [x] macOS
- [ ] visionOS

## Related
Closes #212