### PR TITLE
fix(indexing): give tvOS an embedding model that actually loads

### DIFF
--- a/Lume/Services/Indexing/ContentIndexText.swift
+++ b/Lume/Services/Indexing/ContentIndexText.swift
@@ -105,6 +105,30 @@ nonisolated enum ContentIndexText {
         return parts.joined(separator: " ")
     }
 
+    /// The short form of the embedding document: just the title, year and
+    /// genre.
+    ///
+    /// For the coarse `NLEmbedding` sentence backend (tvOS), which the long
+    /// document defeats — the tagline, plot and cast dilute the few words that
+    /// actually distinguish one title from another until every pair of titles
+    /// sits at the same cosine. See `TextEmbedder.prefersShortDocuments` for
+    /// the measured margins.
+    static func shortDocument(for facts: TitleFacts) -> String {
+        var parts: [String] = []
+
+        var title = facts.name
+        if let year = facts.year {
+            title += " (\(year))"
+        }
+        parts.append(title + ".")
+
+        if let genre = facts.genre, !genre.isEmpty {
+            parts.append(genre + ".")
+        }
+
+        return parts.joined(separator: " ")
+    }
+
     /// Parses a year out of a provider release-date string ("2010-07-16",
     /// "2010").
     static func year(fromReleaseDate releaseDate: String?) -> Int? {

--- a/Lume/Services/Indexing/ContentIndexer.swift
+++ b/Lume/Services/Indexing/ContentIndexer.swift
@@ -5,7 +5,11 @@
 //  Builds the local content index: resolves each movie and series against
 //  TMDB (searching by cleaned title when the provider supplies no id), applies
 //  the same enrichment the detail screens use, and stores an on-device
-//  embedding vector for future semantic search.
+//  embedding vector that "For You" ranks against.
+//
+//  Which embedding model that is depends on the platform (`TextEmbedder`), and
+//  the two produce incomparable vectors — so the pass stamps the vector space it
+//  used and drops everything it can no longer compare when that changes.
 //
 //  Designed to run slowly in the background: items are processed in small
 //  chunks on a dedicated ModelContext with pauses in between, so neither TMDB
@@ -48,6 +52,12 @@ actor ContentIndexer {
     /// the run (which would stall indexing until the next launch or sync).
     private let assetRetryPause: Duration = .seconds(15)
     private let assetRetryMaxPause: Duration = .seconds(300)
+    /// How many times one pass asks for the assets before giving up and ending
+    /// as `.unavailable`. Bounded on purpose — see `prepareEmbedder`.
+    private let assetRetryLimit = 5
+    /// Rows per batch when dropping embeddings the engine can no longer compare
+    /// — see `resetEmbeddingsIfSpaceChanged`.
+    private let resetBatchSize = 5000
 
     init(modelContainer: ModelContainer, tmdbClient: TMDBClient? = nil) {
         self.modelContainer = modelContainer
@@ -76,6 +86,26 @@ actor ContentIndexer {
     /// an unavailable embedding model, or on a transient network failure (the
     /// next kick retries — already-indexed items are never reprocessed).
     func run(status: ContentIndexingService) async throws {
+        // Which backend, and therefore which vector space, is settled first:
+        // choosing costs nothing (no assets, no load, no network) and the
+        // "already done" check below is only meaningful against the *current*
+        // space — a catalog embedded by the other backend is fully stamped and
+        // entirely unusable, and has to re-open the pass.
+        let embedder = try TextEmbedder.preferred()
+        // Release the model the moment the pass ends — completion, cancellation,
+        // or throw — so the tens-of-MB embedding model isn't left resident between
+        // passes or while the app is suspended in the background.
+        defer { embedder.unload() }
+
+        if EmbeddingSpaceStore.needsReset(to: embedder.spaceID) {
+            // Behind the same gate as everything else that saves: this writes
+            // across the catalog, and `LumeApp` kicks a pass while Home is still
+            // fetching its rails.
+            try await waitWhileBusy(status: status)
+            try dropStaleEmbeddings()
+        }
+        EmbeddingSpaceStore.set(embedder.spaceID)
+
         var counts = try currentCounts()
         await status.update(indexed: counts.indexed, total: counts.total)
         guard counts.indexed < counts.total else {
@@ -89,11 +119,6 @@ actor ContentIndexer {
         try await waitWhileBusy(status: status)
 
         await status.setPreparing()
-        let embedder = try TextEmbedder()
-        // Release the model the moment the pass ends — completion, cancellation,
-        // or throw — so the tens-of-MB embedding model isn't left resident between
-        // passes or while the app is suspended in the background.
-        defer { embedder.unload() }
         try await prepareEmbedder(embedder, status: status)
 
         while !Task.isCancelled {
@@ -136,18 +161,25 @@ actor ContentIndexer {
     /// download. The on-device asset request times out on slow connections;
     /// rather than abandoning the pass (which leaves indexing stalled until the
     /// next launch or sync) we back off and try again — the download usually
-    /// succeeds on a later attempt. A model that genuinely has no assets for
-    /// this device throws `EmbedderError`, which ends the run for good.
+    /// succeeds on a later attempt.
+    ///
+    /// Bounded, though. Retrying forever is how an unserved asset turns into a
+    /// pass that sits in `.preparing`/`.waiting` for the life of the process
+    /// without ever indexing a title. After `assetRetryLimit` attempts the run
+    /// ends as `.unavailable`; the next launch tries again from scratch.
+    /// `modelUnavailable` — no model for this device at all — ends it
+    /// immediately, since no amount of waiting fixes that.
     private func prepareEmbedder(_ embedder: TextEmbedder, status: ContentIndexingService) async throws {
         var pause = assetRetryPause
-        while true {
+        for attempt in 1 ... assetRetryLimit {
             try Task.checkCancellation()
             do {
                 try await embedder.prepare()
                 return
-            } catch let error as TextEmbedder.EmbedderError {
-                throw error
+            } catch TextEmbedder.EmbedderError.modelUnavailable {
+                throw TextEmbedder.EmbedderError.modelUnavailable
             } catch {
+                guard attempt < assetRetryLimit else { break }
                 let seconds = pause.components.seconds
                 Logger.indexing.warning("Embedding asset download failed, retrying in \(seconds)s: \(error)")
                 await status.setWaiting()
@@ -156,6 +188,57 @@ actor ContentIndexer {
                 await status.setPreparing()
             }
         }
+        // Local copy: SwiftFormat strips `self.` inside the autoclosure and the
+        // build then fails on the implicit capture (see CLAUDE.md).
+        let attempts = assetRetryLimit
+        Logger.indexing.error("Embedding assets unavailable after \(attempts) attempts")
+        throw TextEmbedder.EmbedderError.assetsUnavailable
+    }
+
+    // MARK: - Vector space
+
+    /// Drops every stored embedding, so the next chunks rebuild them in the
+    /// space the engine now compares in. Called when the backend changed under
+    /// the store — see `EmbeddingSpaceStore` for why that is otherwise invisible.
+    ///
+    /// `indexedAt` is cleared alongside `embeddingData` because it is the "this
+    /// title is done" marker `fetchPending` reads; `tmdbId` and the enrichment
+    /// stamp are deliberately left in place, so the rebuild costs no TMDB
+    /// traffic — `resolve` short-circuits on both and the items flow straight
+    /// through to `write`.
+    private func dropStaleEmbeddings() throws {
+        // Drained in batches on a fresh context each time, not fetched whole: a
+        // fully indexed catalog is hundreds of thousands of rows, and realising
+        // them all at once is exactly the kind of spike that gets an Apple TV
+        // jetsammed. Clearing the column shrinks the predicate's own result set,
+        // so each pass sees only what is left.
+        var dropped = 0
+        while true {
+            let context = ModelContext(modelContainer)
+            context.autosaveEnabled = false
+
+            var movies = FetchDescriptor<Movie>(predicate: #Predicate { $0.embeddingData != nil })
+            movies.fetchLimit = resetBatchSize
+            var series = FetchDescriptor<Series>(predicate: #Predicate { $0.embeddingData != nil })
+            series.fetchLimit = resetBatchSize
+
+            let staleMovies = try context.fetch(movies)
+            let staleSeries = try context.fetch(series)
+            if staleMovies.isEmpty, staleSeries.isEmpty { break }
+
+            for movie in staleMovies {
+                movie.embeddingData = nil
+                movie.indexedAt = nil
+            }
+            for show in staleSeries {
+                show.embeddingData = nil
+                show.indexedAt = nil
+            }
+            try context.save()
+            dropped += staleMovies.count + staleSeries.count
+        }
+
+        Logger.indexing.info("Embedding space changed; dropped \(dropped) vectors for re-embedding")
     }
 
     // MARK: - Chunk processing
@@ -180,6 +263,11 @@ actor ContentIndexer {
         let item: PendingItem
         let resolvedTMDBId: Int?
         let details: TMDBTitleDetails?
+        /// Whether resolving actually issued a TMDB request. False when the id
+        /// and enrichment were already stored, which is the whole of a re-embed
+        /// pass (see `resetEmbeddingsIfSpaceChanged`) — `itemPause` exists to
+        /// rate-limit TMDB, so an item that never touched it shouldn't wait.
+        let usedNetwork: Bool
     }
 
     /// Indexes up to `chunkSize` pending titles (movies first, then series).
@@ -205,8 +293,11 @@ actor ContentIndexer {
         for item in pending {
             do {
                 try Task.checkCancellation()
-                try await resolved.append(resolve(item))
-                try await Task.sleep(for: itemPause)
+                let result = try await resolve(item)
+                resolved.append(result)
+                if result.usedNetwork {
+                    try await Task.sleep(for: itemPause)
+                }
             } catch {
                 // Transient failure or cancellation: stop fetching, but still
                 // write the items already resolved so progress isn't lost.
@@ -279,11 +370,15 @@ actor ContentIndexer {
     /// (when not yet enriched) over the network, working only on values.
     private func resolve(_ item: PendingItem) async throws -> IndexResult {
         guard tmdbClient.isConfigured else {
-            return IndexResult(item: item, resolvedTMDBId: item.existingTMDBId, details: nil)
+            return IndexResult(
+                item: item, resolvedTMDBId: item.existingTMDBId, details: nil, usedNetwork: false
+            )
         }
 
+        var usedNetwork = false
         var tmdbId = item.existingTMDBId
         if tmdbId == nil {
+            usedNetwork = true
             tmdbId = try await skippingPermanentFailures {
                 switch item.kind {
                 case .movie: try await self.searchMovieID(query: item.title, year: item.year)
@@ -294,6 +389,7 @@ actor ContentIndexer {
 
         var details: TMDBTitleDetails?
         if item.needsEnrichment, let tmdbId {
+            usedNetwork = true
             details = try await skippingPermanentFailures {
                 switch item.kind {
                 case .movie: try await self.tmdbClient.movieDetails(tmdbId)
@@ -302,7 +398,9 @@ actor ContentIndexer {
             }
         }
 
-        return IndexResult(item: item, resolvedTMDBId: tmdbId, details: details)
+        return IndexResult(
+            item: item, resolvedTMDBId: tmdbId, details: details, usedNetwork: usedNetwork
+        )
     }
 
     /// Re-fetches the title on the write context and applies the resolved TMDB
@@ -326,14 +424,14 @@ actor ContentIndexer {
                 // detail view fully enriches (incl. cast) on first open.
                 applyMovieDetails(details, to: movie, context: context, includeCast: false)
             }
-            let document = ContentIndexText.document(for: .init(
+            let document = Self.document(for: .init(
                 name: result.item.title,
                 year: result.item.year,
                 genre: movie.genre,
                 tagline: movie.tagline,
                 plot: movie.plot,
                 cast: movie.actors
-            ))
+            ), embedder: embedder)
             if let vector = try? embedder.vector(for: document) {
                 movie.embeddingData = TextEmbedder.encode(vector)
             }
@@ -354,19 +452,31 @@ actor ContentIndexer {
                 // string; the detail view fully enriches (incl. cast) later.
                 applySeriesDetails(details, to: series, context: context, includeCast: false)
             }
-            let document = ContentIndexText.document(for: .init(
+            let document = Self.document(for: .init(
                 name: result.item.title,
                 year: result.item.year,
                 genre: series.genre,
                 tagline: series.tagline,
                 plot: series.plot,
                 cast: series.cast
-            ))
+            ), embedder: embedder)
             if let vector = try? embedder.vector(for: document) {
                 series.embeddingData = TextEmbedder.encode(vector)
             }
             series.indexedAt = Date()
         }
+    }
+
+    /// The document to embed for a title, in the shape this embedder's backend
+    /// can actually use. The coarse sentence backend (tvOS) drowns in a full
+    /// plot + cast document — see `TextEmbedder.prefersShortDocuments`.
+    private static func document(
+        for facts: ContentIndexText.TitleFacts,
+        embedder: TextEmbedder
+    ) -> String {
+        embedder.prefersShortDocuments
+            ? ContentIndexText.shortDocument(for: facts)
+            : ContentIndexText.document(for: facts)
     }
 
     // MARK: - TMDB search with year fallback

--- a/Lume/Services/Indexing/EmbeddingSpaceStore.swift
+++ b/Lume/Services/Indexing/EmbeddingSpaceStore.swift
@@ -1,0 +1,42 @@
+//
+//  EmbeddingSpaceStore.swift
+//  Lume
+//
+//  Remembers which vector space the stored embeddings were produced in.
+//
+//  `TextEmbedder` has two backends and they are not interchangeable: a cosine
+//  between a contextual vector and a sentence vector is meaningless, and both
+//  happen to be 512-dimensional, so nothing about the blob itself gives the
+//  mismatch away. If the backend ever changes under an existing store — a
+//  device that indexed on an older build, a platform whose model support
+//  changes — every recommendation silently becomes noise.
+//
+//  So the indexer stamps the space it used and, on a mismatch, drops the
+//  embeddings it can no longer compare so the next pass rebuilds them. Cheap in
+//  practice: the backend is a platform constant, so this fires at most once per
+//  device, and re-embedding costs no TMDB traffic (the ids and enrichment are
+//  already stored — see `ContentIndexer.resolve`).
+//
+
+import Foundation
+
+nonisolated enum EmbeddingSpaceStore {
+    private static let key = "contentIndex.embeddingSpaceID"
+
+    /// The space the stored embeddings were produced in, or nil before the
+    /// first pass ever completed a chunk.
+    static func current(in defaults: UserDefaults = .standard) -> String? {
+        defaults.string(forKey: key)
+    }
+
+    static func set(_ spaceID: String, in defaults: UserDefaults = .standard) {
+        defaults.set(spaceID, forKey: key)
+    }
+
+    /// True when the stored embeddings came from a *different* backend and must
+    /// be rebuilt. False on a first run: there is nothing stored to invalidate.
+    static func needsReset(to spaceID: String, in defaults: UserDefaults = .standard) -> Bool {
+        guard let stored = current(in: defaults) else { return false }
+        return stored != spaceID
+    }
+}

--- a/Lume/Services/Indexing/TextEmbedder.swift
+++ b/Lume/Services/Indexing/TextEmbedder.swift
@@ -2,38 +2,133 @@
 //  TextEmbedder.swift
 //  Lume
 //
-//  Wraps NLContextualEmbedding to turn index documents into fixed-size
-//  vectors for on-device semantic search. The model assets download
-//  over-the-air on first use; `prepare()` must succeed before `vector(for:)`.
+//  Turns index documents into fixed-size vectors for the on-device
+//  recommendation engine (and future semantic search).
+//
+//  Two backends, because the good one isn't available on every platform:
+//
+//  • `NLContextualEmbedding` (transformer, 512-dim, multilingual) is the
+//    preferred model. Its assets download over the air on first use.
+//  • `NLEmbedding.sentenceEmbedding(for: .english)` is the tvOS backend:
+//    bundled with the OS, nothing to download, but much coarser — it only
+//    separates titles when the document is SHORT, which is what
+//    `prefersShortDocuments` is for.
+//
+//  **tvOS serves no contextual assets.** Measured on tvOS 26.5:
+//  `NLContextualEmbedding(script: .latin)` constructs fine, but
+//  `hasAvailableAssets` is false and `requestAssets` never calls its completion
+//  handler — not an error, not a timeout, nothing. The old code awaited that
+//  handler, so every Apple TV sat in `.preparing` forever, indexed zero titles
+//  and left "For You" permanently empty. The backend is therefore chosen at
+//  compile time on tvOS rather than discovered at runtime.
+//
+//  `requestAssets` is still wrapped in a timeout on the other platforms: a call
+//  that never returns would wedge the pass the same way, and the caller's
+//  retry/backoff handles a genuinely slow download.
+//
+//  Backends produce vectors in *different, incomparable* spaces, so each one
+//  publishes a `spaceID` and `ContentIndexer` re-embeds the catalog whenever it
+//  changes.
 //
 
 import Foundation
 import NaturalLanguage
+import os
 
 final nonisolated class TextEmbedder {
     enum EmbedderError: Error {
-        /// No contextual embedding model exists for the script on this device.
+        /// No embedding model of any kind exists for this device.
         case modelUnavailable
         /// Model assets are not on-device and could not be downloaded.
         case assetsUnavailable
+        /// The asset request never came back — see the type comment.
+        case assetRequestTimedOut
     }
 
-    private let embedding: NLContextualEmbedding
+    private enum Backend {
+        case contextual(NLContextualEmbedding)
+        case sentence(NLEmbedding)
+    }
 
-    /// The Latin-script model covers all languages the app localizes to
-    /// (English, German) plus most other European languages in one shared
-    /// vector space, so documents and future search queries stay comparable.
-    init() throws {
+    /// How long to wait for `requestAssets` before giving up on this attempt.
+    /// The caller retries with backoff, so this only has to be longer than a
+    /// realistic download, not longer than the worst connection.
+    private static let assetRequestTimeout: Duration = .seconds(120)
+
+    private let backend: Backend
+
+    /// Identifies the vector space this embedder produces. Vectors from two
+    /// different spaces are not comparable, so `ContentIndexer` stores this
+    /// alongside the index and re-embeds the catalog when it changes.
+    let spaceID: String
+
+    /// True when long documents degrade the vector, so the indexer should embed
+    /// `ContentIndexText.shortDocument` instead of the full one.
+    ///
+    /// Measured on tvOS 26.5 over 8 titles in 4 genre pairs, as the gap between
+    /// the mean same-genre and mean cross-genre cosine: `title (year). genre.`
+    /// scores 0.118, the full `+ tagline + plot + cast` document 0.003 — i.e.
+    /// the long document is pure noise through this model. (The contextual
+    /// model has no such problem, which is why this is per-backend.)
+    let prefersShortDocuments: Bool
+
+    private init(backend: Backend) {
+        self.backend = backend
+        switch backend {
+        case let .contextual(embedding):
+            spaceID = "contextual-\(embedding.modelIdentifier)"
+            prefersShortDocuments = false
+        case let .sentence(embedding):
+            spaceID = "sentence-en-\(embedding.dimension)"
+            prefersShortDocuments = true
+        }
+    }
+
+    /// The embedder to index with on this platform.
+    ///
+    /// tvOS gets the sentence model outright — see the type comment: the
+    /// contextual model's assets are never served there and asking for them
+    /// hangs. Everywhere else the contextual model is the only choice, so that
+    /// one device can never end up with a catalog embedded half in each space.
+    static func preferred() throws -> TextEmbedder {
+        #if os(tvOS)
+            try sentence()
+        #else
+            try contextual()
+        #endif
+    }
+
+    /// The contextual (preferred) embedder. The Latin-script model covers every
+    /// language the app localizes to plus most other European ones in one shared
+    /// vector space. `prepare()` must succeed before `vector(for:)`.
+    static func contextual() throws -> TextEmbedder {
         guard let embedding = NLContextualEmbedding(script: .latin) else {
             throw EmbedderError.modelUnavailable
         }
-        self.embedding = embedding
+        return TextEmbedder(backend: .contextual(embedding))
+    }
+
+    /// The bundled English sentence embedder. Needs no `prepare()` work, no
+    /// network and no assets — but see `prefersShortDocuments`.
+    ///
+    /// English-only in name, and that matters less than it sounds for the short
+    /// document: measured on tvOS 26.5, German `title (year). genre.` documents
+    /// separate at a 0.097 margin against 0.118 for the same titles in English,
+    /// because the genre words carry the signal and most are cognates. Not worth
+    /// a second, English-language TMDB fetch per title (which would also
+    /// overwrite the localized genre the user sees).
+    static func sentence() throws -> TextEmbedder {
+        guard let embedding = NLEmbedding.sentenceEmbedding(for: .english) else {
+            throw EmbedderError.modelUnavailable
+        }
+        return TextEmbedder(backend: .sentence(embedding))
     }
 
     /// Downloads the model assets if needed and loads the model into memory.
     func prepare() async throws {
+        guard case let .contextual(embedding) = backend else { return }
         if !embedding.hasAvailableAssets {
-            let result = try await embedding.requestAssets()
+            let result = try await Self.requestAssets(for: embedding)
             guard result == .available else {
                 throw EmbedderError.assetsUnavailable
             }
@@ -41,29 +136,74 @@ final nonisolated class TextEmbedder {
         try embedding.load()
     }
 
-    /// Frees the loaded model from memory. The model is tens of MB resident; call
-    /// this when an indexing pass ends so it isn't left loaded between passes (and
-    /// while the app sits in the background as a jetsam target). Idempotent and
-    /// safe whether or not `prepare()` loaded the model.
+    /// `requestAssets`, bounded by `assetRequestTimeout`. Deliberately not a
+    /// task group racing a sleep: cancelling a group waits for its children, and
+    /// the child awaiting a completion handler that never fires would never
+    /// finish — reintroducing the exact hang this guards against.
+    private static func requestAssets(
+        for embedding: NLContextualEmbedding
+    ) async throws -> NLContextualEmbedding.AssetsResult {
+        let hasResumed = OSAllocatedUnfairLock(initialState: false)
+        return try await withCheckedThrowingContinuation { continuation in
+            /// Resumes at most once, whichever of the two paths gets there first.
+            func finish(_ body: () -> Void) {
+                let first = hasResumed.withLock { resumed -> Bool in
+                    defer { resumed = true }
+                    return !resumed
+                }
+                if first { body() }
+            }
+
+            embedding.requestAssets { result, error in
+                finish {
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: result)
+                    }
+                }
+            }
+
+            DispatchQueue.global(qos: .utility).asyncAfter(
+                deadline: .now() + Double(assetRequestTimeout.components.seconds)
+            ) {
+                finish { continuation.resume(throwing: EmbedderError.assetRequestTimedOut) }
+            }
+        }
+    }
+
+    /// Frees the loaded model from memory. The contextual model is tens of MB
+    /// resident; call this when an indexing pass ends so it isn't left loaded
+    /// between passes (and while the app sits in the background as a jetsam
+    /// target). Idempotent and safe whether or not `prepare()` loaded a model.
     func unload() {
-        embedding.unload()
+        if case let .contextual(embedding) = backend {
+            embedding.unload()
+        }
     }
 
     /// Mean-pooled sentence vector for `text`. Returns nil when the model
     /// produces no tokens (e.g. empty input).
     func vector(for text: String) throws -> [Float]? {
-        let result = try embedding.embeddingResult(for: text, language: nil)
-        var sum = [Double](repeating: 0, count: embedding.dimension)
-        var tokenCount = 0
-        result.enumerateTokenVectors(in: text.startIndex ..< text.endIndex) { vector, _ in
-            for (index, value) in vector.enumerated() where index < sum.count {
-                sum[index] += value
+        switch backend {
+        case let .contextual(embedding):
+            let result = try embedding.embeddingResult(for: text, language: nil)
+            var sum = [Double](repeating: 0, count: embedding.dimension)
+            var tokenCount = 0
+            result.enumerateTokenVectors(in: text.startIndex ..< text.endIndex) { vector, _ in
+                for (index, value) in vector.enumerated() where index < sum.count {
+                    sum[index] += value
+                }
+                tokenCount += 1
+                return true
             }
-            tokenCount += 1
-            return true
+            guard tokenCount > 0 else { return nil }
+            return sum.map { Float($0 / Double(tokenCount)) }
+
+        case let .sentence(embedding):
+            guard let vector = embedding.vector(for: text) else { return nil }
+            return vector.map(Float.init)
         }
-        guard tokenCount > 0 else { return nil }
-        return sum.map { Float($0 / Double(tokenCount)) }
     }
 
     // MARK: - Vector blob coding

--- a/LumeTests/Services/ContentIndexTextTests.swift
+++ b/LumeTests/Services/ContentIndexTextTests.swift
@@ -100,6 +100,45 @@ struct ContentIndexTextTests {
         #expect(ContentIndexText.year(fromReleaseDate: "unknown") == nil)
     }
 
+    // MARK: - shortDocument
+
+    @Test func `short document keeps only title, year and genre`() {
+        let document = ContentIndexText.shortDocument(for: .init(
+            name: "Inception",
+            year: 2010,
+            genre: "Action, Science Fiction",
+            tagline: "Your mind is the scene of the crime.",
+            plot: "A thief who steals corporate secrets through dream-sharing technology.",
+            cast: "Leonardo DiCaprio, Joseph Gordon-Levitt"
+        ))
+        #expect(document == "Inception (2010). Action, Science Fiction.")
+    }
+
+    @Test func `short document skips empty parts`() {
+        let document = ContentIndexText.shortDocument(for: .init(
+            name: "Inception",
+            year: nil,
+            genre: "",
+            tagline: nil,
+            plot: nil,
+            cast: nil
+        ))
+        #expect(document == "Inception.")
+    }
+
+    @Test func `short document is a prefix of the full document`() {
+        let facts = ContentIndexText.TitleFacts(
+            name: "Inception",
+            year: 2010,
+            genre: "Action",
+            tagline: "Your mind is the scene of the crime.",
+            plot: "A thief who steals corporate secrets.",
+            cast: "Leonardo DiCaprio"
+        )
+        #expect(ContentIndexText.document(for: facts)
+            .hasPrefix(ContentIndexText.shortDocument(for: facts)))
+    }
+
     // MARK: - Embedding blob coding
 
     @Test func `vector blob roundtrips`() {

--- a/LumeTests/Services/TextEmbedderTests.swift
+++ b/LumeTests/Services/TextEmbedderTests.swift
@@ -1,0 +1,101 @@
+//
+//  TextEmbedderTests.swift
+//  LumeTests
+//
+//  Covers the two-backend embedder and the vector-space bookkeeping that keeps
+//  the recommendation engine from comparing vectors it cannot compare.
+//
+//  The tests run on the iOS simulator only (see CLAUDE.md), so the tvOS branch
+//  of `TextEmbedder.preferred()` cannot be exercised here — what *is* covered is
+//  everything the tvOS path depends on: that the sentence backend loads with no
+//  assets and no network, that it produces usable vectors, that it is stamped
+//  with its own space id, and that a space change invalidates the store.
+//
+
+import Foundation
+@testable import Lume
+import Testing
+
+struct TextEmbedderTests {
+    // MARK: - Backends
+
+    @Test func `sentence backend needs no assets and no prepare`() async throws {
+        let embedder = try TextEmbedder.sentence()
+        // Must not hang, throw or reach the network — this is the whole point
+        // of the backend on tvOS, where contextual assets are never served.
+        try await embedder.prepare()
+        let embedded = try embedder.vector(for: "Inception (2010). Action, Science Fiction.")
+        let vector = try #require(embedded)
+        #expect(vector.count > 0)
+        #expect(vector.contains { $0 != 0 })
+    }
+
+    @Test func `sentence backend separates genres in short documents`() throws {
+        let embedder = try TextEmbedder.sentence()
+        func vector(_ text: String) throws -> [Float] {
+            let vector = try embedder.vector(for: text)
+            return try #require(vector)
+        }
+        let nemo = try vector("Finding Nemo (2003). Animation, Family, Adventure.")
+        let toyStory = try vector("Toy Story (1995). Animation, Family, Adventure.")
+        let godfather = try vector("The Godfather (1972). Crime, Drama.")
+
+        // Same genre must sit closer than a different one, measured with the
+        // very function "For You" ranks on. If this inverts, the backend is
+        // useless and the row fills with noise.
+        #expect(RecommendationScoring.cosineSimilarity(nemo, toyStory)
+            > RecommendationScoring.cosineSimilarity(nemo, godfather))
+    }
+
+    @Test func `sentence backend prefers short documents`() throws {
+        #expect(try TextEmbedder.sentence().prefersShortDocuments)
+    }
+
+    @Test func `backends occupy different vector spaces`() throws {
+        let sentence = try TextEmbedder.sentence()
+        // Not available on every host; skip rather than fail when it isn't.
+        guard let contextual = try? TextEmbedder.contextual() else { return }
+        #expect(sentence.spaceID != contextual.spaceID)
+        #expect(!contextual.prefersShortDocuments)
+    }
+
+    @Test func `unload is safe on a backend that was never prepared`() throws {
+        try TextEmbedder.sentence().unload()
+        try TextEmbedder.sentence().unload()
+    }
+
+    // MARK: - Space bookkeeping
+
+    @Test func `first run has nothing to invalidate`() throws {
+        let defaults = try makeDefaults()
+        #expect(EmbeddingSpaceStore.current(in: defaults) == nil)
+        #expect(!EmbeddingSpaceStore.needsReset(to: "sentence-en-512", in: defaults))
+    }
+
+    @Test func `same space needs no reset`() throws {
+        let defaults = try makeDefaults()
+        EmbeddingSpaceStore.set("sentence-en-512", in: defaults)
+        #expect(!EmbeddingSpaceStore.needsReset(to: "sentence-en-512", in: defaults))
+    }
+
+    @Test func `changed space needs a reset`() throws {
+        let defaults = try makeDefaults()
+        EmbeddingSpaceStore.set("sentence-en-512", in: defaults)
+        #expect(EmbeddingSpaceStore.needsReset(to: "contextual-ABC", in: defaults))
+
+        EmbeddingSpaceStore.set("contextual-ABC", in: defaults)
+        #expect(!EmbeddingSpaceStore.needsReset(to: "contextual-ABC", in: defaults))
+        #expect(EmbeddingSpaceStore.current(in: defaults) == "contextual-ABC")
+    }
+
+    // MARK: - Helpers
+
+    /// A private suite so the tests never touch (or race on) the app's
+    /// `UserDefaults.standard`.
+    private func makeDefaults() throws -> UserDefaults {
+        let name = "TextEmbedderTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+}


### PR DESCRIPTION
Users reported that indexing — and therefore the **For You** row — never works on Apple TV.

## Root cause

tvOS serves no `NLContextualEmbedding` assets, and the API fails by **hanging silently**. Measured on tvOS 26.5:

```
model: 5C45D94E-BAB4-4927-94B6-8B5745C46289 dim=512 hasAvailableAssets=false
requestAssets TIMED OUT after 60s (callback never fired)
```

The model constructs fine, `hasAvailableAssets` is `false`, and `requestAssets` **never calls its completion handler at all** — no error, no timeout. `ContentIndexer` awaited that before its first chunk, so every Apple TV sat in `.preparing` for the life of the process, indexed zero titles, and `RecommendationEngine` had no embeddings to build a taste profile from. iOS and macOS were unaffected — the assets are served there.

## Changes

**`TextEmbedder` gets a second backend.** tvOS takes the bundled `NLEmbedding.sentenceEmbedding(for: .english)` — chosen at *compile time*, not by runtime probing, since probing is the thing that hangs. Everywhere else stays contextual, so one device can never end up with a catalog embedded half in each space. `requestAssets` is wrapped in a 120 s timeout on the other platforms as a hang guard.

**`ContentIndexText.shortDocument`.** The sentence backend only separates titles on a short document. Measured on tvOS 26.5 as the gap between the mean same-genre and mean cross-genre cosine, over 8 titles in 4 genre pairs:

| document | margin |
|---|---|
| `title (year).` | 0.056 |
| `title (year). genre.` | **0.118** |
| `+ tagline` | 0.034 |
| full (`+ tagline + plot + cast`) | 0.003 |

The indexer picks the shape per backend (`TextEmbedder.prefersShortDocuments`). The English-only model needs no English text: German short documents score 0.097 against 0.118 for English, because the genre words carry the signal and most are cognates — not worth a second English-language TMDB fetch that would also overwrite the localized genre users see.

**`EmbeddingSpaceStore` (new).** The two backends' vectors are incomparable and both happen to be 512-dimensional, so nothing in the blob reveals a mismatch. Each pass stamps the space it used and drops embeddings it can no longer compare. Re-embedding costs no TMDB traffic — `tmdbId` and the enrichment stamp survive — and `itemPause` is now skipped for items that issue no request, so a rebuild runs at full speed instead of at the TMDB rate limit.

**`prepareEmbedder` is bounded** at five attempts instead of retrying forever. Unbounded retry is how "the assets never arrive" became "indexes nothing, quietly, for the life of the process"; the run now ends as `.unavailable` and the next launch tries again.

## Verification

Unit tests cannot run on tvOS, so the platform-specific parts were verified against the real tvOS runtime.

- **Real app sources compiled for tvOS** and run on the simulator: `preferred()` → `sentence-en-512`, `prepare()` returns in **0.08 s** (was: never), correct document shape, and Nemo/Toy Story rank above Nemo/Der Pate through the app's own `RecommendationScoring.cosineSimilarity`.
- **Full app on the tvOS simulator with a real M3U playlist:** 8 movies imported, **8/8 indexed** with 2048-byte (512×`Float`) embeddings, TMDB genres resolved.
- **Space-change path,** by planting a foreign space id: `Embedding space changed; dropped 8 vectors for re-embedding` → `Content index complete: 8 of 8 titles`, three seconds later.
- tvOS, iOS and macOS builds succeed; **1199/1199** unit tests pass; SwiftFormat/SwiftLint clean.

New tests cover `shortDocument`, the sentence backend loading with no assets and no network, its genre separation through the engine's own similarity function, the two backends occupying different spaces, and the space-invalidation rules.

## Not changed

"For You" remains opt-in (`RecommendationSettings.enabledDefault == false`) and premium-gated on every platform — users still enable it in Settings › Layout › Home, same as on iOS. A first full index of a large catalog still takes hours on any platform, since it is one TMDB request per title; partial progress already feeds the row.
