### PR TITLE
test(perf): benchmark and pin the browse read path

### DIFF
--- a/Lume/Views/Components/LibraryCollectionRows.swift
+++ b/Lume/Views/Components/LibraryCollectionRows.swift
@@ -53,7 +53,7 @@ struct LibraryCollection: Hashable {
 }
 
 /// How many items each preview row shows before "Show All".
-private let collectionPreviewLimit = 20
+let collectionPreviewLimit = 20
 
 /// Upper bound on a preview row's fetch. A row renders `collectionPreviewLimit`
 /// items and only needs to know whether one more exists, but the hidden-category
@@ -62,14 +62,14 @@ private let collectionPreviewLimit = 20
 /// use — a viewer with many hidden categories must not end up with a short row
 /// or a missing "Show All". Unbounded, Recently Watched and Favorites re-fetched
 /// every matching row in the store on every catalog write.
-private let collectionRowFetchLimit = 200
+let collectionRowFetchLimit = 200
 
 /// Upper bound on the "Recently Added" fetch, preview row and "Show All" grid
 /// alike. Recently Watched and Favorites match small subsets, but every title
 /// carries an `added` timestamp, so that predicate matches the playlist whole —
 /// an unbounded fetch would hydrate the entire catalog on every change and
 /// stutter badly during sync. We only ever surface the newest slice.
-private let recentlyAddedFetchLimit = 200
+let recentlyAddedFetchLimit = 200
 
 // MARK: - Shared preview row
 
@@ -215,7 +215,12 @@ struct MovieCollectionView: View {
     }
 }
 
-private enum MovieCollectionQuery {
+/// Internal, not fileprivate, so the tests and benchmarks can build these
+/// descriptors and assert their shape — the `fetchLimit`, the playlist scope and
+/// the lexical `added` comparator are performance contracts a well-meaning
+/// refactor can undo without changing a single visible row. Same reasoning as
+/// the search predicates in `SearchFetching.swift`.
+enum MovieCollectionQuery {
     /// The fetch behind a preview row — always bounded, see
     /// `collectionRowFetchLimit`.
     static func rowDescriptor(for kind: LibraryCollection.Kind, playlistPrefix: String) -> FetchDescriptor<Movie> {
@@ -337,7 +342,8 @@ struct SeriesCollectionView: View {
     }
 }
 
-private enum SeriesCollectionQuery {
+/// Internal for the same reason as `MovieCollectionQuery`.
+enum SeriesCollectionQuery {
     /// The fetch behind a preview row — always bounded, see
     /// `collectionRowFetchLimit`.
     static func rowDescriptor(for kind: LibraryCollection.Kind, playlistPrefix: String) -> FetchDescriptor<Series> {

--- a/LumePerformanceTests/BrowseQueryBenchmarks.swift
+++ b/LumePerformanceTests/BrowseQueryBenchmarks.swift
@@ -1,0 +1,449 @@
+//
+//  BrowseQueryBenchmarks.swift
+//  LumePerformanceTests
+//
+//  The fetches behind browsing: the Movies/Series collection rails, the Live TV
+//  section gates, a category preview row, and search.
+//
+//  Every one of these was measured on a real 284k-row Xtream catalog and found
+//  to be scanning where it should have been seeking. On that store, per
+//  interaction, before the browse-latency work:
+//
+//      cold launch -> Home      1,904 ms of SQL   (10,412 fetches)
+//      Movies tab switch          739 ms          ( 7,883 fetches)
+//      one "Add to Favorites"   1,158 ms          (23,991 fetches)
+//
+//  and after it, 774 / 91 / 145 ms. The rest of this target measures the sync
+//  and import path; `EPGQueryBenchmarks` measures the two guide loaders. This
+//  file is the browse read path, which nothing covered.
+//
+//  What each benchmark is actually guarding is written on the test. They are
+//  mostly one-token regressions — a `sortBy:` added back to a bounded fetch, a
+//  `fetchLimit` dropped, `comparator: .lexical` lost to the default — that
+//  change no visible row and so survive review and the unit suite. The cheap
+//  deterministic half of that guard lives in
+//  `LumeTests/Services/BrowseQueryShapeTests.swift`; this half is the cost.
+//
+//  Scale note: 20k movies / 6k series / 8k channels, the same order as
+//  `PersistenceBenchmarks` uses, not the 284k of the measured provider. Big
+//  enough that an unindexed scan separates from an index seek by more than the
+//  noise floor, small enough to seed in seconds. When chasing a specific
+//  regression, raise the counts locally.
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import XCTest
+
+final class BrowseQueryBenchmarks: XCTestCase {
+    private var store: (container: ModelContainer, directory: URL)!
+
+    private let movieCount = 20000
+    private let seriesCount = 6000
+    private let channelCount = 8000
+    private let categoryCount = 200
+
+    /// Proportions taken from the heavy-user state the audit measured (1,506
+    /// favorites and 5,069 watch-history rows against 284k titles), scaled down
+    /// with the catalog. A fresh install exercises none of these paths, which is
+    /// exactly why the regressions went unnoticed for so long.
+    private var favoriteEvery: Int {
+        40
+    }
+
+    private var watchedEvery: Int {
+        12
+    }
+
+    private var hiddenEvery: Int {
+        19
+    }
+
+    /// The section gates are sub-millisecond when they are working, which is
+    /// below what `XCTClockMetric` can resolve on a single call — a regression
+    /// from 0.02 ms to 8 ms would still read as "0.000 s". Each probe benchmark
+    /// therefore runs the fetch as many times as one measured cold launch did
+    /// (18-25), which puts the fast case just above the timer floor and the
+    /// unbounded case far above it.
+    private let probeRepeats = 25
+
+    /// The active playlist. Row ids are `"<uuid>-<kind>-<n>"`, the shape
+    /// `ContentSyncManager` writes and every browse predicate scopes on;
+    /// `Category` derives the same shape from its `playlist` in `init`.
+    /// `Playlist` mints its own id, so both are read back after seeding.
+    private var playlistID: UUID!
+    /// A second installed playlist. It exists so the scoping predicates have
+    /// something to exclude: the bug this guards against is a fetch that reads
+    /// every playlist's rows and filters in Swift afterwards, which is invisible
+    /// until a second playlist is installed.
+    private var otherPlaylistID: UUID!
+
+    private var prefix: String {
+        "\(playlistID.uuidString)-"
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        store = try PerfStore.makeOnDiskContainer()
+        seedCatalog()
+    }
+
+    override func tearDownWithError() throws {
+        if let store {
+            PerfStore.destroy(directory: store.directory)
+        }
+        store = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Collection rails
+
+    /// "Recently Added" on the Movies tab. The most expensive single query in
+    /// the app before the fix: `Movie.added` carried no index *and* the default
+    /// `SortDescriptor` comparator emitted `COLLATE NSCollateFinderlike`, so the
+    /// plan was `SCAN ZMOVIE` plus a temp B-tree sort of every row — 222 ms per
+    /// run on 179k titles, re-run on every catalog write.
+    ///
+    /// Two independent things keep it fast, and losing either brings the scan
+    /// back: the `#Index<Movie>([\.added])` entry, and `comparator: .lexical` on
+    /// the sort. A binary index cannot serve a localized collation.
+    func testRecentlyAddedMovieRail() {
+        let descriptor = MovieCollectionQuery.rowDescriptor(for: .recentlyAdded, playlistPrefix: prefix)
+        let context = ModelContext(store.container)
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            let rows = (try? context.fetch(descriptor)) ?? []
+            XCTAssertEqual(rows.count, collectionRowFetchLimit)
+        }
+    }
+
+    /// The Series equivalent, sorting on `lastModified` — same index and same
+    /// comparator dependency.
+    func testRecentlyAddedSeriesRail() {
+        let descriptor = SeriesCollectionQuery.rowDescriptor(for: .recentlyAdded, playlistPrefix: prefix)
+        let context = ModelContext(store.container)
+
+        measure(metrics: [XCTClockMetric()]) {
+            let rows = (try? context.fetch(descriptor)) ?? []
+            XCTAssertEqual(rows.count, collectionRowFetchLimit)
+        }
+    }
+
+    /// The Favorites rail. This one fetched *every* favorite across *every*
+    /// playlist and then took `prefix(20)` in Swift: 0.85 ms with no favorites,
+    /// 59 ms with a few thousand, re-run on every write anywhere in the app.
+    /// Guards the `fetchLimit` and the in-SQL playlist scope together.
+    func testFavoritesMovieRail() {
+        let descriptor = MovieCollectionQuery.rowDescriptor(for: .favorites, playlistPrefix: prefix)
+        let context = ModelContext(store.container)
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            let rows = (try? context.fetch(descriptor)) ?? []
+            XCTAssertFalse(rows.isEmpty)
+            XCTAssertLessThanOrEqual(rows.count, collectionRowFetchLimit)
+        }
+    }
+
+    /// Recently Watched, same shape as Favorites but ordered by a date index.
+    func testRecentlyWatchedMovieRail() {
+        let descriptor = MovieCollectionQuery.rowDescriptor(for: .recentlyWatched, playlistPrefix: prefix)
+        let context = ModelContext(store.container)
+
+        measure(metrics: [XCTClockMetric()]) {
+            let rows = (try? context.fetch(descriptor)) ?? []
+            XCTAssertFalse(rows.isEmpty)
+            XCTAssertLessThanOrEqual(rows.count, collectionRowFetchLimit)
+        }
+    }
+
+    /// The "Show All" grid behind Favorites, which is unbounded on purpose — the
+    /// surface that legitimately shows everything. Measured so that "unbounded"
+    /// stays a deliberate cost on one screen rather than something that creeps
+    /// back into the rails.
+    func testFavoritesMovieGrid() {
+        let descriptor = MovieCollectionQuery.gridDescriptor(for: .favorites, playlistPrefix: prefix)
+        let context = ModelContext(store.container)
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            let rows = (try? context.fetch(descriptor)) ?? []
+            XCTAssertFalse(rows.isEmpty)
+        }
+    }
+
+    // MARK: - Live TV section gates
+
+    /// Whether the Favorites rail row should exist at all. The rail used to
+    /// answer this by materializing every favorited channel and filtering in
+    /// Swift — 7.6 ms a call, and the call happened 18-25 times on a cold launch
+    /// of a tab the viewer may never open. It is a `LIMIT 1` probe now.
+    ///
+    /// Also guards the composite `#Index<LiveStream>([\.isFavorite, \.isHidden])`:
+    /// with only the single-column indexes, SQLite picked the `isHidden` one,
+    /// which matches almost every channel in the table.
+    func testLiveFavoritesProbe() {
+        let descriptor = LiveChannelQuery.favoritesProbe(playlistPrefix: prefix, restriction: ContentRestriction())
+        let context = ModelContext(store.container)
+
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0 ..< probeRepeats {
+                let rows = (try? context.fetch(descriptor)) ?? []
+                XCTAssertEqual(rows.count, 1)
+            }
+        }
+    }
+
+    /// The Recently Watched gate. Guards
+    /// `#Index<LiveStream>([\.isHidden, \.lastWatchedDate])` — and its column
+    /// order specifically: the intuitive `[lastWatchedDate, isHidden]` is *not*
+    /// chosen without table statistics, which Core Data never generates, so the
+    /// plan silently falls back to the whole-table `isHidden` index.
+    func testLiveRecentlyWatchedProbe() {
+        let descriptor = LiveChannelQuery.recentlyWatchedProbe(playlistPrefix: prefix, restriction: ContentRestriction())
+        let context = ModelContext(store.container)
+
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0 ..< probeRepeats {
+                let rows = (try? context.fetch(descriptor)) ?? []
+                XCTAssertEqual(rows.count, 1)
+            }
+        }
+    }
+
+    /// The same gate for a viewer with categories locked away, where the
+    /// exclusion set becomes an `IN (…)` clause alongside the index seek. A
+    /// child profile on a large playlist is the worst shape this predicate takes.
+    func testLiveFavoritesProbeWithRestrictions() {
+        let restriction = ContentRestriction(
+            isActive: true,
+            restrictedCategoryIDs: Set((0 ..< 40).map { "\(prefix)live-cat\($0)" }),
+            hiddenCategoryIDs: Set((40 ..< 80).map { "\(prefix)live-cat\($0)" })
+        )
+        let descriptor = LiveChannelQuery.favoritesProbe(playlistPrefix: prefix, restriction: restriction)
+        let context = ModelContext(store.container)
+
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0 ..< probeRepeats {
+                _ = (try? context.fetch(descriptor)) ?? []
+            }
+        }
+    }
+
+    /// A whole live category's channel list — the fetch behind opening a
+    /// category in Live TV, served by `[\.categoryId, \.isHidden]`.
+    func testLiveCategoryChannelList() {
+        let scope = LiveChannelScope.category("\(prefix)live-cat0")
+        let descriptor = LiveChannelQuery.descriptor(for: scope, sort: .playlist)
+        let context = ModelContext(store.container)
+
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            let rows = (try? context.fetch(descriptor)) ?? []
+            XCTAssertFalse(rows.isEmpty)
+        }
+    }
+
+    // MARK: - Category preview
+
+    /// One category preview row on the Movies tab. Four of these mount at once,
+    /// and they re-fetch on every catalog write, so the per-row cost is
+    /// multiplied by four and then by however often something saves.
+    func testMovieCategoryPreviewRow() {
+        let categoryId = "\(prefix)vod-cat0"
+        var descriptor = FetchDescriptor<Movie>(
+            predicate: #Predicate { $0.categoryId == categoryId },
+            sortBy: ContentSortOption.playlist.movieDescriptors
+        )
+        descriptor.fetchLimit = 21
+        let context = ModelContext(store.container)
+
+        measure(metrics: [XCTClockMetric()]) {
+            let rows = (try? context.fetch(descriptor)) ?? []
+            XCTAssertEqual(rows.count, 21)
+        }
+    }
+
+    // MARK: - Search
+
+    /// A common term, which is what every intermediate keystroke of a real query
+    /// looks like. This is the one `sortBy:` guards: with an ORDER BY, SQLite
+    /// must find *and sort* every match before it can apply `LIMIT 50`, so a
+    /// bounded fetch still scanned the whole table. Measured on the real store,
+    /// 66 ms -> 0.4 ms once the sort moved to the 50 hydrated rows.
+    ///
+    /// If this benchmark ever approaches `testSearchRareTerm`, a `sortBy:` has
+    /// come back.
+    func testSearchCommonTerm() {
+        let request = searchRequest(query: "the")
+
+        measure(metrics: [XCTClockMetric()]) {
+            let hits = SearchFetcher.fetch(container: store.container, request: request)
+            XCTAssertEqual(hits.movies.count, request.limit)
+        }
+    }
+
+    /// A term that matches almost nothing. The scan runs to the end whatever the
+    /// sort does, so this is the floor set by `localizedStandardContains` being
+    /// unindexable — the number to beat if a normalized search column ever lands.
+    func testSearchRareTerm() {
+        let request = searchRequest(query: "zzqxv")
+
+        measure(metrics: [XCTClockMetric()]) {
+            let hits = SearchFetcher.fetch(container: store.container, request: request)
+            XCTAssertTrue(hits.movies.isEmpty)
+        }
+    }
+
+    /// Search restricted to the active playlist. The scope used to be a second
+    /// `localizedStandardContains`, on `categoryId` — a full substring search
+    /// used as a prefix test, as expensive again as the name match it was paired
+    /// with. It is a `starts(with:)` on the indexed id now.
+    func testSearchScopedToPlaylist() {
+        let request = searchRequest(query: "the", restrictToPlaylist: true)
+
+        measure(metrics: [XCTClockMetric()]) {
+            let hits = SearchFetcher.fetch(container: store.container, request: request)
+            XCTAssertFalse(hits.movies.isEmpty)
+        }
+    }
+
+    private func searchRequest(query: String, restrictToPlaylist: Bool = false) -> SearchRequest {
+        SearchRequest(
+            query: query,
+            playlistID: playlistID.uuidString,
+            restrictToPlaylist: restrictToPlaylist,
+            wantMovies: true,
+            wantSeries: false,
+            wantLive: false,
+            excludedCategoryIDs: [],
+            limit: 50
+        )
+    }
+
+    // MARK: - Seeding
+
+    /// Builds a catalog shaped like a provider's, across two playlists, with the
+    /// user state the browse predicates actually filter on.
+    ///
+    /// Seeded once per test in `setUp` and never inside a measured block —
+    /// writing these rows costs far more than any query being measured.
+    private func seedCatalog() {
+        let context = ModelContext(store.container)
+        context.autosaveEnabled = false
+
+        let active = Playlist(name: "Active", serverURL: "http://perf.test", username: "u", password: "p")
+        let other = Playlist(name: "Other", serverURL: "http://perf.test", username: "u", password: "p")
+        context.insert(active)
+        context.insert(other)
+        playlistID = active.id
+        otherPlaylistID = other.id
+
+        seedCategories(for: [active, other], in: context)
+        seedMovies(in: context)
+        seedSeries(in: context)
+        seedChannels(in: context)
+
+        try? context.save()
+    }
+
+    private func seedCategories(for playlists: [Playlist], in context: ModelContext) {
+        for playlist in playlists {
+            for index in 0 ..< categoryCount {
+                for kind in [CategoryType.vod, .series, .live] {
+                    context.insert(Lume.Category(
+                        apiId: "cat\(index)",
+                        name: "\(kind.rawValue.uppercased()) Category \(index)",
+                        parentId: 0,
+                        type: kind,
+                        playlist: playlist
+                    ))
+                }
+            }
+        }
+    }
+
+    private func seedMovies(in context: ModelContext) {
+        // Titles carry a common token ("the") and a rare one so search has both
+        // a dense and a sparse case to measure; `added` is a ten-digit Unix
+        // second string, the width Xtream ships and the width that makes a
+        // lexical sort agree with a numeric one.
+        for playlist in [playlistID!, otherPlaylistID!] {
+            let scope = "\(playlist.uuidString)-"
+            let isActive = playlist == playlistID
+            autoreleasepool {
+                for index in 0 ..< movieCount {
+                    let movie = Movie(
+                        id: "\(scope)vod-\(index)",
+                        streamId: index,
+                        name: index.isMultiple(of: 3) ? "The Feature \(index)" : "Feature \(index)",
+                        added: String(1_700_000_000 + index),
+                        num: index,
+                        categoryId: "\(scope)vod-cat\(index % categoryCount)"
+                    )
+                    if isActive, index.isMultiple(of: favoriteEvery) {
+                        movie.isFavorite = true
+                        movie.favoriteOrder = index / favoriteEvery
+                    }
+                    if isActive, index.isMultiple(of: watchedEvery) {
+                        movie.lastWatchedDate = Date(timeIntervalSince1970: 1_800_000_000 - Double(index))
+                        movie.watchProgress = 300
+                    }
+                    context.insert(movie)
+                }
+            }
+        }
+    }
+
+    private func seedSeries(in context: ModelContext) {
+        for playlist in [playlistID!, otherPlaylistID!] {
+            let scope = "\(playlist.uuidString)-"
+            let isActive = playlist == playlistID
+            autoreleasepool {
+                for index in 0 ..< seriesCount {
+                    let show = Series(
+                        id: "\(scope)series-\(index)",
+                        seriesId: index,
+                        name: index.isMultiple(of: 3) ? "The Show \(index)" : "Show \(index)",
+                        lastModified: String(1_700_000_000 + index),
+                        num: index,
+                        categoryId: "\(scope)series-cat\(index % categoryCount)"
+                    )
+                    if isActive, index.isMultiple(of: favoriteEvery) { show.isFavorite = true }
+                    if isActive, index.isMultiple(of: watchedEvery) {
+                        show.lastWatchedDate = Date(timeIntervalSince1970: 1_800_000_000 - Double(index))
+                    }
+                    context.insert(show)
+                }
+            }
+        }
+    }
+
+    private func seedChannels(in context: ModelContext) {
+        for playlist in [playlistID!, otherPlaylistID!] {
+            let scope = "\(playlist.uuidString)-"
+            let isActive = playlist == playlistID
+            autoreleasepool {
+                for index in 0 ..< channelCount {
+                    let stream = LiveStream(
+                        id: "\(scope)live-\(index)",
+                        streamId: index,
+                        name: "Channel \(index)",
+                        num: index,
+                        categoryId: "\(scope)live-cat\(index % categoryCount)"
+                    )
+                    // Hidden channels are the reason the composite indexes exist:
+                    // almost every row is visible, so `isHidden` alone is a
+                    // useless index to seek on.
+                    stream.isHidden = index.isMultiple(of: hiddenEvery)
+                    if isActive, index.isMultiple(of: favoriteEvery), !stream.isHidden {
+                        stream.isFavorite = true
+                        stream.favoriteOrder = index / favoriteEvery
+                    }
+                    if isActive, index.isMultiple(of: watchedEvery), !stream.isHidden {
+                        stream.lastWatchedDate = Date(timeIntervalSince1970: 1_800_000_000 - Double(index))
+                    }
+                    context.insert(stream)
+                }
+            }
+        }
+    }
+}

--- a/LumePerformanceTests/README.md
+++ b/LumePerformanceTests/README.md
@@ -32,7 +32,8 @@ Release would change what ships. Debug, Release and Sideload are untouched.
 
 | Layer | Where | What it catches |
 |---|---|---|
-| Microbenchmarks | `ParsingBenchmarks`, `PersistenceBenchmarks`, `M3UPersistenceBenchmarks`, `EPGQueryBenchmarks` | Parser / import / query regressions |
+| Microbenchmarks | `ParsingBenchmarks`, `PersistenceBenchmarks`, `M3UPersistenceBenchmarks` | Parser / import regressions |
+| Browse read path | `BrowseQueryBenchmarks`, `EPGQueryBenchmarks` | A browse fetch going back to scanning |
 | End-to-end import | `M3UColdImportBenchmarks` | The whole production cold import, phase by phase |
 | Attribution harnesses | `M3UEpisodeRelationshipBenchmarks`, `M3UExistingRowFetchBenchmarks` | Which part of an import loop the time is actually in |
 | Signpost metrics | `SignpostBenchmarks` | A named production phase getting slower |
@@ -44,6 +45,36 @@ diagnostic report the user can export (Settings → Diagnostics). They are liste
 here because they are the same measurement programme: the tests tell you whether
 a phase regressed on your machine, MetricKit and QoE tell you whether it matters
 in the field.
+
+## The browse path has two halves
+
+Import is not the only thing users wait on. A 284k-row catalog made every browse
+interaction expensive too — 1,904 ms of SQL on a cold launch, 739 ms on a tab
+switch, 1,158 ms on a single "Add to Favorites" — and none of it was covered
+here, because every other file in this target measures the sync path.
+
+`BrowseQueryBenchmarks` covers the fetches behind the Movies/Series rails, the
+Live TV section gates, a category preview row and search. What makes those
+regress is unusual, and worth knowing before reading the numbers: they are
+one-token changes that alter **no visible row**. A `sortBy:` added back to a
+bounded fetch, a dropped `fetchLimit`, `comparator: .lexical` lost to the
+`SortDescriptor` default. The app still shows exactly the right content — after
+scanning the whole table — so the change passes review, the unit suite and every
+screenshot.
+
+That shape needs a second, cheaper guard, because a benchmark only catches it if
+somebody runs the benchmark. `LumeTests/Services/BrowseQueryShapeTests.swift`
+asserts the contracts themselves — the limit is set, the probe has no sort, the
+scope is in the predicate, the comparator is lexical — and runs in the normal
+suite on every commit. Both halves were mutation-tested when they were written:
+removing `fetchLimit = 1` from the Live TV probe moved its benchmark
+0.004 s → 0.140 s *and* failed the shape test.
+
+Two benchmarks are deliberately a matched pair. `testSearchCommonTerm` and
+`testSearchRareTerm` measure the same fetch against a dense and a sparse term:
+without an ORDER BY, SQLite stops the scan at the 50th hit, so the common term is
+several times *faster* than the rare one. If they ever converge, a `sortBy:` has
+come back.
 
 ## Signposts are the load-bearing part
 

--- a/LumeTests/Services/BrowseQueryShapeTests.swift
+++ b/LumeTests/Services/BrowseQueryShapeTests.swift
@@ -1,0 +1,236 @@
+//
+//  BrowseQueryShapeTests.swift
+//  LumeTests
+//
+//  The browse fetches have performance contracts that no visible row depends on:
+//  a `fetchLimit` that bounds a rail, a probe with no `sortBy`, a playlist scope
+//  that runs in SQLite instead of in Swift, and a lexical comparator that is the
+//  only reason an index can serve the "Recently Added" sort.
+//
+//  Each of those is one token. Remove it and the app still shows exactly the
+//  right rows — just after scanning the whole table — so the change survives
+//  review, the rest of this suite, and every screenshot. On the measured 284k-row
+//  catalog those same tokens were worth 1,904 -> 774 ms on launch and
+//  1,158 -> 145 ms on a single favorite tap.
+//
+//  `LumePerformanceTests/BrowseQueryBenchmarks.swift` measures what they cost.
+//  These tests just assert they are still there, in the normal suite, on every
+//  commit — which is the half that runs in CI.
+//
+
+import Foundation
+@testable import Lume
+import SwiftData
+import Testing
+
+@MainActor
+struct BrowseQueryShapeTests {
+    private let prefix = "\(UUID().uuidString)-"
+
+    // MARK: - Collection rails are bounded
+
+    /// A preview row renders 20 items. It must never fetch the whole table to
+    /// find them: this was the rail that went from 0.85 ms to 59 ms once a user
+    /// had a few thousand watched titles, re-running on every catalog write.
+    @Test func `every preview row is bounded`() {
+        for kind in [LibraryCollection.Kind.recentlyWatched, .favorites, .recentlyAdded] {
+            #expect(MovieCollectionQuery.rowDescriptor(for: kind, playlistPrefix: prefix).fetchLimit == collectionRowFetchLimit)
+            #expect(SeriesCollectionQuery.rowDescriptor(for: kind, playlistPrefix: prefix).fetchLimit == collectionRowFetchLimit)
+        }
+        #expect(collectionRowFetchLimit > collectionPreviewLimit, "the cap has to leave room for `hasMore`")
+    }
+
+    /// "Show All" is the one surface that legitimately shows everything, so
+    /// Recently Watched and Favorites are unbounded there on purpose. Recently
+    /// Added keeps its cap because its predicate matches the whole catalog —
+    /// every title has an `added` stamp.
+    @Test func `show-all grids are unbounded except recently added`() {
+        #expect(MovieCollectionQuery.gridDescriptor(for: .favorites, playlistPrefix: prefix).fetchLimit == nil)
+        #expect(MovieCollectionQuery.gridDescriptor(for: .recentlyWatched, playlistPrefix: prefix).fetchLimit == nil)
+        #expect(MovieCollectionQuery.gridDescriptor(for: .recentlyAdded, playlistPrefix: prefix).fetchLimit == recentlyAddedFetchLimit)
+    }
+
+    // MARK: - Live TV gates stay probes
+
+    /// Both rail gates answer "is there at least one". They must stay `LIMIT 1`
+    /// with no sort: a `sortBy` makes SQLite find and order every match before
+    /// the limit can apply, which is exactly the work the probe exists to avoid.
+    /// The unbounded version cost 7.6 ms a call, 18-25 times per cold launch, on
+    /// a tab the viewer may never open.
+    @Test func `live tv section gates are limit-one probes with no sort`() {
+        for descriptor in [
+            LiveChannelQuery.favoritesProbe(playlistPrefix: prefix, restriction: ContentRestriction()),
+            LiveChannelQuery.recentlyWatchedProbe(playlistPrefix: prefix, restriction: ContentRestriction())
+        ] {
+            #expect(descriptor.fetchLimit == 1)
+            #expect(descriptor.sortBy.isEmpty)
+        }
+    }
+
+    // MARK: - The lexical comparator
+
+    /// `added` and `lastModified` hold Unix seconds as strings. `SortDescriptor`
+    /// defaults to `.localizedStandard` for String key paths, which compares
+    /// them *numerically* — so this test passes either way on equal-width
+    /// values, and the fixtures below are deliberately unequal in width to tell
+    /// the two comparators apart.
+    ///
+    /// `.lexical` is what matters: it is the only comparator a binary `#Index`
+    /// can serve, and the localized one emits `COLLATE NSCollateFinderlike`,
+    /// which turns the "Recently Added" rail back into `SCAN ZMOVIE` plus a full
+    /// temp B-tree sort — 222 ms per run on a 179k-title catalog.
+    ///
+    /// Real provider data is always ten digits wide, so lexical and numeric
+    /// order agree in production; this asserts which one is configured.
+    @Test func `newest-first sorts movies lexically, not numerically`() {
+        let movies = [
+            Movie(id: "a", streamId: 1, name: "A", added: "100"),
+            Movie(id: "b", streamId: 2, name: "B", added: "50")
+        ]
+        let sorted = movies.sorted(using: ContentSortOption.newest.movieDescriptors)
+        // Lexically "50" > "100"; numerically it is the other way round.
+        #expect(sorted.map(\.id) == ["b", "a"])
+    }
+
+    @Test func `newest-first sorts series lexically, not numerically`() {
+        let shows = [
+            Series(id: "a", seriesId: 1, name: "A", lastModified: "100"),
+            Series(id: "b", seriesId: 2, name: "B", lastModified: "50")
+        ]
+        let sorted = shows.sorted(using: ContentSortOption.newest.seriesDescriptors)
+        #expect(sorted.map(\.id) == ["b", "a"])
+    }
+
+    @Test func `newest-first sorts channels lexically, not numerically`() {
+        let channels = [
+            LiveStream(id: "a", streamId: 1, name: "A", added: "100"),
+            LiveStream(id: "b", streamId: 2, name: "B", added: "50")
+        ]
+        let sorted = channels.sorted(using: ContentSortOption.newest.liveStreamDescriptors)
+        #expect(sorted.map(\.id) == ["b", "a"])
+    }
+
+    // MARK: - The playlist scope runs in SQLite
+
+    /// The rails used to fetch every installed playlist's rows and filter with
+    /// `id.hasPrefix` in Swift afterwards, so a user who added a big playlist
+    /// permanently slowed down their small one. The scope is a predicate now.
+    ///
+    /// Needs an on-disk store: an in-memory one evaluates predicates without
+    /// generating SQL, so a `starts(with:)` that CoreData cannot render would
+    /// pass here and trap on device (see `SearchPredicateTests`).
+    @Test func `collection rails only fetch the active playlist`() throws {
+        let container = try makeSQLiteContainer()
+        let context = ModelContext(container)
+        let mine = "\(UUID().uuidString)-"
+        let theirs = "\(UUID().uuidString)-"
+
+        for (scope, count) in [(mine, 3), (theirs, 5)] {
+            for index in 0 ..< count {
+                let movie = Movie(
+                    id: "\(scope)vod-\(index)",
+                    streamId: index,
+                    name: "Feature \(index)",
+                    added: String(1_700_000_000 + index)
+                )
+                movie.isFavorite = true
+                movie.lastWatchedDate = Date()
+                context.insert(movie)
+            }
+        }
+        try context.save()
+
+        for kind in [LibraryCollection.Kind.favorites, .recentlyWatched, .recentlyAdded] {
+            let rows = try context.fetch(MovieCollectionQuery.rowDescriptor(for: kind, playlistPrefix: mine))
+            #expect(rows.count == 3, "\(kind) leaked rows from another playlist")
+            #expect(rows.allSatisfy { $0.id.hasPrefix(mine) })
+        }
+    }
+
+    /// The same property for the Live TV gates: a favorite in *another* playlist
+    /// must not light up this playlist's Favorites row.
+    @Test func `live tv gates only see the active playlist`() throws {
+        let container = try makeSQLiteContainer()
+        let context = ModelContext(container)
+        let mine = "\(UUID().uuidString)-"
+        let theirs = "\(UUID().uuidString)-"
+
+        let other = LiveStream(id: "\(theirs)live-1", streamId: 1, name: "Theirs")
+        other.isFavorite = true
+        other.lastWatchedDate = Date()
+        context.insert(other)
+        try context.save()
+
+        let restriction = ContentRestriction()
+        #expect(try context.fetch(LiveChannelQuery.favoritesProbe(playlistPrefix: mine, restriction: restriction)).isEmpty)
+        #expect(try context.fetch(LiveChannelQuery.recentlyWatchedProbe(playlistPrefix: mine, restriction: restriction)).isEmpty)
+
+        let ours = LiveStream(id: "\(mine)live-1", streamId: 2, name: "Ours")
+        ours.isFavorite = true
+        ours.lastWatchedDate = Date()
+        context.insert(ours)
+        try context.save()
+
+        #expect(try context.fetch(LiveChannelQuery.favoritesProbe(playlistPrefix: mine, restriction: restriction)).count == 1)
+        #expect(try context.fetch(LiveChannelQuery.recentlyWatchedProbe(playlistPrefix: mine, restriction: restriction)).count == 1)
+    }
+
+    /// A hidden channel is the only favorite: the gate must report empty, or the
+    /// rail offers a section whose list then renders nothing.
+    @Test func `live tv gates respect channel visibility`() throws {
+        let container = try makeSQLiteContainer()
+        let context = ModelContext(container)
+        let mine = "\(UUID().uuidString)-"
+
+        let hidden = LiveStream(id: "\(mine)live-1", streamId: 1, name: "Hidden")
+        hidden.isFavorite = true
+        hidden.isHidden = true
+        context.insert(hidden)
+        try context.save()
+
+        let probe = LiveChannelQuery.favoritesProbe(playlistPrefix: mine, restriction: ContentRestriction())
+        #expect(try context.fetch(probe).isEmpty)
+    }
+
+    /// The restriction has to be *in* the predicate. With `fetchLimit = 1` and a
+    /// Swift-side check, a single restricted row coming back would call the
+    /// whole collection empty and drop a section full of visible channels.
+    @Test func `a restricted-only favorite does not light up the rail`() throws {
+        let container = try makeSQLiteContainer()
+        let context = ModelContext(container)
+        let mine = "\(UUID().uuidString)-"
+        let locked = "\(mine)live-locked"
+
+        let stream = LiveStream(id: "\(mine)live-1", streamId: 1, name: "Locked", categoryId: locked)
+        stream.isFavorite = true
+        context.insert(stream)
+        try context.save()
+
+        let restriction = ContentRestriction(isActive: true, restrictedCategoryIDs: [locked])
+        let probe = LiveChannelQuery.favoritesProbe(playlistPrefix: mine, restriction: restriction)
+        #expect(try context.fetch(probe).isEmpty)
+
+        // …and is offered again to a viewer the lock does not apply to.
+        let parent = LiveChannelQuery.favoritesProbe(playlistPrefix: mine, restriction: ContentRestriction())
+        #expect(try context.fetch(parent).count == 1)
+    }
+
+    // MARK: - Helpers
+
+    /// The container must be held for the test's duration — see
+    /// `SearchPredicateTests` for what happens when it is not.
+    private func makeSQLiteContainer() throws -> ModelContainer {
+        let schema = Schema([
+            Playlist.self, Lume.Category.self, LiveStream.self, Movie.self,
+            Series.self, Episode.self, CastMember.self, EPGListing.self, EPGSource.self
+        ])
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("catalog.store")
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        let config = ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+}


### PR DESCRIPTION
Follow-up to #224. Answers "can we catch it if this regresses?" — it couldn't, and now it can.

## Why this wasn't covered

The performance target measures the **sync and import** path: nine of its ten files are parsing, persistence and m3u import. `EPGQueryBenchmarks` is the only read-side suite and it covers the two guide loaders. The fetches behind browsing — the Movies/Series rails, the Live TV section gates, a category preview row, search — had nothing.

Which is to say: everything #224 fixed was unguarded.

## The awkward part

These regress differently from import code. Every one of them is **one token**, and removing it changes **no visible row**:

- a `sortBy:` added back to a bounded fetch
- a dropped `fetchLimit`
- `comparator: .lexical` lost to the `SortDescriptor` default
- a playlist scope moved back out of the predicate into a Swift `filter`

The app still shows exactly the right content — it just scans the whole table to find it. That passes review, passes the unit suite, and looks identical in every screenshot. On the measured 284k-row catalog those same tokens were worth 1,904 → 774 ms on launch and 1,158 → 145 ms on one favorite tap.

So a benchmark alone isn't enough, because a benchmark only helps if someone runs it.

## Two halves

**`LumePerformanceTests/BrowseQueryBenchmarks.swift`** — 11 benchmarks measuring the cost, against a seeded 20k-movie / 6k-series / 8k-channel catalog across **two** playlists (the scoping bug is invisible with one), with favorites, watch history and hidden channels in the proportions the audit measured on a real heavy-user store.

Two are deliberately a matched pair:

| | |
|---|---|
| `testSearchCommonTerm` | **3 ms** |
| `testSearchRareTerm` | **15 ms** |

Without an `ORDER BY`, SQLite stops the scan at the 50th hit, so the *common* term is five times faster than the rare one. If those two ever converge, a `sortBy:` has come back.

**`LumeTests/Services/BrowseQueryShapeTests.swift`** — 10 tests asserting the contracts themselves: the limit is set, the probe is `LIMIT 1` with no sort, the scope is in the predicate, the comparator is lexical. These run in the normal suite on every commit, cost 0.12 s total, and need nobody to remember anything.

## Mutation-tested, not assumed

A guard that can't fail is decoration, so each was verified by breaking the thing it protects:

| Mutation | Benchmark | Shape test |
|---|---|---|
| `fetchLimit = 1` removed from the Live TV probe | 0.004 s → **0.140 s** (35×) | — (its own assertion also failed: 189 rows, not 1) |
| `comparator: .lexical` removed | — | ✗ `["a","b"] == ["b","a"]` |
| rail `fetchLimit` removed | — | ✗ `nil == 200` |

## One production change

`MovieCollectionQuery` / `SeriesCollectionQuery` and the three row limits go from `private` to internal so the tests can reach them — the same reason the search predicates in `SearchFetching.swift` already are, and with a comment saying so. No behaviour change.

## Verified

- 1,188 unit tests pass (`-parallel-testing-enabled NO`).
- `Scripts/run-performance-tests.sh BrowseQueryBenchmarks` — 11 benchmarks, all passing, rsd 2–11%.
- iOS, tvOS and macOS build. SwiftFormat + SwiftLint `--strict` clean.
- `LumePerformanceTests/README.md` gains the browse layer, why it needs two halves, and the matched-pair note.

## Not done

No CI gate — the README already explains why absolute numbers are only comparable on the same machine at the same thermal state. The shape tests are the part that gates.

Still no signposts on the browse path (`PerformanceSignposts.swift` names 38 phases, all sync/EPG/playback). That would extend this to field telemetry via MetricKit rather than a dev machine, and is the natural next step — but it touches production code, so it isn't in here.

https://claude.ai/code/session_01NHCFpqKQcVCXqdkcrcZU8k
